### PR TITLE
Schema specifies use String not utf8

### DIFF
--- a/avro4s-json/src/test/resources/avro1_with_strings.avsc
+++ b/avro4s-json/src/test/resources/avro1_with_strings.avsc
@@ -1,0 +1,104 @@
+{
+  "type": "record",
+  "name": "MyClass",
+  "namespace": "com.test.avro",
+  "fields": [
+    {
+      "name": "firstName",
+      "type": {
+        "type": "string",
+        "avro.java.string": "String"
+      }
+    },
+    {
+      "name": "lastName",
+      "type": {
+        "type": "string",
+        "avro.java.string": "String"
+      }
+    },
+    {
+      "name": "age",
+      "type": "long"
+    },
+    {
+      "name": "address",
+      "type": {
+        "type": "record",
+        "name": "address",
+        "fields": [
+          {
+            "name": "streetAddress",
+            "type": {
+              "type": "string",
+              "avro.java.string": "String"
+            }
+          },
+          {
+            "name": "city",
+            "type": {
+              "type": "string",
+              "avro.java.string": "String"
+            }
+          },
+          {
+            "name": "state",
+            "type": {
+              "type": "string",
+              "avro.java.string": "String"
+            }
+          },
+          {
+            "name": "postalCode",
+            "type": {
+              "type": "string",
+              "avro.java.string": "String"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "phoneNumber",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "phoneNumber",
+          "fields": [
+            {
+              "name": "type",
+              "type": {
+                "type": "string",
+                "avro.java.string": "String"
+              }
+            },
+            {
+              "name": "number",
+              "type": {
+                "type": "string",
+                "avro.java.string": "String"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "gender",
+      "type": {
+        "type": "record",
+        "name": "gender",
+        "fields": [
+          {
+            "name": "type",
+            "type": {
+              "type": "string",
+              "avro.java.string": "String"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/avro4s-json/src/test/resources/avro2_with_strings.avsc
+++ b/avro4s-json/src/test/resources/avro2_with_strings.avsc
@@ -1,0 +1,139 @@
+{
+  "type": "record",
+  "name": "MyClass",
+  "namespace": "com.test.avro",
+  "fields": [
+    {
+      "name": "data",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "data",
+          "fields": [
+            {
+              "name": "type",
+              "type": {
+                "type": "string",
+                "avro.java.string": "String"
+              }
+            },
+            {
+              "name": "id",
+              "type": {
+                "type": "string",
+                "avro.java.string": "String"
+              }
+            },
+            {
+              "name": "attributes",
+              "type": {
+                "type": "record",
+                "name": "attributes",
+                "fields": [
+                  {
+                    "name": "title",
+                    "type": {
+                      "type": "string",
+                      "avro.java.string": "String"
+                    }
+                  },
+                  {
+                    "name": "body",
+                    "type": {
+                      "type": "string",
+                      "avro.java.string": "String"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "name": "relationships",
+              "type": {
+                "type": "record",
+                "name": "relationships",
+                "fields": [
+                  {
+                    "name": "author",
+                    "type": {
+                      "type": "record",
+                      "name": "author",
+                      "fields": [
+                        {
+                          "name": "nested",
+                          "type": {
+                            "type": "record",
+                            "name": "nested",
+                            "fields": [
+                              {
+                                "name": "id",
+                                "type": {
+                                  "type": "string",
+                                  "avro.java.string": "String"
+                                }
+                              },
+                              {
+                                "name": "type",
+                                "type": {
+                                  "type": "string",
+                                  "avro.java.string": "String"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "included",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "included",
+          "fields": [
+            {
+              "name": "type",
+              "type": {
+                "type": "string",
+                "avro.java.string": "String"
+              }
+            },
+            {
+              "name": "id",
+              "type": {
+                "type": "string",
+                "avro.java.string": "String"
+              }
+            },
+            {
+              "name": "details",
+              "type": {
+                "type": "record",
+                "name": "details",
+                "fields": [
+                  {
+                    "name": "name",
+                    "type": {
+                      "type": "string",
+                      "avro.java.string": "String"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/avro4s-json/src/test/scala/com/sksamuel/avro4s/json/JsonToAvroConverterTest.scala
+++ b/avro4s-json/src/test/scala/com/sksamuel/avro4s/json/JsonToAvroConverterTest.scala
@@ -14,6 +14,15 @@ class JsonToAvroConverterTest extends WordSpec with Matchers {
         schema.toString(true) shouldBe new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream(s"/avro$k.avsc")).toString(true)
       }
     }
+
+    "convert json to avro but avoid utf8 and set the schema to use String" in {
+      for (k <- 1 to 2) {
+        val json = Source.fromInputStream(getClass.getResourceAsStream(s"/json$k.json")).getLines.mkString("\n")
+        val schema = new JsonToAvroConverter("com.test.avro", true).convert("MyClass", json)
+        schema.toString(true) shouldBe new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream(s"/avro${k}_with_strings.avsc")).toString(true)
+      }
+    }
+
     "convert nulls to Option[String]" in {
       val json = """ { "foo" : null } """
       val schema = new JsonToAvroConverter("com.test.avro").convert("MyClass", json)


### PR DESCRIPTION
Allowing the user to specify if the schema generated should specify use String not Utf8. This way when Avro deserialises the payload will create String instances not Utf8

Not sure what the best way is to change the macro ToSchema to allow a flag. I leave that to your capable hands :)