### PR TITLE
Fixed avro binary serialization/deserialization 

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroInputStream.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroInputStream.scala
@@ -1,24 +1,16 @@
 package com.sksamuel.avro4s
 
 import java.io.File
-import java.nio.file.Path
+import java.nio.file.{Files, Path}
 import java.io.EOFException
 
-import org.apache.avro.file.{DataFileReader, SeekableByteArrayInput, SeekableFileInput, SeekableInput}
+import org.apache.avro.file.SeekableByteArrayInput
 import org.apache.avro.generic.{GenericDatumReader, GenericRecord}
 import org.apache.avro.io.DecoderFactory
 
 import scala.util.Try
 
-trait AvroInputStream[T] {
-  def close(): Unit
-  def iterator(): Iterator[T]
-  def tryIterator(): Iterator[Try[T]]
-}
-
-class AvroBinaryInputStream[T](in: SeekableByteArrayInput)(implicit schemaFor: SchemaFor[T], fromRecord: FromRecord[T])
-  extends AvroInputStream[T] {
-
+class AvroInputStream[T](in: SeekableByteArrayInput)(implicit schemaFor: SchemaFor[T], fromRecord: FromRecord[T]) {
   val datumReader = new GenericDatumReader[GenericRecord](schemaFor())
   val binDecoder = DecoderFactory.get().binaryDecoder(in, null)
   val records = new java.util.ArrayList[GenericRecord]()
@@ -31,41 +23,27 @@ class AvroBinaryInputStream[T](in: SeekableByteArrayInput)(implicit schemaFor: S
   }
   val result = records.iterator()
 
-  override def iterator: Iterator[T] = new Iterator[T] {
+  def iterator: Iterator[T] = new Iterator[T] {
     override def hasNext: Boolean = result.hasNext
+
     override def next(): T = fromRecord(result.next)
   }
 
-  override def tryIterator: Iterator[Try[T]] = new Iterator[Try[T]] {
+  def tryIterator: Iterator[Try[T]] = new Iterator[Try[T]] {
     override def hasNext: Boolean = result.hasNext
+
     override def next(): Try[T] = Try(fromRecord(result.next))
   }
 
-  override def close(): Unit = in.close()
-}
-
-class AvroDataInputStream[T](in: SeekableInput)(implicit schemaFor: SchemaFor[T], fromRecord: FromRecord[T])
-  extends AvroInputStream[T] {
-
-  val datumReader = new GenericDatumReader[GenericRecord](schemaFor())
-  val dataFileReader = new DataFileReader[GenericRecord](in, datumReader)
-
-  override def iterator: Iterator[T] = new Iterator[T] {
-    override def hasNext: Boolean = dataFileReader.hasNext
-    override def next(): T = fromRecord(dataFileReader.next)
-  }
-
-  override def tryIterator: Iterator[Try[T]] = new Iterator[Try[T]] {
-    override def hasNext: Boolean = dataFileReader.hasNext
-    override def next(): Try[T] = Try(fromRecord(dataFileReader.next))
-  }
-
-  override def close(): Unit = in.close()
+  def close(): Unit = in.close()
 }
 
 object AvroInputStream {
-  def apply[T: SchemaFor : FromRecord](bytes: Array[Byte]): AvroInputStream[T] = new AvroBinaryInputStream[T](new SeekableByteArrayInput(bytes))
+  def apply[T: SchemaFor : FromRecord](bytes: Array[Byte]): AvroInputStream[T] = new AvroInputStream[T](new SeekableByteArrayInput(bytes))
+
   def apply[T: SchemaFor : FromRecord](path: String): AvroInputStream[T] = apply(new File(path))
+
   def apply[T: SchemaFor : FromRecord](path: Path): AvroInputStream[T] = apply(path.toFile)
-  def apply[T: SchemaFor : FromRecord](file: File): AvroInputStream[T] = new AvroDataInputStream[T](new SeekableFileInput (file))
+
+  def apply[T: SchemaFor : FromRecord](file: File): AvroInputStream[T] = new AvroInputStream[T](new SeekableByteArrayInput(Files.readAllBytes(file.toPath)))
 }

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroInputStream.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroInputStream.scala
@@ -2,32 +2,70 @@ package com.sksamuel.avro4s
 
 import java.io.File
 import java.nio.file.Path
+import java.io.EOFException
 
 import org.apache.avro.file.{DataFileReader, SeekableByteArrayInput, SeekableFileInput, SeekableInput}
 import org.apache.avro.generic.{GenericDatumReader, GenericRecord}
+import org.apache.avro.io.DecoderFactory
+
 import scala.util.Try
 
-class AvroInputStream[T](in: SeekableInput)(implicit schemaFor: SchemaFor[T], fromRecord: FromRecord[T]) {
+trait AvroInputStream[T] {
+  def close(): Unit
+  def iterator(): Iterator[T]
+  def tryIterator(): Iterator[Try[T]]
+}
+
+class AvroBinaryInputStream[T](in: SeekableByteArrayInput)(implicit schemaFor: SchemaFor[T], fromRecord: FromRecord[T])
+  extends AvroInputStream[T] {
+
+  val datumReader = new GenericDatumReader[GenericRecord](schemaFor())
+  val binDecoder = DecoderFactory.get().binaryDecoder(in, null)
+  val records = new java.util.ArrayList[GenericRecord]()
+
+  try {
+    while (true)
+      records.add(datumReader.read(null, binDecoder))
+  } catch {
+    case _: EOFException => null
+  }
+  val result = records.iterator()
+
+  override def iterator: Iterator[T] = new Iterator[T] {
+    override def hasNext: Boolean = result.hasNext
+    override def next(): T = fromRecord(result.next)
+  }
+
+  override def tryIterator: Iterator[Try[T]] = new Iterator[Try[T]] {
+    override def hasNext: Boolean = result.hasNext
+    override def next(): Try[T] = Try(fromRecord(result.next))
+  }
+
+  override def close(): Unit = in.close()
+}
+
+class AvroDataInputStream[T](in: SeekableInput)(implicit schemaFor: SchemaFor[T], fromRecord: FromRecord[T])
+  extends AvroInputStream[T] {
 
   val datumReader = new GenericDatumReader[GenericRecord](schemaFor())
   val dataFileReader = new DataFileReader[GenericRecord](in, datumReader)
 
-  def iterator: Iterator[T] = new Iterator[T] {
+  override def iterator: Iterator[T] = new Iterator[T] {
     override def hasNext: Boolean = dataFileReader.hasNext
     override def next(): T = fromRecord(dataFileReader.next)
   }
 
-  def tryIterator: Iterator[Try[T]] = new Iterator[Try[T]] {
+  override def tryIterator: Iterator[Try[T]] = new Iterator[Try[T]] {
     override def hasNext: Boolean = dataFileReader.hasNext
     override def next(): Try[T] = Try(fromRecord(dataFileReader.next))
   }
 
-  def close(): Unit = in.close()
+  override def close(): Unit = in.close()
 }
 
 object AvroInputStream {
-  def apply[T: SchemaFor : FromRecord](bytes: Array[Byte]): AvroInputStream[T] = new AvroInputStream[T](new SeekableByteArrayInput(bytes))
+  def apply[T: SchemaFor : FromRecord](bytes: Array[Byte]): AvroInputStream[T] = new AvroBinaryInputStream[T](new SeekableByteArrayInput(bytes))
   def apply[T: SchemaFor : FromRecord](path: String): AvroInputStream[T] = apply(new File(path))
   def apply[T: SchemaFor : FromRecord](path: Path): AvroInputStream[T] = apply(path.toFile)
-  def apply[T: SchemaFor : FromRecord](file: File): AvroInputStream[T] = new AvroInputStream[T](new SeekableFileInput(file))
+  def apply[T: SchemaFor : FromRecord](file: File): AvroInputStream[T] = new AvroDataInputStream[T](new SeekableFileInput (file))
 }

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroOutputStream.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroOutputStream.scala
@@ -49,18 +49,13 @@ class AvroDataOutputStream[T](os: OutputStream)(implicit schemaFor: SchemaFor[T]
 }
 
 object AvroOutputStream {
-  def apply[T: SchemaFor : ToRecord](file: File): AvroOutputStream[T] = apply(file.toPath, true)
 
-  def apply[T: SchemaFor : ToRecord](file: File, includeSchema: Boolean): AvroOutputStream[T] = apply(file.toPath, includeSchema)
+  def apply[T: SchemaFor : ToRecord](file: File): AvroOutputStream[T] = apply(file.toPath)
 
-  def apply[T: SchemaFor : ToRecord](path: Path): AvroOutputStream[T] = apply(Files.newOutputStream(path), true)
+  def apply[T: SchemaFor : ToRecord](path: String): AvroOutputStream[T] = apply(new File(path))
 
-  def apply[T: SchemaFor : ToRecord](path: Path, includeSchema: Boolean): AvroOutputStream[T] = apply(Files.newOutputStream(path), includeSchema)
+  def apply[T: SchemaFor : ToRecord](path: Path): AvroOutputStream[T] = new AvroDataOutputStream(Files.newOutputStream(path))
 
-  def apply[T: SchemaFor : ToRecord](os: OutputStream): AvroOutputStream[T] = apply(os, true)
+  def apply[T: SchemaFor : ToRecord](os: OutputStream): AvroOutputStream[T] = new AvroBinaryOutputStream(os)
 
-  def apply[T: SchemaFor : ToRecord](os: OutputStream, includeSchema: Boolean): AvroOutputStream[T] = {
-    if (includeSchema) new AvroDataOutputStream[T](os)
-    else new AvroBinaryOutputStream[T](os)
-  }
 }

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroOutputStream.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroOutputStream.scala
@@ -49,13 +49,15 @@ class AvroDataOutputStream[T](os: OutputStream)(implicit schemaFor: SchemaFor[T]
 }
 
 object AvroOutputStream {
+  def apply[T: SchemaFor : ToRecord](file: File): AvroOutputStream[T] = apply(file.toPath, true)
+  def apply[T: SchemaFor : ToRecord](file: File, binaryModeDisabled: Boolean): AvroOutputStream[T] = apply(file.toPath, binaryModeDisabled)
 
-  def apply[T: SchemaFor : ToRecord](file: File): AvroOutputStream[T] = apply(file.toPath)
+  def apply[T: SchemaFor : ToRecord](path: Path): AvroOutputStream[T] = apply(Files.newOutputStream(path), true)
+  def apply[T: SchemaFor : ToRecord](path: Path, binaryModeDisabled: Boolean): AvroOutputStream[T] = apply(Files.newOutputStream(path), binaryModeDisabled)
 
-  def apply[T: SchemaFor : ToRecord](path: String): AvroOutputStream[T] = apply(new File(path))
-
-  def apply[T: SchemaFor : ToRecord](path: Path): AvroOutputStream[T] = new AvroDataOutputStream(Files.newOutputStream(path))
-
-  def apply[T: SchemaFor : ToRecord](os: OutputStream): AvroOutputStream[T] = new AvroBinaryOutputStream(os)
-
+  def apply[T: SchemaFor : ToRecord](os: OutputStream): AvroOutputStream[T] = apply(os, false)
+  def apply[T: SchemaFor : ToRecord](os: OutputStream, binaryModeDisabled: Boolean): AvroOutputStream[T] = {
+    if (binaryModeDisabled) new AvroDataOutputStream[T](os)
+    else new AvroBinaryOutputStream[T](os)
+  }
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroBinaryOutputStreamTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroBinaryOutputStreamTest.scala
@@ -12,7 +12,7 @@ class AvroBinaryOutputStreamTest extends WordSpec with Matchers {
   "AvroBinaryOutputStream" should {
     "not include schema" in {
       val baos = new ByteArrayOutputStream()
-      val output = AvroOutputStream[Composer](baos, false)
+      val output = AvroOutputStream[Composer](baos)
       output.write(ennio)
       output.close()
       new String(baos.toByteArray) should not include "birthplace"

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroBinaryOutputStreamTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroBinaryOutputStreamTest.scala
@@ -12,7 +12,7 @@ class AvroBinaryOutputStreamTest extends WordSpec with Matchers {
   "AvroBinaryOutputStream" should {
     "not include schema" in {
       val baos = new ByteArrayOutputStream()
-      val output = AvroOutputStream[Composer](baos)
+      val output = AvroOutputStream[Composer](baos, false)
       output.write(ennio)
       output.close()
       new String(baos.toByteArray) should not include "birthplace"

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroDataOutputStreamTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroDataOutputStreamTest.scala
@@ -12,11 +12,11 @@ class AvroDataOutputStreamTest extends WordSpec with Matchers {
   "AvroDataOutputStream" should {
     "not include schema" in {
       val baos = new ByteArrayOutputStream()
-      val output = AvroOutputStream[Composer](baos, true)
+      val output = AvroOutputStream[Composer](baos)
       output.write(ennio)
       output.close()
-      new String(baos.toByteArray) should include("birthplace")
-      new String(baos.toByteArray) should include("compositions")
+      new String(baos.toByteArray) should not include "birthplace"
+      new String(baos.toByteArray) should not include "compositions"
     }
   }
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroDataOutputStreamTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroDataOutputStreamTest.scala
@@ -12,7 +12,7 @@ class AvroDataOutputStreamTest extends WordSpec with Matchers {
   "AvroDataOutputStream" should {
     "not include schema" in {
       val baos = new ByteArrayOutputStream()
-      val output = AvroOutputStream[Composer](baos)
+      val output = AvroOutputStream[Composer](baos, false)
       output.write(ennio)
       output.close()
       new String(baos.toByteArray) should not include "birthplace"

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroInputStreamTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroInputStreamTest.scala
@@ -45,6 +45,8 @@ class AvroInputStreamTest extends WordSpec with Matchers with Timeouts {
   case class Goo(double: Double)
   case class Moo(either: Either[Joo, Goo])
   case class Enums(wine: Wine)
+  case class ComplexElement(unit: Ints, decimal: Doubles, flag: Booleans)
+  case class ComplexType(elements: Seq[ComplexElement])
 
 
   def write[T](ts: Seq[T])(implicit schema: SchemaFor[T], ser: ToRecord[T]): Array[Byte] = {
@@ -69,6 +71,14 @@ class AvroInputStreamTest extends WordSpec with Matchers with Timeouts {
       val bytes = write(data)
 
       val in = AvroInputStream[BigDecimalTest](bytes)
+      in.iterator.toList shouldBe data.toList
+      in.close()
+    }
+    "read complex type" in {
+      val data = Seq(ComplexType(Seq(ComplexElement(Ints(2), Doubles(0.12345), Booleans(true)), ComplexElement(Ints(5), Doubles(0.98568), Booleans(false)))))
+      val bytes = write(data)
+
+      val in = AvroInputStream[ComplexType](bytes)
       in.iterator.toList shouldBe data.toList
       in.close()
     }


### PR DESCRIPTION
issue #21 
- removed the flag "include schema" from the AvroOutputStream because according with the Apache Avro documentation the schema is always included with the Data. So it's not need it.
[http://avro.apache.org/docs/1.8.0/gettingstartedjava.html: "Data in Avro is always stored with its corresponding schema, meaning we can always read a serialized item regardless of whether we know the schema ahead of time."
- added "AvroBinaryInputStream" and "AvroDataInputStream" that extends AvroInputStream, in order to distinguish between data file stream or binary stream
- fixed the Unit tests