### PR TITLE
Fixed macro outside avro4s package

### DIFF
--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/ToRecord.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/ToRecord.scala
@@ -139,7 +139,7 @@ object ToRecord {
 
     c.Expr[ToRecord[T]](
       q"""new com.sksamuel.avro4s.ToRecord[$tpe] {
-            private val schemaFor : SchemaFor[$tpe] = SchemaFor[$tpe]
+            private val schemaFor : com.sksamuel.avro4s.SchemaFor[$tpe] = com.sksamuel.avro4s.SchemaFor[$tpe]
             private val converters : Array[com.sksamuel.avro4s.ToValue[_]] = Array(..$converters)
 
             def apply(t : $tpe): org.apache.avro.generic.GenericRecord = {


### PR DESCRIPTION
Fixed macro outside avro4s package by using fully qualified name for SchemaFor in ToRecord macro.