### PR TITLE
fixed missing semicolon in enum template generator

### DIFF
--- a/avro4s-generator/src/main/scala/com/sksamuel/avro4s/TemplateGenerator.scala
+++ b/avro4s-generator/src/main/scala/com/sksamuel/avro4s/TemplateGenerator.scala
@@ -15,7 +15,7 @@ object TemplateGenerator {
     val enums = modules.collect {
       case enum: EnumType => Template(
         enum.namespace.replace(".", File.separator) + File.separator + enum.name + ".java",
-        s"package ${enum.namespace}\n\n" + renderer(enum))
+        s"package ${enum.namespace};\n\n" + renderer(enum))
     }
 
     // records can be grouped into a single file per package

--- a/avro4s-generator/src/test/scala/com/sksamuel/avro4s/TemplateGeneratorTest.scala
+++ b/avro4s-generator/src/test/scala/com/sksamuel/avro4s/TemplateGeneratorTest.scala
@@ -7,7 +7,7 @@ class TemplateGeneratorTest extends WordSpec with Matchers {
   "TemplateGenerator" should {
     "generate a file per enum" in {
       val enums = TemplateGenerator(Seq(EnumType("com.a", "Boo", Seq("A", "B")), EnumType("com.a", "Foo", Seq("A", "B"))))
-      enums shouldBe Seq(Template("com/a/Boo.java", "package com.a\n\n//auto generated code by avro4s\npublic enum Boo{\n    A, B\n}"), Template("com/a/Foo.java", "package com.a\n\n//auto generated code by avro4s\npublic enum Foo{\n    A, B\n}"))
+      enums shouldBe Seq(Template("com/a/Boo.java", "package com.a;\n\n//auto generated code by avro4s\npublic enum Boo{\n    A, B\n}"), Template("com/a/Foo.java", "package com.a;\n\n//auto generated code by avro4s\npublic enum Foo{\n    A, B\n}"))
     }
     "generate one file for all records of same namespace" in {
       val enums = TemplateGenerator(Seq(RecordType("com.a", "Boo", Seq(FieldDef("name", PrimitiveType.String), FieldDef("bibble", PrimitiveType.Long))), RecordType("com.a", "Foo", Seq(FieldDef("dibble", PrimitiveType.Double), FieldDef("bibble", PrimitiveType.Boolean)))))


### PR DESCRIPTION
The java enum template generator wasn't including the semicolon :)