### PR TITLE
Fix problem with option default value

### DIFF
--- a/avro4s-core/src/test/resources/optiondefaultvalues.avsc
+++ b/avro4s-core/src/test/resources/optiondefaultvalues.avsc
@@ -1,0 +1,17 @@
+{
+  "type": "record",
+  "name": "OptionDefaultValues",
+  "namespace": "com.sksamuel.avro4s",
+  "fields": [
+    { "name": "name", "type": "string", "default": "sammy" },
+    {
+      "name": "description",
+      "type": ["null", "string"]
+    },
+    {
+      "name": "currency",
+      "type": ["null", "string"],
+      "default": "$"
+    }
+  ]
+}

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroSchemaTest.scala
@@ -2,6 +2,7 @@ package com.sksamuel.avro4s
 
 import java.util.UUID
 
+import org.apache.avro.reflect.AvroDefault
 import org.scalatest.{Matchers, WordSpec}
 
 sealed trait Wibble
@@ -261,8 +262,19 @@ class AvroSchemaTest extends WordSpec with Matchers {
       val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/defaultvalues.avsc"))
       schema.toString(true) shouldBe expected.toString(true)
     }
+    "support default option values" in {
+      val schema = SchemaFor[OptionDefaultValues]()
+      val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/optiondefaultvalues.avsc"))
+      schema.toString(true) shouldBe expected.toString(true)
+    }
   }
 }
+
+case class OptionDefaultValues(
+  name: String = "sammy",
+  description: Option[String] = None,
+  currency: Option[String] = Some("$")
+)
 
 case class DefaultValues(
   name: String = "sammy",

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
@@ -45,7 +45,7 @@ object ToSchema extends LowPriorityToSchema {
   }
 
   implicit val DoubleToSchema: ToSchema[Double] = new ToSchema[Double] {
-    protected val schema =  Schema.create(Schema.Type.DOUBLE)
+    protected val schema = Schema.create(Schema.Type.DOUBLE)
   }
 
   implicit def EitherToSchema[A, B](implicit aSchema: ToSchema[A], bSchema: ToSchema[B]): ToSchema[Either[A, B]] = {
@@ -284,14 +284,15 @@ object SchemaFor {
       case x: Double => new DoubleNode(x)
       case x: Seq[_] =>
         val arrayNode = new ArrayNode(JsonNodeFactory.instance)
-        x.foreach( z => arrayNode.add(toNode(z)))
+        x.foreach(z => arrayNode.add(toNode(z)))
         arrayNode
       case x: Map[String, _] =>
         val objectNode = new ObjectNode(JsonNodeFactory.instance)
-        x.foreach{ case (k, v) =>
+        x.foreach { case (k, v) =>
           objectNode.put(k, toNode(v))
         }
         objectNode
+      case x: Option[_] => x.map(toNode).orNull
       case _ => new TextNode(value.toString)
     }
 


### PR DESCRIPTION
A filed option with default value to none generate a scheam with "default : "None". Example :
`case class OptionDefaultValues(
  name: String = "sammy",
  description: Option[String] = None,
  currency: Option[String] = Some("$")
)`

produce this schema :

`{"type":"record","name":"OptionDefaultValues","namespace":"com.sksamuel.avro4s","fields":[{"name":"name","type":"string","default":"sammy"},{"name":"description","type":["null","string"],"default":"None"},{"name":"currency","type":["null","string"],"default":"Some($)"}]}`

With this fix the schema is 
`{
  "type": "record",
  "name": "OptionDefaultValues",
  "namespace": "com.sksamuel.avro4s",
  "fields": [
    { "name": "name", "type": "string", "default": "sammy" },
    {
      "name": "description",
      "type": ["null", "string"]
    },
    {
      "name": "currency",
      "type": ["null", "string"],
      "default": "$"
    }
  ]
}`