### PR TITLE
Template filename bug

### DIFF
--- a/avro4s-generator/src/main/scala/com/sksamuel/avro4s/ModuleGenerator.scala
+++ b/avro4s-generator/src/main/scala/com/sksamuel/avro4s/ModuleGenerator.scala
@@ -119,19 +119,21 @@ case class Template(file: String, extension: String, definition: String)
 
 
 object FileRenderer {
+  def output(dir: Path, template: Seq[Template]): Map[Path, String] = template.map { template =>
+    val targetPath = dir resolve Paths.get(template.file.replace(".", File.separator) + s".${template.extension}")
+    targetPath -> template.definition
+  }.toMap
+
   def render(dir: Path, template: Seq[Template]): Seq[Path] = {
+    output(dir, template).map {
+      case (targetPath, contents) =>
+        val packagePath = targetPath.getParent
+        packagePath.toFile.mkdirs()
 
-    template.map { template =>
-
-      val targetPath = dir resolve Paths.get(template.file.replace(".", File.separator) + s".${template.extension}")
-      val packagePath = targetPath.getParent
-      packagePath.toFile.mkdirs()
-
-      val writer = Files.newBufferedWriter(targetPath)
-      writer.write(template.definition)
-      writer.close()
-      targetPath
-
-    }
+        val writer = Files.newBufferedWriter(targetPath)
+        writer.write(contents)
+        writer.close()
+        targetPath
+    }.toSeq
   }
 }

--- a/avro4s-generator/src/main/scala/com/sksamuel/avro4s/ModuleGenerator.scala
+++ b/avro4s-generator/src/main/scala/com/sksamuel/avro4s/ModuleGenerator.scala
@@ -115,7 +115,7 @@ object TypeRenderer {
 
 
 // templates contains all generated definitions grouped by file
-case class Template(file: String, definition: String)
+case class Template(file: String, extension: String, definition: String)
 
 
 object FileRenderer {
@@ -123,7 +123,7 @@ object FileRenderer {
 
     template.map { template =>
 
-      val targetPath = dir resolve Paths.get(template.file.replace(".", File.separator))
+      val targetPath = dir resolve Paths.get(template.file.replace(".", File.separator) + s".${template.extension}")
       val packagePath = targetPath.getParent
       packagePath.toFile.mkdirs()
 

--- a/avro4s-generator/src/main/scala/com/sksamuel/avro4s/TemplateGenerator.scala
+++ b/avro4s-generator/src/main/scala/com/sksamuel/avro4s/TemplateGenerator.scala
@@ -14,7 +14,8 @@ object TemplateGenerator {
     // each enum must go into its own template
     val enums = modules.collect {
       case enum: EnumType => Template(
-        enum.namespace.replace(".", File.separator) + File.separator + enum.name + ".java",
+        enum.namespace.replace(".", File.separator) + File.separator + enum.name,
+        "java",
         s"package ${enum.namespace};\n\n" + renderer(enum))
     }
 
@@ -24,7 +25,8 @@ object TemplateGenerator {
     }.groupBy(_.namespace).map { case (namespace, records) =>
       val defin = s"package $namespace\n\n" + records.map(renderer.apply).mkString("\n\n")
       Template(
-        namespace.replace(".", File.separator) + File.separator + "domain.scala",
+        namespace.replace(".", File.separator) + File.separator + "domain",
+        "scala",
         defin
       )
     }

--- a/avro4s-generator/src/test/scala/com/sksamuel/avro4s/FileRendererTest.scala
+++ b/avro4s-generator/src/test/scala/com/sksamuel/avro4s/FileRendererTest.scala
@@ -1,0 +1,12 @@
+package com.sksamuel.avro4s
+
+import org.scalatest.{Matchers, WordSpec}
+import java.nio.file.Paths
+
+class FileRendererTest extends WordSpec with Matchers {
+  "FileRenderer" should {
+    "write files with the right name" in {
+      FileRenderer.output(Paths.get("/dir"), Seq(Template("com.some.package.Klass", "scala", "contents"))) shouldBe Map(Paths.get("/dir/com/some/package/Klass.scala") -> "contents")
+    }
+  }
+}

--- a/avro4s-generator/src/test/scala/com/sksamuel/avro4s/TemplateGeneratorTest.scala
+++ b/avro4s-generator/src/test/scala/com/sksamuel/avro4s/TemplateGeneratorTest.scala
@@ -7,11 +7,11 @@ class TemplateGeneratorTest extends WordSpec with Matchers {
   "TemplateGenerator" should {
     "generate a file per enum" in {
       val enums = TemplateGenerator(Seq(EnumType("com.a", "Boo", Seq("A", "B")), EnumType("com.a", "Foo", Seq("A", "B"))))
-      enums shouldBe Seq(Template("com/a/Boo.java", "package com.a;\n\n//auto generated code by avro4s\npublic enum Boo{\n    A, B\n}"), Template("com/a/Foo.java", "package com.a;\n\n//auto generated code by avro4s\npublic enum Foo{\n    A, B\n}"))
+      enums shouldBe Seq(Template("com/a/Boo", "java", "package com.a;\n\n//auto generated code by avro4s\npublic enum Boo{\n    A, B\n}"), Template("com/a/Foo", "java", "package com.a;\n\n//auto generated code by avro4s\npublic enum Foo{\n    A, B\n}"))
     }
     "generate one file for all records of same namespace" in {
       val enums = TemplateGenerator(Seq(RecordType("com.a", "Boo", Seq(FieldDef("name", PrimitiveType.String), FieldDef("bibble", PrimitiveType.Long))), RecordType("com.a", "Foo", Seq(FieldDef("dibble", PrimitiveType.Double), FieldDef("bibble", PrimitiveType.Boolean)))))
-      enums shouldBe Seq(Template("com/a/domain.scala", "package com.a\n\n//auto generated code by avro4s\ncase class Boo(\n  name: String,\n  bibble: Long\n)\n\n//auto generated code by avro4s\ncase class Foo(\n  dibble: Double,\n  bibble: Boolean\n)"))
+      enums shouldBe Seq(Template("com/a/domain", "scala", "package com.a\n\n//auto generated code by avro4s\ncase class Boo(\n  name: String,\n  bibble: Long\n)\n\n//auto generated code by avro4s\ncase class Foo(\n  dibble: Double,\n  bibble: Boolean\n)"))
     }
   }
 }


### PR DESCRIPTION
Hey! Quick little bugfix here, you were generating `domain/scala` files when using `sbt-avro4s`. 