### PR TITLE
Recursive schemas

### DIFF
--- a/avro4s-core/src/test/resources/mutrec.avsc
+++ b/avro4s-core/src/test/resources/mutrec.avsc
@@ -1,0 +1,29 @@
+{
+  "type" : "record",
+  "name" : "MutRec1",
+  "namespace" : "com.sksamuel.avro4s",
+  "fields" : [ {
+    "name" : "payload",
+    "type" : "int"
+  }, {
+    "name" : "children",
+    "type" : {
+      "type": "array",
+      "items": {
+        "type": "record",
+        "name": "MutRec2",
+        "namespace": "com.sksamuel.avro4s",
+        "fields": [ {
+          "name": "payload",
+          "type": "string"
+        }, {
+           "name": "children",
+           "type": {
+             "type": "array",
+             "items": "MutRec1"
+           }
+        } ]
+      }
+    }
+  } ]
+}

--- a/avro4s-core/src/test/resources/recursive.avsc
+++ b/avro4s-core/src/test/resources/recursive.avsc
@@ -1,0 +1,12 @@
+{
+  "type" : "record",
+  "name" : "Recursive",
+  "namespace" : "com.sksamuel.avro4s",
+  "fields" : [ {
+    "name" : "payload",
+    "type" : "int"
+  }, {
+    "name" : "next",
+    "type" : [ "null", "Recursive" ]
+  } ]
+}

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroSchemaTest.scala
@@ -27,6 +27,11 @@ case class Level1(level2: Level2)
 
 case class Ids(myid: UUID)
 
+case class Recursive(payload: Int, next: Option[Recursive])
+
+case class MutRec1(payload: Int, children: List[MutRec2])
+case class MutRec2(payload: String, children: List[MutRec1])
+
 class AvroSchemaTest extends WordSpec with Matchers {
 
   case class NestedListString(list: List[String])
@@ -265,6 +270,16 @@ class AvroSchemaTest extends WordSpec with Matchers {
     "support default option values" in {
       val schema = SchemaFor[OptionDefaultValues]()
       val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/optiondefaultvalues.avsc"))
+      schema.toString(true) shouldBe expected.toString(true)
+    }
+    "support recursive types" in {
+      val schema = SchemaFor[Recursive]()
+      val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/recursive.avsc"))
+      schema.toString(true) shouldBe expected.toString(true)
+    }
+    "support mutually recursive types" in {
+      val schema = SchemaFor[MutRec1]()
+      val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/mutrec.avsc"))
       schema.toString(true) shouldBe expected.toString(true)
     }
   }


### PR DESCRIPTION
Handle recursive schemas by splitting up the record's schema before fields are added, and the record's schema after fields are added, as separate values.