### PR TITLE
targeted laziness in to/fromRecord

### DIFF
--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroDataTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroDataTest.scala
@@ -24,5 +24,26 @@ class AvroDataTest extends WordSpec with Matchers {
       is.close()
       file.delete()
     }
+
+    "be able to serialize/deserialize recursive data" in {
+      val data = Recursive(4, Some(Recursive(2, Some(Recursive(9, None)))))
+
+      val file: File = new File("recursive.avro")
+
+      // at the moment you need to store the recursive schema in a variable
+      // so that the compiler doesn't try to expand it forever
+      implicit val schema = SchemaFor[Recursive]
+
+      val os = AvroOutputStream.data[Recursive](file)
+      os.write(data)
+      os.close
+
+      val is = AvroInputStream.data[Recursive](file)
+      val parsed = is.iterator.toList
+      is.close()
+      file.delete()
+
+      parsed shouldBe List(data)
+    }
   }
 }

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/ToRecord.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/ToRecord.scala
@@ -118,7 +118,7 @@ object ToRecord {
             import com.sksamuel.avro4s.ToValue._
             import com.sksamuel.avro4s.SchemaFor._
 
-            com.sksamuel.avro4s.ToRecord.converter[$sig]
+            com.sksamuel.avro4s.ToRecord.lazyConverter[$sig]
           }
        """
     }
@@ -131,8 +131,8 @@ object ToRecord {
 
         q"""
           {
-            val converter = converters($idx).asInstanceOf[com.sksamuel.avro4s.ToValue[$sig]]
-            record.put($fieldName, converter(t.$name : $sig))
+            val converter = converters($idx).asInstanceOf[shapeless.Lazy[com.sksamuel.avro4s.ToValue[$sig]]]
+            record.put($fieldName, converter.value(t.$name : $sig))
           }
         """
     }
@@ -140,7 +140,7 @@ object ToRecord {
     c.Expr[ToRecord[T]](
       q"""new com.sksamuel.avro4s.ToRecord[$tpe] {
             private val schemaFor : com.sksamuel.avro4s.SchemaFor[$tpe] = com.sksamuel.avro4s.SchemaFor[$tpe]
-            private val converters : Array[com.sksamuel.avro4s.ToValue[_]] = Array(..$converters)
+            private val converters : Array[shapeless.Lazy[com.sksamuel.avro4s.ToValue[_]]] = Array(..$converters)
 
             def apply(t : $tpe): org.apache.avro.generic.GenericRecord = {
 
@@ -153,5 +153,5 @@ object ToRecord {
     )
   }
 
-  def converter[T](implicit toValue: Lazy[ToValue[T]]): ToValue[T] = toValue.value
+  def lazyConverter[T](implicit toValue: Lazy[ToValue[T]]): Lazy[ToValue[T]] = toValue
 }


### PR DESCRIPTION
My apologies; I should've tested `toRecord` and `fromRecord` as well! 

Right now there appears to be an issue where if you're using a recursive schema, you can't rely on the `SchemaFor[T]` being implicitly built; you have to provide a `implicit val schema = SchemaFor[T]` line so that the compiler doesn't go into recursive loops. I'm tentatively okay with that; what do you think?