### PR TITLE
Coproducts!

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,16 @@ val schema = AvroSchema[MyDecimal]
 }
 ```
 
+## Coproducts
+
+Avro supports generalised unions, eithers of more than two values. To represent these in scala, we use `shapeless.:+:`, such that `A :+: B :+: C :+: CNil` represents cases where a type is `A` OR `B` OR `C`. See shapeless' [documentation on coproducts](https://github.com/milessabin/shapeless/wiki/Feature-overview:-shapeless-2.0.0#coproducts-and-discriminated-unions) for more on how to use coproducts.
+
 ## Type Mappings
+
+``` scala
+import scala.collection.{Array, List, Seq, Iterable, Set, Map, Option, Either}
+import shapeless.{:+:, CNil}
+```
 
 |Scala Type|Avro Type|
 |----------|---------|
@@ -254,14 +263,17 @@ val schema = AvroSchema[MyDecimal]
 |Java Enums|enum|
 |scala.Enumeration|enum|
 |sealed trait T|enum|
-|scala.collection.Array[T]|array|
-|scala.collection.List[T]|array|
-|scala.collection.Seq[T]|array|
-|scala.collection.Iterable[T]|array|
-|scala.collection.Set[T]|array|
-|scala.collection.Map[String, T]|map|
-|scala.collection.Option[T]|union:null,T|
-|scala.collection.Either[L, R]|union:L,R|
+|Array[T]|array|
+|List[T]|array|
+|Seq[T]|array|
+|Iterable[T]|array|
+|Set[T]|array|
+|Map[String, T]|map|
+|Option[T]|union:null,T|
+|Either[L, R]|union:L,R|
+|A :+: B :+: C :+: CNil|union:A,B,C|
+|Option[Either[L, R]]|union:null,L,R|
+|Option[A :+: B :+: C :+: CNil]|union:null,A,B,C|
 |T|record|
 
 ## Custom Type Mappings

--- a/avro4s-core/src/test/resources/optionalunion.avsc
+++ b/avro4s-core/src/test/resources/optionalunion.avsc
@@ -1,0 +1,9 @@
+{
+  "type":"record",
+  "name":"OptionalUnion",
+  "namespace":"com.sksamuel.avro4s",
+  "fields":[ {
+    "name":"union",
+    "type": [ "null", "int", "string" ]
+   } ]
+}

--- a/avro4s-core/src/test/resources/union.avsc
+++ b/avro4s-core/src/test/resources/union.avsc
@@ -1,0 +1,9 @@
+{
+  "type":"record",
+  "name":"Union",
+  "namespace":"com.sksamuel.avro4s",
+  "fields":[ {
+    "name":"union",
+    "type": [ "int", "string", "boolean" ]
+   } ]
+}

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroInputStreamTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroInputStreamTest.scala
@@ -52,6 +52,7 @@ class AvroInputStreamTest extends WordSpec with Matchers with Timeouts {
   case class ComplexType(elements: Seq[ComplexElement])
   case class CoPrimitives(cp: String :+: Boolean :+: CNil)
   case class CoRecords(cp: Joo :+: Goo :+: CNil)
+  case class CoArrays(cp: Seq[String] :+: Int :+: CNil)
 
   def write[T](ts: Seq[T])(implicit schema: SchemaFor[T], ser: ToRecord[T]): Array[Byte] = {
     val output = new ByteArrayOutputStream
@@ -142,6 +143,18 @@ class AvroInputStreamTest extends WordSpec with Matchers with Timeouts {
       val bytes = write(data)
 
       val in = AvroInputStream[CoRecords](bytes)
+      in.iterator.toList shouldBe data.toList
+      in.close()
+    }
+    "read coproducts of arrays" in {
+      type SSI = Seq[String] :+: Int :+: CNil
+      val data = Seq(
+        CoArrays(Coproduct[SSI](Seq("hello", "goodbye"))),
+        CoArrays(Coproduct[SSI](4))
+      )
+
+      val bytes = write(data)
+      val in = AvroInputStream[CoArrays](bytes)
       in.iterator.toList shouldBe data.toList
       in.close()
     }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroInputStreamTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroInputStreamTest.scala
@@ -37,6 +37,7 @@ class AvroInputStreamTest extends WordSpec with Matchers with Timeouts {
   case class SetStrings(set: Set[String])
   case class SetCaseClasses(set: Set[Foo])
   case class EitherStringBoolean(either: Either[String, Boolean])
+  case class EitherArray(payload: Either[Seq[Int], String])
   case class MapBoolean(map: Map[String, Boolean])
   case class MapSeq(map: Map[String, Seq[String]])
   case class MapOptions(map: Map[String, Option[String]])
@@ -108,6 +109,14 @@ class AvroInputStreamTest extends WordSpec with Matchers with Timeouts {
       val bytes = write(data)
 
       val in = AvroInputStream[EitherStringBoolean](bytes)
+      in.iterator.toList shouldBe data.toList
+      in.close()
+    }
+    "read eithers of arrays" in {
+      val data = Seq(EitherArray(Left(Seq(1,2))), EitherArray(Right("lammy")))
+
+      val bytes = write(data)
+      val in = AvroInputStream[EitherArray](bytes)
       in.iterator.toList shouldBe data.toList
       in.close()
     }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroInputStreamTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroInputStreamTest.scala
@@ -38,6 +38,7 @@ class AvroInputStreamTest extends WordSpec with Matchers with Timeouts {
   case class SetCaseClasses(set: Set[Foo])
   case class EitherStringBoolean(either: Either[String, Boolean])
   case class EitherArray(payload: Either[Seq[Int], String])
+  case class EitherMap(payload: Either[Map[String, Int], Boolean])
   case class MapBoolean(map: Map[String, Boolean])
   case class MapSeq(map: Map[String, Seq[String]])
   case class MapOptions(map: Map[String, Option[String]])
@@ -118,6 +119,15 @@ class AvroInputStreamTest extends WordSpec with Matchers with Timeouts {
 
       val bytes = write(data)
       val in = AvroInputStream[EitherArray](bytes)
+      in.iterator.toList shouldBe data.toList
+      in.close()
+    }
+    "read eithers of maps" in {
+      val data = Seq(EitherMap(Left(Map("val" -> 4))), EitherMap(Right(true)))
+
+      val bytes = write(data)
+
+      val in = AvroInputStream[EitherMap](bytes)
       in.iterator.toList shouldBe data.toList
       in.close()
     }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroInputStreamTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroInputStreamTest.scala
@@ -54,6 +54,7 @@ class AvroInputStreamTest extends WordSpec with Matchers with Timeouts {
   case class CoPrimitives(cp: String :+: Boolean :+: CNil)
   case class CoRecords(cp: Joo :+: Goo :+: CNil)
   case class CoArrays(cp: Seq[String] :+: Int :+: CNil)
+  case class CoMaps(cp: Map[String, Int] :+: Int :+: CNil)
 
   def write[T](ts: Seq[T])(implicit schema: SchemaFor[T], ser: ToRecord[T]): Array[Byte] = {
     val output = new ByteArrayOutputStream
@@ -165,6 +166,19 @@ class AvroInputStreamTest extends WordSpec with Matchers with Timeouts {
 
       val bytes = write(data)
       val in = AvroInputStream[CoArrays](bytes)
+      in.iterator.toList shouldBe data.toList
+      in.close()
+    }
+    "read coproducts of maps" in {
+      type MSII = Map[String, Int] :+: Int :+: CNil
+      val data = Seq(
+        CoMaps(Coproduct[MSII](Map("v" -> 1))),
+        CoMaps(Coproduct[MSII](9))
+      )
+
+      val bytes = write(data)
+      println(bytes)
+      val in = AvroInputStream[CoMaps](bytes)
       in.iterator.toList shouldBe data.toList
       in.close()
     }

--- a/avro4s-generator/src/test/scala/com/sksamuel/avro4s/ModuleRendererTest.scala
+++ b/avro4s-generator/src/test/scala/com/sksamuel/avro4s/ModuleRendererTest.scala
@@ -53,5 +53,13 @@ class ModuleRendererTest extends WordSpec with Matchers {
     "generate either for union types of records" in {
       new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("name", UnionType(PrimitiveType.String, RecordType("com.sammy", "NestedClass", Seq(FieldDef("name", PrimitiveType.String)))))))) shouldBe "//auto generated code by avro4s\ncase class MyClass(\n  name: Either[String, com.sammy.NestedClass]\n)"
     }
-  }
+    "generate Option[Either] for union types of 3 types with null" in {
+      new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("name", UnionType(NullType, PrimitiveType.Int, PrimitiveType.Boolean))))) shouldBe "//auto generated code by avro4s\ncase class MyClass(\n  name: Option[Either[Int, Boolean]]\n)"
+    }
+    "generate coproducts for union types of 3+ non-null types" in {
+      new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("name", UnionType(PrimitiveType.String, PrimitiveType.Int, PrimitiveType.Boolean))))) shouldBe "//auto generated code by avro4s\ncase class MyClass(\n  name: shapeless.:+:[String, shapeless.:+:[Int, shapeless.:+:[Boolean, shapeless.CNil]]]\n)"
+    }
+    "generate Option[coproducts] for union types of 3+ non-null types with null" in {
+      new ModuleRenderer()(RecordType("com.sammy", "MyClass", Seq(FieldDef("name", UnionType(NullType, PrimitiveType.String, PrimitiveType.Int, PrimitiveType.Boolean))))) shouldBe "//auto generated code by avro4s\ncase class MyClass(\n  name: Option[shapeless.:+:[String, shapeless.:+:[Int, shapeless.:+:[Boolean, shapeless.CNil]]]]\n)"
+    }}
 }

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
@@ -143,6 +143,15 @@ object FromValue extends LowPriorityFromValue {
       case _: Long if tpe <:< typeOf[Long] => Some(from(value))
       case _: Double if tpe <:< typeOf[Double] => Some(from(value))
       case _: Float if tpe <:< typeOf[Float] => Some(from(value))
+      // we don't need to worry about the inner type of the array,
+      // as avro schemas will not legally allow multiple arrays in a union
+      // tpe is the type we're _expecting_, though, so we need to
+      // check both scala and java collections
+      case _: GenericData.Array[_]
+          if tpe <:< typeOf[Array[_]] ||
+             tpe <:< typeOf[java.util.Collection[_]] ||
+             tpe <:< typeOf[Iterable[_]] =>
+        Some(from(value))
       case record: GenericData.Record if typeVals == recordFields(record) => Some(from(value))
       case _ => None
     }

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
@@ -6,7 +6,7 @@ import java.util.UUID
 import org.apache.avro.Schema.Field
 import org.apache.avro.generic.{GenericData, GenericRecord}
 import org.apache.avro.util.Utf8
-import shapeless.Lazy
+import shapeless.{ :+:, CNil, Coproduct, Inr, Lazy }
 
 import scala.language.experimental.macros
 import scala.reflect.ClassTag
@@ -122,46 +122,64 @@ object FromValue extends LowPriorityFromValue {
 
   import scala.reflect.runtime.universe.WeakTypeTag
 
-  implicit def EitherFromValue[A, B](implicit
-                                     leftfromvalue: FromValue[A],
-                                     rightfromvalue: FromValue[B],
-                                     leftType: WeakTypeTag[A],
-                                     rightType: WeakTypeTag[B]): FromValue[Either[A, B]] = new FromValue[Either[A, B]] {
-    override def apply(value: Any, field: Field): Either[A, B] = {
+  private def safeFrom[T:WeakTypeTag:FromValue](value: Any): Option[T] = {
+    import scala.reflect.runtime.universe.typeOf
 
-      import scala.reflect.runtime.universe.typeOf
+    val tpe = implicitly[WeakTypeTag[T]].tpe
+    val from = implicitly[FromValue[T]]
 
-      def convert[C](tpe: scala.reflect.runtime.universe.Type): Either[A, B] = {
-        if (leftType.tpe <:< tpe) Left(leftfromvalue(value))
-        else if (rightType.tpe <:< tpe) Right(rightfromvalue(value))
-        else sys.error(s"Value $value of type ${value.getClass} is not compatible with the defined either types")
-      }
+    // if we have a generic record, we can't use the type to work out which one it matches,
+    // so we have to compare field names
+    val typeVals: Set[String] =
+      tpe.members.filter(_.isTerm).map(_.asTerm).filter(_.isVal).map(_.name.decodedName.toString.trim).toSet
 
-      def typeVals(tpe: scala.reflect.runtime.universe.Type): List[String] = {
-        tpe.members.filter(_.isTerm).map(_.asTerm).filter(_.isVal).map(_.name.decodedName.toString.trim).toList
-      }
+    def recordFields(record: GenericRecord): Set[String] =
+      record.getSchema.getFields.asScala.map(_.name).toSet
 
-      // if we have a generic record, we can't use the type to work out which one it matches,
-      // so we have to compare field names
-      def fromRecord(record: GenericRecord): Either[A, B] = {
-        import scala.collection.JavaConverters._
-        val fieldNames = record.getSchema.getFields.asScala.map(_.name).toList
-        if (typeVals(leftType.tpe).toSet == fieldNames.toSet) Left(leftfromvalue(value))
-        else if (typeVals(rightType.tpe).toSet == fieldNames.toSet) Right(rightfromvalue(value))
-        else sys.error(s"Value $value of type ${value.getClass} is not compatible with the defined either types")
-      }
-
-      value match {
-        case utf8: Utf8 => convert(typeOf[java.lang.String])
-        case true | false => convert(typeOf[Boolean])
-        case _: Int => convert(typeOf[Int])
-        case _: Long => convert(typeOf[Long])
-        case _: Double => convert(typeOf[Double])
-        case _: Float => convert(typeOf[Float])
-        case record: GenericData.Record => fromRecord(record)
-        case _ => sys.error(s"Value $value of type ${value.getClass} is not compatible with the defined either types")
-      }
+    value match {
+      case utf8: Utf8 if tpe <:< typeOf[java.lang.String] => Some(from(value))
+      case true | false if tpe <:< typeOf[Boolean] => Some(from(value))
+      case _: Int if tpe <:< typeOf[Int] => Some(from(value))
+      case _: Long if tpe <:< typeOf[Long] => Some(from(value))
+      case _: Double if tpe <:< typeOf[Double] => Some(from(value))
+      case _: Float if tpe <:< typeOf[Float] => Some(from(value))
+      case record: GenericData.Record if typeVals == recordFields(record) => Some(from(value))
+      case _ => None
     }
+  }
+
+  implicit def EitherFromValue[A:WeakTypeTag:FromValue, B:WeakTypeTag:FromValue]: FromValue[Either[A, B]] = new FromValue[Either[A, B]] {
+    override def apply(value: Any, field: Field): Either[A, B] =
+      safeFrom[A](value).map(Left[A,B](_))
+        .orElse(safeFrom[B](value).map(Right[A,B](_)))
+        .getOrElse(sys.error(s"Value $value of type ${value.getClass} is not compatible with ${field.name}"))
+  }
+
+  // A coproduct is a union, or a generalised either.
+  // A :+: B :+: C :+: CNil is a type that is either an A, or a B, or a C.
+
+  // Shapeless's implementation builds up the type recursively,
+  // (i.e., it's actually A :+: (B :+: (C :+: CNil)))
+
+  // `apply` here should never be invoked under normal operation; if
+  // we're trying to read a value of type CNil it's because we've
+  // tried all the other cases and failed. But the FromValue[CNil]
+  // needs to exist to supply a base case for the recursion.
+  implicit def CNilFromValue: FromValue[CNil] = new FromValue[CNil] {
+    override def apply(value: Any, field: Field): CNil =
+      sys.error(s"Value $value of type ${value.getClass} is not compatible with ${field.name}")
+  }
+
+  // We're expecting to read a value of type S :+: T from avro.  Avro
+  // unions are untyped, so we have to attempt to read a value of type
+  // S (the concrete type), and if that fails, attempt to read the
+  // rest of the coproduct type T.
+
+  // thus, the bulk of the logic here is shared with reading Eithers, in `safeFrom`.
+  implicit def CoproductFromValue[S:WeakTypeTag:FromValue, T <: Coproduct :FromValue]: FromValue[S :+: T] = new FromValue[S :+: T] {
+    override def apply(value: Any, field: Field): S :+: T =
+      safeFrom[S](value).map(Coproduct[S :+: T](_))
+        .getOrElse(Inr(implicitly[FromValue[T]].apply(value, field)))
   }
 }
 

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
@@ -152,6 +152,11 @@ object FromValue extends LowPriorityFromValue {
              tpe <:< typeOf[java.util.Collection[_]] ||
              tpe <:< typeOf[Iterable[_]] =>
         Some(from(value))
+      // and similarly for maps
+      case _: java.util.Map[_, _]
+          if tpe <:< typeOf[java.util.Map[_,_]] ||
+             tpe <:< typeOf[Map[_,_]] =>
+        Some(from(value))
       case record: GenericData.Record if typeVals == recordFields(record) => Some(from(value))
       case _ => None
     }


### PR DESCRIPTION
Support for general union types! 

I did my best to make sure existing usecases were unimpacted; `avro4s` still uses Options and Eithers for the simpler cases, but now it can support larger unions as well.