### PR TITLE
set BigDecimal scale and precision for schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,19 @@ val format = RecordFormat[Composer]
 val ennio = format.from(record)
 ```
 
+## Set a schema's decimal scale and precision
+
+Bring an implicit `ScaleAndPrecision` into scope before using `AvroSchema`.
+
+```scala
+import com.sksamuel.avro4s.ScaleAndPrecision
+
+case class MyDecimal(d: BigDecimal)
+
+implicit sp = ScaleAndPrecision(8, 20)
+val schema = AvroSchema[MyDecimal]
+```
+
 ## Type Mappings
 
 |Scala Type|Avro Type|

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
@@ -27,17 +27,19 @@ trait LowPriorityToSchema {
   }
 }
 
+case class ScaleAndPrecision(scale: Int, precision: Int)
+
 object ToSchema extends LowPriorityToSchema {
 
   implicit val BooleanToSchema: ToSchema[Boolean] = new ToSchema[Boolean] {
     protected val schema = Schema.create(Schema.Type.BOOLEAN)
   }
 
-  implicit val BigDecimalToSchema: ToSchema[BigDecimal] = new ToSchema[BigDecimal] {
+  implicit def BigDecimalToSchema(implicit sp: ScaleAndPrecision = ScaleAndPrecision(2, 8)): ToSchema[BigDecimal] = new ToSchema[BigDecimal] {
     protected val schema = Schema.create(Schema.Type.BYTES)
     schema.addProp("logicalType", "decimal": Any)
-    schema.addProp("scale", "2": Any)
-    schema.addProp("precision", "8": Any)
+    schema.addProp("scale", sp.scale.toString: Any)
+    schema.addProp("precision", sp.precision.toString: Any)
   }
 
   implicit val ByteArrayToSchema: ToSchema[Array[Byte]] = new ToSchema[Array[Byte]] {


### PR DESCRIPTION
TODOs:
* `ScaleAndPrecision` should go somewhere else. It is a big project; so, please guide me.
* Should the example print the schema of `MyDecimal`?

Ideally, it would be nice for users to have the ability to use different `ScaleAndPrecision`s within schema `BigDecimal`s. I'm not sure how to do that yet but would love to do this if it is possible.