### PR TITLE
Optimise reflection evaluation

### DIFF
--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
@@ -131,7 +131,7 @@ object FromValue extends LowPriorityFromValue {
 
     // if we have a generic record, we can't use the type to work out which one it matches,
     // so we have to compare field names
-    val typeVals: Set[String] =
+    lazy val typeVals: Set[String] =
     tpe.members.filter(_.isTerm).map(_.asTerm).filter(_.isVal).map(_.name.decodedName.toString.trim).toSet
 
     def recordFields(record: GenericRecord): Set[String] =


### PR DESCRIPTION
The evaluation of the typeVals on every invocation of FromValue.safeFrom is causing a huge performance impact under load due to excessive reflection calls.

Changing typeVals to a lazy val means it is only evaluated if we are matching a GenericData.Record.

Through profiling of our application under load this change has resulted in a noticable improvement in performance.

Here is an example stack trace identified as consuming a majority of CPU: 

rules-akka.actor.default-dispatcher-31 [RUNNABLE]
scala.reflect.internal.Types$Type.members() Types.scala:260
com.sksamuel.avro4s.FromValue$.com$sksamuel$avro4s$FromValue$$safeFrom(Object, TypeTags$WeakTypeTag, FromValue) FromRecord.scala:134
com.sksamuel.avro4s.FromValue$$anon$10.apply(Object, Schema$Field) FromRecord.scala:181
com.sksamuel.avro4s.FromValue$$anon$10.apply(Object, Schema$Field) FromRecord.scala:179