### PR TITLE
Remove all compiler warnings

### DIFF
--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroInputStreamTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroInputStreamTest.scala
@@ -2,13 +2,12 @@ package com.sksamuel.avro4s
 
 import java.io.ByteArrayOutputStream
 import java.util.UUID
-
-import org.scalatest.concurrent.Timeouts
+import org.scalatest.concurrent.TimeLimits
 import org.scalatest.{Matchers, WordSpec}
 
 import shapeless.{:+:, Coproduct, CNil}
 
-class AvroInputStreamTest extends WordSpec with Matchers with Timeouts {
+class AvroInputStreamTest extends WordSpec with Matchers with TimeLimits {
 
   case class Booleans(bool: Boolean)
   case class BigDecimalTest(decimal: BigDecimal)

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroOutputStreamTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroOutputStreamTest.scala
@@ -7,7 +7,7 @@ import java.util.UUID
 import org.apache.avro.file.{DataFileReader, SeekableByteArrayInput}
 import org.apache.avro.generic.{GenericDatumReader, GenericRecord}
 import org.apache.avro.util.Utf8
-import org.scalatest.concurrent.Timeouts
+import org.scalatest.concurrent.TimeLimits
 import org.scalatest.{Matchers, WordSpec}
 
 import scala.collection.JavaConverters._
@@ -46,7 +46,7 @@ object CPWrapper {
   type ISTTB = Int :+: String :+: Test1 :+: Test2 :+: Boolean :+: CNil
 }
 
-class AvroOutputStreamTest extends WordSpec with Matchers with Timeouts {
+class AvroOutputStreamTest extends WordSpec with Matchers with TimeLimits {
 
   def read[T](out: ByteArrayOutputStream)(implicit schema: SchemaFor[T]): GenericRecord = read(out.toByteArray)
   def read[T](bytes: Array[Byte])(implicit schema: SchemaFor[T]): GenericRecord = {

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/ReadmeTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/ReadmeTest.scala
@@ -27,12 +27,12 @@ class ReadmeTest extends WordSpec with Matchers {
 
       val pepperoni = Pizza("pepperoni", Seq(Ingredient("pepperoni", 12.2, 4.4), Ingredient("onions", 1.2, 0.4)), false, false, 500)
       val hawaiian = Pizza("hawaiian", Seq(Ingredient("ham", 1.5, 5.6), Ingredient("pineapple", 5.2, 0.2)), false, false, 500)
-      val os = AvroOutputStream[Pizza](new File("pizzas.avro"))
+      val os = AvroOutputStream.data[Pizza](new File("pizzas.avro"))
       os.write(Seq(pepperoni, hawaiian))
       os.flush()
       os.close()
 
-      val is = AvroInputStream[Pizza](new File("pizzas.avro"))
+      val is = AvroInputStream.data[Pizza](new File("pizzas.avro"))
       val pizzas = is.iterator.toList
       is.close()
       pizzas shouldEqual List(pepperoni, hawaiian)

--- a/avro4s-json/src/main/scala/com/sksamuel/avro4s/json/JsonToAvroConverter.scala
+++ b/avro4s-json/src/main/scala/com/sksamuel/avro4s/json/JsonToAvroConverter.scala
@@ -38,7 +38,9 @@ class JsonToAvroConverter(namespace: String, avroStringTypeIsString: Boolean = f
     case JString(_) => createStringSchema
     case JObject(values) =>
       val record = Schema.createRecord(name, null, namespace, false)
-      val fields = values.map { case (name, value) => new Schema.Field(name, convert(name, value), null, null) }
+      val doc: String = null
+      val default: AnyRef = null
+      val fields = values.map { case (name, value) => new Schema.Field(name, convert(name, value), doc, default) }
       record.setFields(fields.asJava)
       record
   }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -22,7 +22,9 @@ object Build extends Build {
     resolvers += Resolver.mavenLocal,
     publishArtifact in Test := false,
     parallelExecution in Test := false,
-    scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8", "-Ywarn-unused-import"),
+    scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8", "-Ywarn-unused-import",
+      "-Xfatal-warnings", "-feature", "-language:existentials"
+    ),
     javacOptions := Seq("-source", "1.7", "-target", "1.7"),
     sbtrelease.ReleasePlugin.autoImport.releasePublishArtifactsAction := PgpKeys.publishSigned.value,
     sbtrelease.ReleasePlugin.autoImport.releaseCrossBuild := true,


### PR DESCRIPTION
This PR removes all compiler warnings and requires going forward that no more warnings are allowed by adding `-Xfatal-warnings` to the build's `scalacOptions`.

This PR was motivated by #76, though it does not fix the bug. I am trying to reproduce #76 via a unit test but so far have not been able to. However, please consider merging these small changes to prevent compiler warnings being introduced in the future.