### PR TITLE
proper fixed type support

### DIFF
--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/FixedTypeTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/FixedTypeTest.scala
@@ -1,0 +1,48 @@
+package com.sksamuel.avro4s
+
+import java.io.ByteArrayOutputStream
+
+import org.apache.avro.Schema.Type
+import org.scalatest.{Matchers, WordSpec}
+
+class FixedTypeTest extends WordSpec with Matchers {
+  val m = AvroMessage(
+    QuarterSHA256(new scala.collection.mutable.WrappedArray.ofByte(Array[Byte](0, 1, 2, 3, 4, 5, 6, 7))),
+    Array[Byte](0, 1, 2, 3))
+
+  "Avro4s" should {
+    "generate fixed(n) type fir @AvroFixed(n) case class" in {
+      val schema = SchemaFor[QuarterSHA256]()
+      schema.getType shouldBe Type.FIXED
+      schema.getFixedSize shouldBe 8
+    }
+    "encode fixed(n) as a plain vector of bytes with fixed length" in {
+      val baos = new ByteArrayOutputStream()
+      val output = AvroOutputStream.binary[AvroMessage](baos)
+      output.write(m.copy(payload = Array.emptyByteArray))
+      output.close()
+
+      val bytes = baos.toByteArray
+
+      bytes.length shouldBe 9
+      bytes.take(8) shouldBe m.schema.bytes
+      bytes(8) shouldBe 0
+    }
+    "encode and decode fixed(n)" in {
+      val baos = new ByteArrayOutputStream()
+      val output = AvroOutputStream.binary[AvroMessage](baos)
+      output.write(m)
+      output.close()
+
+      val decoded = AvroInputStream.binary[AvroMessage](baos.toByteArray).iterator.next()
+
+      decoded.schema shouldBe m.schema
+      decoded.payload.toSeq shouldBe m.payload.toSeq
+    }
+  }
+}
+
+@AvroFixed(8)
+case class QuarterSHA256(bytes: scala.collection.mutable.WrappedArray.ofByte) extends AnyVal
+
+case class AvroMessage(schema: QuarterSHA256, payload: Array[Byte])

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
@@ -191,6 +191,14 @@ object SchemaFor {
     def apply(): org.apache.avro.Schema = SchemaBuilder.builder().stringType()
   }
 
+  def fixedSchemaFor[T](name: String, annos: Seq[Anno], namespace: String, size: Int): SchemaFor[T] = {
+    new SchemaFor[T] {
+      private val schema = Schema.createFixed(name, doc(annos), namespace, size)
+
+      override def apply(): Schema = schema
+    }
+  }
+
   implicit def apply[T]: SchemaFor[T] = macro SchemaFor.applyImpl[T]
 
   def applyImpl[T: c.WeakTypeTag](c: whitebox.Context): c.Expr[SchemaFor[T]] = {
@@ -205,13 +213,20 @@ object SchemaFor {
       q"com.sksamuel.avro4s.Anno($name, $args)"
     }
 
+    lazy val fixedAnnotation: Option[AvroFixed] = tType.typeSymbol.annotations.collectFirst {
+      case anno if anno.tree.tpe <:< c.weakTypeOf[AvroFixed] =>
+        anno.tree.children.tail match {
+          case Literal(Constant(size: Int)) :: Nil => AvroFixed(size)
+        }
+    }
+
     def fieldsForType(atype: c.universe.Type): List[c.universe.Symbol] = {
       atype.decls.collectFirst {
         case m: MethodSymbol if m.isPrimaryConstructor => m.paramLists.head
       }.getOrElse(Nil)
     }
 
-    val valueClass = tType.typeSymbol.isClass && tType.typeSymbol.asClass.isDerivedValueClass
+    val valueClass = tType.typeSymbol.isClass && tType.typeSymbol.asClass.isDerivedValueClass && fixedAnnotation.isEmpty
     val underlyingType = if (valueClass) {
       tType.typeSymbol.asClass.primaryConstructor.asMethod.paramLists.flatten.head.typeSignature
     } else {
@@ -299,28 +314,38 @@ object SchemaFor {
       """
       )
     } else {
-      c.Expr[SchemaFor[T]](
-        q"""
-        new com.sksamuel.avro4s.SchemaFor[$tType] {
-          val (incompleteSchema: org.apache.avro.Schema, completeSchema: shapeless.Lazy[org.apache.avro.Schema]) = {
-            com.sksamuel.avro4s.SchemaFor.recordBuilder[$tType](
-              $name,
-              $pack,
-              shapeless.Lazy {
-                val selfSchema = incompleteSchema
-                implicit val selfToSchema: com.sksamuel.avro4s.ToSchema[$tType] = new com.sksamuel.avro4s.ToSchema[$tType] {
-                  val schema: org.apache.avro.Schema = selfSchema
-                }
-                Seq(..$fieldSchemaPartTrees)
-              },
-              Seq(..$annos)
-            )
-          }
+      fixedAnnotation match {
+        case Some(AvroFixed(size)) =>
+          val expr = c.Expr[SchemaFor[T]](
+            q"""
+              com.sksamuel.avro4s.SchemaFor.fixedSchemaFor[$tType]($name, Seq(..$annos), $pack, $size)
+            """
+          )
+          expr
+        case None =>
+          c.Expr[SchemaFor[T]](
+            q"""
+            new com.sksamuel.avro4s.SchemaFor[$tType] {
+              val (incompleteSchema: org.apache.avro.Schema, completeSchema: shapeless.Lazy[org.apache.avro.Schema]) = {
+                com.sksamuel.avro4s.SchemaFor.recordBuilder[$tType](
+                  $name,
+                  $pack,
+                  shapeless.Lazy {
+                    val selfSchema = incompleteSchema
+                    implicit val selfToSchema: com.sksamuel.avro4s.ToSchema[$tType] = new com.sksamuel.avro4s.ToSchema[$tType] {
+                      val schema: org.apache.avro.Schema = selfSchema
+                    }
+                    Seq(..$fieldSchemaPartTrees)
+                  },
+                  Seq(..$annos)
+                )
+              }
 
-          def apply(): org.apache.avro.Schema = completeSchema.value
-        }
-      """
-      )
+              def apply(): org.apache.avro.Schema = completeSchema.value
+            }
+          """
+          )
+      }
     }
   }
 
@@ -334,6 +359,8 @@ object SchemaFor {
 
   // returns any aliases present in the list of annotations
   def aliases(annos: Seq[Anno]): Seq[String] = annotationsFor(classOf[AvroAlias], annos).flatMap(_.values.headOption)
+
+  def fixed(annos: Seq[Anno]): Option[Int] = annotationsFor(classOf[AvroFixed], annos).headOption.map(_.values.head.toInt)
 
   def addProps(annos: Seq[Anno], f: (String, String) => Unit): Unit = {
     annotationsFor(classOf[AvroProp], annos).map(_.values.toList).foreach {


### PR DESCRIPTION
Associated PR: https://github.com/sksamuel/sbt-avro4s/pull/9

Added proper support for `fixed` types, currently represented as:
`@AvroFixed(32) case class SHA256(bytes: WrappedArray.ofByte) extends AnyVal`