### PR TITLE
Add support for primitives

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroInputStream.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroInputStream.scala
@@ -16,7 +16,7 @@ trait AvroInputStream[T] {
 }
 
 class AvroBinaryInputStream[T](in: InputStream)
-                              (implicit schemaFor: SchemaFor[T], fromRecord: FromRecord[T])
+                              (implicit schemaFor: SchemaFor[T], fromValue: FromValue[T])
   extends AvroInputStream[T] {
 
   val datumReader = new GenericDatumReader[GenericRecord](schemaFor())
@@ -33,19 +33,19 @@ class AvroBinaryInputStream[T](in: InputStream)
 
   override def iterator: Iterator[T] = new Iterator[T] {
     override def hasNext: Boolean = result.hasNext
-    override def next(): T = fromRecord(result.next)
+    override def next(): T = fromValue(result.next)
   }
 
   override def tryIterator: Iterator[Try[T]] = new Iterator[Try[T]] {
     override def hasNext: Boolean = result.hasNext
-    override def next(): Try[T] = Try(fromRecord(result.next))
+    override def next(): Try[T] = Try(fromValue(result.next))
   }
 
   override def close(): Unit = in.close()
 }
 
 class AvroDataInputStream[T](in: SeekableInput)
-                            (implicit schemaFor: SchemaFor[T], fromRecord: FromRecord[T])
+                            (implicit schemaFor: SchemaFor[T], fromValue: FromValue[T])
   extends AvroInputStream[T] {
 
   val datumReader = new GenericDatumReader[GenericRecord](schemaFor())
@@ -53,65 +53,65 @@ class AvroDataInputStream[T](in: SeekableInput)
 
   override def iterator: Iterator[T] = new Iterator[T] {
     override def hasNext: Boolean = dataFileReader.hasNext
-    override def next(): T = fromRecord(dataFileReader.next)
+    override def next(): T = fromValue(dataFileReader.next)
   }
 
   override def tryIterator: Iterator[Try[T]] = new Iterator[Try[T]] {
     override def hasNext: Boolean = dataFileReader.hasNext
-    override def next(): Try[T] = Try(fromRecord(dataFileReader.next))
+    override def next(): Try[T] = Try(fromValue(dataFileReader.next))
   }
 
   override def close(): Unit = in.close()
 }
 
 final case class AvroJsonInputStream[T](in: InputStream)
-                                       (implicit schemaFor: SchemaFor[T], fromRecord: FromRecord[T])
+                                       (implicit schemaFor: SchemaFor[T], fromValue: FromValue[T])
   extends AvroInputStream[T] {
 
   private val schema = schemaFor()
-  private val dataumReader = new GenericDatumReader[GenericRecord](schema)
+  private val dataumReader = new GenericDatumReader[Any](schema)
   private val jsonDecoder = DecoderFactory.get.jsonDecoder(schema, in)
 
   def iterator: Iterator[T] = Iterator.continually(Try{dataumReader.read(null, jsonDecoder)})
     .takeWhile(_.isSuccess)
     .map(_.get)
-    .map(fromRecord.apply)
+    .map(v => fromValue(v))
 
   def tryIterator: Iterator[Try[T]] = Iterator.continually(Try(dataumReader.read(null, jsonDecoder)))
     .takeWhile(_.isSuccess)
     .map(_.get)
-    .map(record => Try(fromRecord(record)))
+    .map(record => Try(fromValue(record)))
 
-  def singleEntity: Try[T] = Try{dataumReader.read(null, jsonDecoder)}.map(fromRecord.apply)
+  def singleEntity: Try[T] = Try{dataumReader.read(null, jsonDecoder)}.map(v => fromValue(v))
 
   override def close(): Unit = in.close()
 }
 
 object AvroInputStream {
 
-  def json[T: SchemaFor : FromRecord](in: InputStream): AvroJsonInputStream[T] = new AvroJsonInputStream[T](in)
-  def json[T: SchemaFor : FromRecord](bytes: Array[Byte]): AvroJsonInputStream[T] = json(new SeekableByteArrayInput(bytes))
-  def json[T: SchemaFor : FromRecord](file: File): AvroJsonInputStream[T] = json(new SeekableFileInput(file))
-  def json[T: SchemaFor : FromRecord](path: String): AvroJsonInputStream[T] = json(Paths.get(path))
-  def json[T: SchemaFor : FromRecord](path: Path): AvroJsonInputStream[T] = json(path.toFile)
+  def json[T: SchemaFor : FromValue](in: InputStream): AvroJsonInputStream[T] = new AvroJsonInputStream[T](in)
+  def json[T: SchemaFor : FromValue](bytes: Array[Byte]): AvroJsonInputStream[T] = json(new SeekableByteArrayInput(bytes))
+  def json[T: SchemaFor : FromValue](file: File): AvroJsonInputStream[T] = json(new SeekableFileInput(file))
+  def json[T: SchemaFor : FromValue](path: String): AvroJsonInputStream[T] = json(Paths.get(path))
+  def json[T: SchemaFor : FromValue](path: Path): AvroJsonInputStream[T] = json(path.toFile)
 
-  def binary[T: SchemaFor : FromRecord](in: InputStream): AvroBinaryInputStream[T] = new AvroBinaryInputStream[T](in)
-  def binary[T: SchemaFor : FromRecord](bytes: Array[Byte]): AvroBinaryInputStream[T] = binary(new SeekableByteArrayInput(bytes))
-  def binary[T: SchemaFor : FromRecord](file: File): AvroBinaryInputStream[T] = binary(new SeekableFileInput(file))
-  def binary[T: SchemaFor : FromRecord](path: String): AvroBinaryInputStream[T] = binary(Paths.get(path))
-  def binary[T: SchemaFor : FromRecord](path: Path): AvroBinaryInputStream[T] = binary(path.toFile)
+  def binary[T: SchemaFor : FromValue](in: InputStream): AvroBinaryInputStream[T] = new AvroBinaryInputStream[T](in)
+  def binary[T: SchemaFor : FromValue](bytes: Array[Byte]): AvroBinaryInputStream[T] = binary(new SeekableByteArrayInput(bytes))
+  def binary[T: SchemaFor : FromValue](file: File): AvroBinaryInputStream[T] = binary(new SeekableFileInput(file))
+  def binary[T: SchemaFor : FromValue](path: String): AvroBinaryInputStream[T] = binary(Paths.get(path))
+  def binary[T: SchemaFor : FromValue](path: Path): AvroBinaryInputStream[T] = binary(path.toFile)
 
-  def data[T: SchemaFor : FromRecord](bytes: Array[Byte]): AvroDataInputStream[T] = new AvroDataInputStream[T](new SeekableByteArrayInput(bytes))
-  def data[T: SchemaFor : FromRecord](file: File): AvroDataInputStream[T] = new AvroDataInputStream[T](new SeekableFileInput(file))
-  def data[T: SchemaFor : FromRecord](path: String): AvroDataInputStream[T] = data(Paths.get(path))
-  def data[T: SchemaFor : FromRecord](path: Path): AvroDataInputStream[T] = data(path.toFile)
+  def data[T: SchemaFor : FromValue](bytes: Array[Byte]): AvroDataInputStream[T] = new AvroDataInputStream[T](new SeekableByteArrayInput(bytes))
+  def data[T: SchemaFor : FromValue](file: File): AvroDataInputStream[T] = new AvroDataInputStream[T](new SeekableFileInput(file))
+  def data[T: SchemaFor : FromValue](path: String): AvroDataInputStream[T] = data(Paths.get(path))
+  def data[T: SchemaFor : FromValue](path: Path): AvroDataInputStream[T] = data(path.toFile)
 
   @deprecated("Use .json .data or .binary to make it explicit which type of output you want", "1.5.0")
-  def apply[T: SchemaFor : FromRecord](bytes: Array[Byte]): AvroInputStream[T] = new AvroBinaryInputStream[T](new SeekableByteArrayInput(bytes))
+  def apply[T: SchemaFor : FromValue](bytes: Array[Byte]): AvroInputStream[T] = new AvroBinaryInputStream[T](new SeekableByteArrayInput(bytes))
   @deprecated("Use .json .data or .binary to make it explicit which type of output you want", "1.5.0")
-  def apply[T: SchemaFor : FromRecord](path: String): AvroInputStream[T] = apply(new File(path))
+  def apply[T: SchemaFor : FromValue](path: String): AvroInputStream[T] = apply(new File(path))
   @deprecated("Use .json .data or .binary to make it explicit which type of output you want", "1.5.0")
-  def apply[T: SchemaFor : FromRecord](path: Path): AvroInputStream[T] = apply(path.toFile)
+  def apply[T: SchemaFor : FromValue](path: Path): AvroInputStream[T] = apply(path.toFile)
   @deprecated("Use .json .data or .binary to make it explicit which type of output you want", "1.5.0")
-  def apply[T: SchemaFor : FromRecord](file: File): AvroInputStream[T] = new AvroDataInputStream[T](new SeekableFileInput(file))
+  def apply[T: SchemaFor : FromValue](file: File): AvroInputStream[T] = new AvroDataInputStream[T](new SeekableFileInput(file))
 }

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroOutputStream.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroOutputStream.scala
@@ -5,7 +5,7 @@ import java.nio.file.{Files, Path}
 
 import org.apache.avro.Schema
 import org.apache.avro.file.DataFileWriter
-import org.apache.avro.generic.{GenericDatumWriter, GenericRecord}
+import org.apache.avro.generic.{GenericDatumWriter}
 import org.apache.avro.io.EncoderFactory
 
 trait AvroOutputStream[T] {
@@ -18,10 +18,10 @@ trait AvroOutputStream[T] {
 
 // avro output stream that does not write the schema, only use when you want the smallest messages possible
 // at the cost of not having the schema available in the messages for downstream clients
-case class AvroBinaryOutputStream[T](os: OutputStream)(implicit schemaFor: SchemaFor[T], toRecord: ToRecord[T])
+case class AvroBinaryOutputStream[T](os: OutputStream)(implicit schemaFor: SchemaFor[T], toValue: ToValue[T])
   extends AvroOutputStream[T] {
 
-  val dataWriter = new GenericDatumWriter[GenericRecord](schemaFor())
+  val dataWriter = new GenericDatumWriter[Any](schemaFor())
   val encoder = EncoderFactory.get().binaryEncoder(os, null)
 
   override def close(): Unit = {
@@ -29,13 +29,13 @@ case class AvroBinaryOutputStream[T](os: OutputStream)(implicit schemaFor: Schem
     os.close()
   }
 
-  override def write(t: T): Unit = dataWriter.write(toRecord(t), encoder)
+  override def write(t: T): Unit = dataWriter.write(toValue(t), encoder)
   override def flush(): Unit = encoder.flush()
   override def fSync(): Unit = ()
 }
 
 // avro output stream that includes the schema for the messages. This is usually what you want.
-case class AvroDataOutputStream[T](os: OutputStream)(implicit schemaFor: SchemaFor[T], toRecord: ToRecord[T])
+case class AvroDataOutputStream[T](os: OutputStream)(implicit schemaFor: SchemaFor[T], toValue: ToValue[T])
   extends AvroOutputStream[T] {
 
   val schema = schemaFor()
@@ -46,11 +46,11 @@ case class AvroDataOutputStream[T](os: OutputStream)(implicit schemaFor: SchemaF
       dataFileWriter.create(schema, os)
       (dataFileWriter, (t: T) => dataFileWriter.append(t))
     case _ =>
-      val datumWriter = new GenericDatumWriter[GenericRecord](schema)
-      val dataFileWriter = new DataFileWriter[GenericRecord](datumWriter)
+      val datumWriter = new GenericDatumWriter[Any](schema)
+      val dataFileWriter = new DataFileWriter[Any](datumWriter)
       dataFileWriter.create(schema, os)
       (dataFileWriter, (t: T) => {
-        val record = toRecord.apply(t)
+        val record = toValue(t)
         dataFileWriter.append(record)
       })
   }
@@ -68,11 +68,11 @@ case class AvroDataOutputStream[T](os: OutputStream)(implicit schemaFor: SchemaF
 }
 
 // avro output stream that writes json instead of a packed format
-case class AvroJsonOutputStream[T](os: OutputStream)(implicit schemaFor: SchemaFor[T], toRecord: ToRecord[T])
+case class AvroJsonOutputStream[T](os: OutputStream)(implicit schemaFor: SchemaFor[T], toValue: ToValue[T])
   extends AvroOutputStream[T] {
 
   private val schema = schemaFor()
-  protected val datumWriter = new GenericDatumWriter[GenericRecord](schema)
+  protected val datumWriter = new GenericDatumWriter[Any](schema)
   private val encoder = EncoderFactory.get.jsonEncoder(schema, os)
 
   override def close(): Unit = {
@@ -80,42 +80,42 @@ case class AvroJsonOutputStream[T](os: OutputStream)(implicit schemaFor: SchemaF
     os.close()
   }
 
-  override def write(t: T): Unit = datumWriter.write(toRecord(t), encoder)
+  override def write(t: T): Unit = datumWriter.write(toValue(t), encoder)
   override def fSync(): Unit = {}
   override def flush(): Unit = encoder.flush()
 }
 
 object AvroOutputStream {
 
-  def json[T: SchemaFor : ToRecord](file: File): AvroJsonOutputStream[T] = json(file.toPath)
-  def json[T: SchemaFor : ToRecord](path: Path): AvroJsonOutputStream[T] = json(Files.newOutputStream(path))
-  def json[T: SchemaFor : ToRecord](os: OutputStream): AvroJsonOutputStream[T] = AvroJsonOutputStream(os)
+  def json[T: SchemaFor : ToValue](file: File): AvroJsonOutputStream[T] = json(file.toPath)
+  def json[T: SchemaFor : ToValue](path: Path): AvroJsonOutputStream[T] = json(Files.newOutputStream(path))
+  def json[T: SchemaFor : ToValue](os: OutputStream): AvroJsonOutputStream[T] = AvroJsonOutputStream(os)
 
-  def data[T: SchemaFor : ToRecord](file: File): AvroDataOutputStream[T] = data(file.toPath)
-  def data[T: SchemaFor : ToRecord](path: Path): AvroDataOutputStream[T] = data(Files.newOutputStream(path))
-  def data[T: SchemaFor : ToRecord](os: OutputStream): AvroDataOutputStream[T] = AvroDataOutputStream(os)
+  def data[T: SchemaFor : ToValue](file: File): AvroDataOutputStream[T] = data(file.toPath)
+  def data[T: SchemaFor : ToValue](path: Path): AvroDataOutputStream[T] = data(Files.newOutputStream(path))
+  def data[T: SchemaFor : ToValue](os: OutputStream): AvroDataOutputStream[T] = AvroDataOutputStream(os)
 
-  def binary[T: SchemaFor : ToRecord](file: File): AvroBinaryOutputStream[T] = binary(file.toPath)
-  def binary[T: SchemaFor : ToRecord](path: Path): AvroBinaryOutputStream[T] = binary(Files.newOutputStream(path))
-  def binary[T: SchemaFor : ToRecord](os: OutputStream): AvroBinaryOutputStream[T] = AvroBinaryOutputStream(os)
-
-  @deprecated("Use .json .data or .binary to make it explicit which type of output you want", "1.5.0")
-  def apply[T: SchemaFor : ToRecord](file: File): AvroOutputStream[T] = apply(file.toPath, true)
+  def binary[T: SchemaFor : ToValue](file: File): AvroBinaryOutputStream[T] = binary(file.toPath)
+  def binary[T: SchemaFor : ToValue](path: Path): AvroBinaryOutputStream[T] = binary(Files.newOutputStream(path))
+  def binary[T: SchemaFor : ToValue](os: OutputStream): AvroBinaryOutputStream[T] = AvroBinaryOutputStream(os)
 
   @deprecated("Use .json .data or .binary to make it explicit which type of output you want", "1.5.0")
-  def apply[T: SchemaFor : ToRecord](file: File, binaryModeDisabled: Boolean): AvroOutputStream[T] = apply(file.toPath, binaryModeDisabled)
+  def apply[T: SchemaFor : ToValue](file: File): AvroOutputStream[T] = apply(file.toPath, true)
 
   @deprecated("Use .json .data or .binary to make it explicit which type of output you want", "1.5.0")
-  def apply[T: SchemaFor : ToRecord](path: Path): AvroOutputStream[T] = apply(Files.newOutputStream(path), true)
+  def apply[T: SchemaFor : ToValue](file: File, binaryModeDisabled: Boolean): AvroOutputStream[T] = apply(file.toPath, binaryModeDisabled)
 
   @deprecated("Use .json .data or .binary to make it explicit which type of output you want", "1.5.0")
-  def apply[T: SchemaFor : ToRecord](path: Path, binaryModeDisabled: Boolean): AvroOutputStream[T] = apply(Files.newOutputStream(path), binaryModeDisabled)
+  def apply[T: SchemaFor : ToValue](path: Path): AvroOutputStream[T] = apply(Files.newOutputStream(path), true)
 
   @deprecated("Use .json .data or .binary to make it explicit which type of output you want", "1.5.0")
-  def apply[T: SchemaFor : ToRecord](os: OutputStream): AvroOutputStream[T] = apply(os, false)
+  def apply[T: SchemaFor : ToValue](path: Path, binaryModeDisabled: Boolean): AvroOutputStream[T] = apply(Files.newOutputStream(path), binaryModeDisabled)
 
   @deprecated("Use .json .data or .binary to make it explicit which type of output you want", "1.5.0")
-  def apply[T: SchemaFor : ToRecord](os: OutputStream, binaryModeDisabled: Boolean): AvroOutputStream[T] = {
+  def apply[T: SchemaFor : ToValue](os: OutputStream): AvroOutputStream[T] = apply(os, false)
+
+  @deprecated("Use .json .data or .binary to make it explicit which type of output you want", "1.5.0")
+  def apply[T: SchemaFor : ToValue](os: OutputStream, binaryModeDisabled: Boolean): AvroOutputStream[T] = {
     if (binaryModeDisabled) new AvroDataOutputStream[T](os)
     else new AvroBinaryOutputStream[T](os)
   }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroBinaryTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroBinaryTest.scala
@@ -38,5 +38,71 @@ class AvroBinaryTest extends WordSpec with Matchers {
       pizzas shouldBe List(tgtbtu)
       is.close()
     }
+
+    "support string type" in {
+      val testSource = "hello"
+      val baos = new ByteArrayOutputStream()
+      val output = AvroOutputStream.binary[String](baos)
+      output.write(testSource)
+      output.close()
+
+      val is = AvroInputStream.binary[String](baos.toByteArray)
+      val pizzas = is.iterator.toList
+      pizzas shouldBe List(testSource)
+      is.close()
+    }
+
+    "support int type" in {
+      val testSource = 123
+      val baos = new ByteArrayOutputStream()
+      val output = AvroOutputStream.binary[Int](baos)
+      output.write(testSource)
+      output.close()
+
+      val is = AvroInputStream.binary[Int](baos.toByteArray)
+      val pizzas = is.iterator.toList
+      pizzas shouldBe List(testSource)
+      is.close()
+    }
+
+    "support long type" in {
+      val testSource = 123L
+      val baos = new ByteArrayOutputStream()
+      val output = AvroOutputStream.binary[Long](baos)
+      output.write(testSource)
+      output.close()
+
+      val is = AvroInputStream.binary[Long](baos.toByteArray)
+      val pizzas = is.iterator.toList
+      pizzas shouldBe List(testSource)
+      is.close()
+    }
+
+    "support double type" in {
+      val testSource: Double = 123.123
+      val baos = new ByteArrayOutputStream()
+      val output = AvroOutputStream.binary[Double](baos)
+      output.write(testSource)
+      output.close()
+
+      val is = AvroInputStream.binary[Double](baos.toByteArray)
+      val pizzas = is.iterator.toList
+      pizzas shouldBe List(testSource)
+      is.close()
+    }
+
+    "support float type" in {
+      val testSource: Float = 123.123F
+      val baos = new ByteArrayOutputStream()
+      val output = AvroOutputStream.binary[Float](baos)
+      output.write(testSource)
+      output.close()
+
+      val is = AvroInputStream.binary[Float](baos.toByteArray)
+      val pizzas = is.iterator.toList
+      pizzas shouldBe List(testSource)
+      is.close()
+    }
+
   }
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroDataTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroDataTest.scala
@@ -25,6 +25,34 @@ class AvroDataTest extends WordSpec with Matchers {
       file.delete()
     }
 
+    "be able to read its own output for string types" in {
+      val testSource = "hello avro"
+      val file: File = new File("string.avro")
+      val os = AvroOutputStream.data[String](file)
+      os.write(testSource)
+      os.close()
+
+      val is = AvroInputStream.data[String](file)
+      val pizzas = is.iterator.toList
+      pizzas shouldBe List(testSource)
+      is.close()
+      file.delete()
+    }
+
+    "be able to read its own output for int types" in {
+      val testSource = 123
+      val file: File = new File("int.avro")
+      val os = AvroOutputStream.data[Int](file)
+      os.write(testSource)
+      os.close()
+
+      val is = AvroInputStream.data[Int](file)
+      val pizzas = is.iterator.toList
+      pizzas shouldBe List(testSource)
+      is.close()
+      file.delete()
+    }
+
     "be able to serialize/deserialize recursive data" in {
       val data = Recursive(4, Some(Recursive(2, Some(Recursive(9, None)))))
 

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroJsonTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroJsonTest.scala
@@ -24,5 +24,20 @@ class AvroJsonTest extends WordSpec with Matchers {
       is.close()
       file.delete()
     }
+
+    "be able to read its own output for strings" in {
+
+      val testSource = "hello avro"
+      val file: File = new File("string.json")
+      val os = AvroOutputStream.json[String](file)
+      os.write(testSource)
+      os.close()
+
+      val is = AvroInputStream.json[String](file)
+      val pizzas = is.iterator.toList
+      pizzas shouldBe List(testSource)
+      is.close()
+      file.delete()
+    }
   }
 }


### PR DESCRIPTION
Hi!

Using the current implementation the following is not possible,

  val boas = new ByteArrayOutputStream()
  val output = AvroOutputStream.binary[String](boas)
  output.write("hello avro")

Because internally, a GenericDatumReader/Write of type [GenericRecord] is being used and primitives arent avro record types.
If we switch this out for a GenericDatumReader/Writer of type [Any], and switch from using implicit From/ToRecord[T] to using From/ToValue[T] in the public API, we get the ability to work with primitives. We also dont loose any functionality around GenericRecord/complex types (due to the implicit conversions between the To/FromValue type classes to the To/FromRecord type classes).

This is a risky change, as it changes the public API, however due to the implict conversions mentioned above I can't imagine there being any breaking changes. (It was also a trivially easy change thanks to the awesome code!)

I've submitted this more for discussion than actually expecting it to be merged as is. I think the ability to use primitives directly (rather than wrapping them in case classes) is a key use case.

Any thoughts??

Thanks

Mark.

