### PR TITLE
Real package path in generated schema

### DIFF
--- a/avro4s-core/src/test/resources/nested_in_uppercase_pkg.avsc
+++ b/avro4s-core/src/test/resources/nested_in_uppercase_pkg.avsc
@@ -1,0 +1,9 @@
+{
+  "type" : "record",
+  "name" : "Data",
+  "namespace" : "com.sksamuel.avro4s.examples.UppercasePkg",
+  "fields" : [ {
+    "name" : "payload",
+    "type" : [ "string", "int" ]
+  } ]
+}

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroSchemaTest.scala
@@ -356,6 +356,12 @@ class AvroSchemaTest extends WordSpec with Matchers {
       val schema = SchemaFor[VectorRecord]()
       schema.toString(true) shouldBe expected.toString(true)
     }
+    "support types nested in uppercase packages" in {
+      val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/nested_in_uppercase_pkg.avsc"))
+      val schema = SchemaFor[examples.UppercasePkg.Data]()
+      println(schema.toString(true))
+      schema.toString(true) shouldBe expected.toString(true)
+    }
   }
 }
 

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/FixedTypeTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/FixedTypeTest.scala
@@ -11,7 +11,7 @@ class FixedTypeTest extends WordSpec with Matchers {
     Array[Byte](0, 1, 2, 3))
 
   "Avro4s" should {
-    "generate fixed(n) type fir @AvroFixed(n) case class" in {
+    "generate fixed(n) type for @AvroFixed(n) case class" in {
       val schema = SchemaFor[QuarterSHA256]()
       schema.getType shouldBe Type.FIXED
       schema.getFixedSize shouldBe 8

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/RecordFormatTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/RecordFormatTest.scala
@@ -1,6 +1,7 @@
 package com.sksamuel.avro4s
 
 import org.scalatest.{Matchers, WordSpec}
+import shapeless.{Inl, Inr}
 
 class RecordFormatTest extends WordSpec with Matchers {
   case class Composer(name: String, birthplace: String, compositions: Seq[String])
@@ -11,6 +12,12 @@ class RecordFormatTest extends WordSpec with Matchers {
       record.toString shouldBe """{"name": "ennio morricone", "birthplace": "rome", "compositions": ["legend of 1900", "ecstasy of gold"]}"""
       val after = RecordFormat[Composer].from(record)
       after shouldBe ennio
+    }
+
+    "convert to/from record for type contained in uppercase package" in {
+      val data = examples.UppercasePkg.Data(Inr(Inl(5)))
+      val fmt = RecordFormat[examples.UppercasePkg.Data]
+      fmt.from(fmt.to(data)) shouldBe data
     }
   }
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/examples/UppercasePkg/Data.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/examples/UppercasePkg/Data.scala
@@ -1,0 +1,5 @@
+package com.sksamuel.avro4s.examples.UppercasePkg
+
+import shapeless.{:+:, CNil}
+
+case class Data(payload: String :+: Int :+: CNil)

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
@@ -139,7 +139,7 @@ object FromValue extends LowPriorityFromValue {
 
     def typeName: String = {
       val nearestPackage = Stream.iterate(tpe.typeSymbol.owner)(_.owner).dropWhile(!_.isPackage).head
-      s"${nearestPackage.fullName}.${tpe.typeSymbol.name}"
+      s"${nearestPackage.fullName}.${tpe.typeSymbol.name.decodedName}"
     }
 
     value match {

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
@@ -302,8 +302,7 @@ object SchemaFor {
 
     // name of the actual class
     val name = underlyingType.typeSymbol.name.decodedName.toString
-    // name of the outer package, can't find a way to get this explicitly so hacking the full class name
-    val pack = underlyingType.typeSymbol.fullName.split('.').takeWhile(_.forall(c => !c.isUpper)).mkString(".")
+    val pack = Stream.iterate(underlyingType.typeSymbol.owner)(_.owner).dropWhile(!_.isPackage).head.fullName
     val annos = annotations(underlyingType.typeSymbol)
 
     // we create an explicit ToSchema[T] in the scope of any


### PR DESCRIPTION
Real package path in generated schema retrieved in generated schema instead of lowercase heuristics. It addresses #100 by unifying method of determining package name of a type both in `FromValue` typeclass derivation for coproducts and generation of schema in `SchemaFor` macro.