### PR TITLE
Introduced consistent end-to-end, union-based encoding of sealed traits

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,13 @@ val schema = AvroSchema[MyDecimal]
 
 Avro supports generalised unions, eithers of more than two values. To represent these in scala, we use `shapeless.:+:`, such that `A :+: B :+: C :+: CNil` represents cases where a type is `A` OR `B` OR `C`. See shapeless' [documentation on coproducts](https://github.com/milessabin/shapeless/wiki/Feature-overview:-shapeless-2.0.0#coproducts-and-discriminated-unions) for more on how to use coproducts.
 
+## Sealed hierarchies
+
+Scala sealed traits/classes are supported both when it comes to schema generation and conversions to/from `GenericRecord`. Generally sealed hierarchies are encoded as unions - in the same way like Coproducts. Under the hood, shapeless `Generic` is used to derive Coproduct representation for sealed hierarchy.
+
+When all descendants of sealed trait/class are singleton objects, optimized, string-based encoding is used instead.
+
+
 ## Type Mappings
 
 ``` scala
@@ -277,7 +284,8 @@ import shapeless.{:+:, CNil}
 |Float|float|
 |java.util.UUID|string|
 |Java Enums|enum|
-|sealed trait T|enum|
+|sealed trait T|union|
+|sealed trait with only case objects|string|
 |Array[T]|array|
 |List[T]|array|
 |Seq[T]|array|

--- a/avro4s-core/src/test/resources/sealed_traits.avsc
+++ b/avro4s-core/src/test/resources/sealed_traits.avsc
@@ -4,16 +4,20 @@
   "namespace" : "com.sksamuel.avro4s",
   "fields" : [ {
     "name" : "wibble",
-    "type" : {
+    "type" : [ {
       "type" : "record",
-      "name" : "Wibble",
+      "name" : "Wabble",
+      "fields" : [ {
+        "name" : "dbl",
+        "type" : "double"
+      } ]
+    }, {
+      "type" : "record",
+      "name" : "Wobble",
       "fields" : [ {
         "name" : "str",
-        "type" : [ "null", "string" ]
-      }, {
-        "name" : "dbl",
-        "type" : [ "double", "null" ]
+        "type" : "string"
       } ]
-    }
+    } ]
   } ]
 }

--- a/avro4s-core/src/test/resources/trait_subtypes_duplicate_fields.avsc
+++ b/avro4s-core/src/test/resources/trait_subtypes_duplicate_fields.avsc
@@ -4,19 +4,26 @@
   "namespace" : "com.sksamuel.avro4s",
   "fields" : [ {
     "name" : "tibble",
-    "type" : {
+    "type" : [ {
       "type" : "record",
-      "name" : "Tibble",
+      "name" : "Tabble",
       "fields" : [ {
         "name" : "str",
-        "type" : [ "double", "string" ]
+        "type" : "double"
       }, {
         "name" : "age",
-        "type" : [ "int", "null" ]
+        "type" : "int"
+      } ]
+    }, {
+      "type" : "record",
+      "name" : "Tobble",
+      "fields" : [ {
+        "name" : "str",
+        "type" : "string"
       }, {
         "name" : "place",
-        "type" : [ "null", "string" ]
+        "type" : "string"
       } ]
-    }
+    } ]
   } ]
 }

--- a/avro4s-core/src/test/resources/trait_subtypes_duplicate_fields_same_type.avsc
+++ b/avro4s-core/src/test/resources/trait_subtypes_duplicate_fields_same_type.avsc
@@ -4,19 +4,26 @@
   "namespace" : "com.sksamuel.avro4s",
   "fields" : [ {
     "name" : "nibble",
-    "type" : {
+    "type" : [ {
       "type" : "record",
-      "name" : "Nibble",
+      "name" : "Nabble",
       "fields" : [ {
         "name" : "str",
-        "type" : [ "string" ]
+        "type" : "string"
       }, {
         "name" : "age",
-        "type" : [ "int", "null" ]
+        "type" : "int"
+      } ]
+    }, {
+      "type" : "record",
+      "name" : "Nobble",
+      "fields" : [ {
+        "name" : "str",
+        "type" : "string"
       }, {
         "name" : "place",
-        "type" : [ "null", "string" ]
+        "type" : "string"
       } ]
-    }
+    } ]
   } ]
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroSchemaTest.scala
@@ -253,12 +253,12 @@ class AvroSchemaTest extends WordSpec with Matchers {
       val schema = SchemaFor[Wrapper]()
       schema.toString(true) shouldBe expected.toString(true)
     }
-    "merge trait subtypes fields with same name into unions" in {
+    "support trait subtypes fields with same name" in {
       val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/trait_subtypes_duplicate_fields.avsc"))
       val schema = SchemaFor[Trapper]()
       schema.toString(true) shouldBe expected.toString(true)
     }
-    "merge trait subtypes fields with same name and same type into a single schema" in {
+    "support trait subtypes fields with same name and same type" in {
       val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/trait_subtypes_duplicate_fields_same_type.avsc"))
       val schema = SchemaFor[Napper]()
       schema.toString(true) shouldBe expected.toString(true)
@@ -359,7 +359,6 @@ class AvroSchemaTest extends WordSpec with Matchers {
     "support types nested in uppercase packages" in {
       val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/nested_in_uppercase_pkg.avsc"))
       val schema = SchemaFor[examples.UppercasePkg.Data]()
-      println(schema.toString(true))
       schema.toString(true) shouldBe expected.toString(true)
     }
   }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/RecordFormatTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/RecordFormatTest.scala
@@ -19,5 +19,13 @@ class RecordFormatTest extends WordSpec with Matchers {
       val fmt = RecordFormat[examples.UppercasePkg.Data]
       fmt.from(fmt.to(data)) shouldBe data
     }
+
+    "convert to/from records containg sealed trait hierarchy" in {
+      val wrapper1 = Wrapper(Wobble("abc"))
+      val wrapper2 = Wrapper(Wabble(3.14))
+      val fmt = RecordFormat[Wrapper]
+      fmt.from(fmt.to(wrapper1)) shouldBe wrapper1
+      fmt.from(fmt.to(wrapper2)) shouldBe wrapper2
+    }
   }
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/examples/TraitObjectEnumerationExample.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/examples/TraitObjectEnumerationExample.scala
@@ -2,6 +2,8 @@ package com.sksamuel.avro4s.examples
 
 import org.scalatest.{Matchers, WordSpec}
 
+import scala.util.Failure
+
 /**
   *
   * Example of how to map sealed trait+case object style of enumeration to
@@ -10,7 +12,7 @@ import org.scalatest.{Matchers, WordSpec}
   * API inspired by scodec
   *
   * Design goals were to avoid the three individual implicits required by README "custom type mapping" example
-  * and avoid redundant specification of the object/Int mapping.
+  * and avoid redundant specification of the object/string mapping.
   *
   */
 class TraitObjectEnumerationExample extends WordSpec with Matchers {
@@ -24,53 +26,38 @@ class TraitObjectEnumerationExample extends WordSpec with Matchers {
   case class Test(v: Base)
 
 
-  object Pack {
-
-    import org.apache.avro.Schema
-    import org.apache.avro.Schema.Field
-    import com.sksamuel.avro4s.{FromValue, ToValue, SchemaFor}
-
-    def apply[T](mapping: (T, Int)*) = new Pack(
-      Map(mapping: _*),
-      Map((for ((k, v) <- mapping) yield (v, k)): _*))
-
-    class Pack[T](to: Map[T, Int], from: Map[Int, T]) extends SchemaFor[T] with ToValue[T] with FromValue[T] {
-      def apply = Schema.create(Schema.Type.INT)
-
-      override def apply(value: T): Int = to(value)
-
-      override def apply(value: Any, field: Field): T = from(value.asInstanceOf[Int])
-    }
-
-  }
-
-  implicit val BasePack = Pack[Base](A -> 0, B -> 1)
-
   import scala.util.Success
   import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
   import com.sksamuel.avro4s.{AvroInputStream, AvroOutputStream, AvroSchema}
 
   "AvroStream" should {
 
-    "generate schema using int " in {
-      AvroSchema[Test].toString should be(
-        """{"type":"record","name":"Test","namespace":"com.sksamuel.avro4s.examples","fields":[{"name":"v","type":"int"}]}""")
+    "generate schema using int" in {
+      AvroSchema[Test].toString should be
+        """{"type":"record","name":"Test","namespace":"com.sksamuel.avro4s.examples","fields":[{"name":"v","type":"string"}]}"""
     }
 
-    "serialize as int" in {
+    "serialize as string" in {
       val baos = new ByteArrayOutputStream()
       val output = AvroOutputStream.json[Test](baos)
       output.write(Test(A))
       output.close()
-      baos.toString("UTF-8") shouldBe ("""{"v":0}""")
+      baos.toString("UTF-8") shouldBe """{"v":"A"}"""
     }
 
-    "deserialize from int" in {
-      val json = """{"v":1}"""
-
+    "deserialize from string" in {
+      val json = """{"v":"B"}"""
       val in = new ByteArrayInputStream(json.getBytes("UTF-8"))
       val input = AvroInputStream.json[Test](in)
-      input.singleEntity shouldBe (Success(Test(B)))
+      input.singleEntity shouldBe Success(Test(B))
+    }
+
+    "handle deserialization from invalid message at runtime" in {
+      val json = """{"v":"C"}"""
+      val in = new ByteArrayInputStream(json.getBytes("UTF-8"))
+      val input = AvroInputStream.json[Test](in)
+      input.singleEntity.asInstanceOf[Failure[Test]].exception.getMessage shouldBe
+        "Value C of type class org.apache.avro.util.Utf8 is not compatible with [v]"
     }
   }
 }


### PR DESCRIPTION
Instead of custom encoding for sealed traits, introduced encoding as unions using shapeless.Generic. Kept optimal, string-based encoding in case when all sealed hierarchy descendants are singleton objects.

@sksamuel I know this is breaking change, but brings nice support for end-to-end sealed hierarchies. Please tell what do you think.