### PR TITLE
Sealed trait + case object encoded as enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Avro supports generalised unions, eithers of more than two values. To represent 
 
 Scala sealed traits/classes are supported both when it comes to schema generation and conversions to/from `GenericRecord`. Generally sealed hierarchies are encoded as unions - in the same way like Coproducts. Under the hood, shapeless `Generic` is used to derive Coproduct representation for sealed hierarchy.
 
-When all descendants of sealed trait/class are singleton objects, optimized, string-based encoding is used instead.
+When all descendants of sealed trait/class are singleton objects, optimized, enum-based encoding is used instead.
 
 
 ## Type Mappings
@@ -285,7 +285,7 @@ import shapeless.{:+:, CNil}
 |java.util.UUID|string|
 |Java Enums|enum|
 |sealed trait T|union|
-|sealed trait with only case objects|string|
+|sealed trait with only case objects|enum|
 |Array[T]|array|
 |List[T]|array|
 |Seq[T]|array|

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/examples/TraitObjectEnumerationExample.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/examples/TraitObjectEnumerationExample.scala
@@ -12,7 +12,7 @@ import scala.util.Failure
   * API inspired by scodec
   *
   * Design goals were to avoid the three individual implicits required by README "custom type mapping" example
-  * and avoid redundant specification of the object/string mapping.
+  * and avoid redundant specification of the object/enum mapping.
   *
   */
 class TraitObjectEnumerationExample extends WordSpec with Matchers {
@@ -32,9 +32,9 @@ class TraitObjectEnumerationExample extends WordSpec with Matchers {
 
   "AvroStream" should {
 
-    "generate schema using int" in {
-      AvroSchema[Test].toString should be
-        """{"type":"record","name":"Test","namespace":"com.sksamuel.avro4s.examples","fields":[{"name":"v","type":"string"}]}"""
+    "generate schema using enum" in {
+      AvroSchema[Test].toString shouldBe
+        """{"type":"record","name":"Test","namespace":"com.sksamuel.avro4s.examples","fields":[{"name":"v","type":{"type":"enum","name":"Base","symbols":["A","B"]}}]}"""
     }
 
     "serialize as string" in {
@@ -56,8 +56,7 @@ class TraitObjectEnumerationExample extends WordSpec with Matchers {
       val json = """{"v":"C"}"""
       val in = new ByteArrayInputStream(json.getBytes("UTF-8"))
       val input = AvroInputStream.json[Test](in)
-      input.singleEntity.asInstanceOf[Failure[Test]].exception.getMessage shouldBe
-        "Value C of type class org.apache.avro.util.Utf8 is not compatible with [v]"
+      input.singleEntity.asInstanceOf[Failure[Test]].exception.getMessage shouldBe "Unknown symbol in enum C"
     }
   }
 }

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
@@ -228,7 +228,7 @@ object FromValue extends LowPriorityFromValue {
                                                                  objs: Reify.Aux[C, L],
                                                                  toList: ToList[L, T]): FromValue[T] = new FromValue[T] {
     override def apply(value: Any, field: Field): T = {
-      val name = StringFromValue(value, field)
+      val name = value.toString
       toList(objs()).find(_.toString == name).getOrElse(sys.error(errorString(value, field)))
     }
   }

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/ToRecord.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/ToRecord.scala
@@ -152,7 +152,7 @@ object ToValue extends LowPriorityToValue {
 
   implicit def genTraitObjectEnum[T, C <: Coproduct](implicit gen: Generic.Aux[T, C],
                                                      objs: Reify[C]): ToValue[T] = new ToValue[T] {
-    override def apply(value: T): Any = StringToValue(value.toString)
+    override def apply(value: T): Any = new EnumSymbol(null, value.toString)
   }
 }
 


### PR DESCRIPTION
Following discussion in #102, replaced string-based encoding for sealed trait + only case object descendants with enum-based one.