### PR TITLE
Add support for modifying namespace in record types

### DIFF
--- a/avro4s-core/src/test/resources/namespace.avsc
+++ b/avro4s-core/src/test/resources/namespace.avsc
@@ -1,0 +1,20 @@
+{
+  "type" : "record",
+  "name" : "AnnotatedNamespace",
+  "namespace" : "com.yuval",
+  "fields" : [ {
+    "name" : "s",
+    "type" : "string"
+  }, {
+    "name" : "internal",
+    "type" : {
+      "type" : "record",
+      "name" : "InternalAnnotated",
+      "namespace" : "com.yuval.internal",
+      "fields" : [ {
+        "name" : "i",
+        "type" : "int"
+      } ]
+    }
+  } ]
+}

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroSchemaTest.scala
@@ -41,13 +41,21 @@ case class AllOptionals(union: Option[Option[Int] :+: Option[String] :+: CNil])
 class AvroSchemaTest extends WordSpec with Matchers {
 
   case class NestedListString(list: List[String])
+
   case class NestedSetDouble(set: Set[Double])
+
   case class NestedSet(set: Set[Nested])
+
   case class Nested(goo: String)
+
   case class NestedBoolean(b: Boolean)
+
   case class NestedTest(foo: String, nested: Nested)
+
   case class Inner(goo: String)
+
   case class Middle(inner: Inner)
+
   case class Outer(middle: Middle)
 
   "AvroSchema" should {
@@ -293,77 +301,83 @@ class AvroSchemaTest extends WordSpec with Matchers {
       val schema = SchemaFor[Annotated]()
       schema.toString(true) shouldBe expected.toString(true)
     }
-    "support scala enums" in {
-      val schema = SchemaFor[ScalaEnums]()
-      val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/scalaenums.avsc"))
-      schema.toString(true) shouldBe expected.toString(true)
-    }
-    "support default values" in {
-      val schema = SchemaFor[DefaultValues]()
-      val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/defaultvalues.avsc"))
-      schema.toString(true) shouldBe expected.toString(true)
-    }
-    "support default option values" in {
-      val schema = SchemaFor[OptionDefaultValues]()
-      val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/optiondefaultvalues.avsc"))
-      schema.toString(true) shouldBe expected.toString(true)
-    }
-    "support recursive types" in {
-      val schema = SchemaFor[Recursive]()
-      val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/recursive.avsc"))
-      schema.toString(true) shouldBe expected.toString(true)
-    }
-    "support mutually recursive types" in {
-      val schema = SchemaFor[MutRec1]()
-      val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/mutrec.avsc"))
-      schema.toString(true) shouldBe expected.toString(true)
-    }
-    "generate schema for underlying field in a value class" in {
-      val schema = SchemaFor[ValueClass]()
-      val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/value_class.avsc"))
-      schema.toString(true) shouldBe expected.toString(true)
-    }
-    "support unions and unions of unions" in {
-      val single = SchemaFor[Union]()
-      val unionOfUnions = SchemaFor[UnionOfUnions]()
 
-      val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/union.avsc"))
-
-      single.toString(true) shouldBe expected.toString(true)
-      unionOfUnions.toString(true) shouldBe expected.toString(true).replace("Union", "UnionOfUnions")
-    }
-    "support mixing optionals with unions, merging appropriately" in {
-      val outsideOptional = SchemaFor[OptionalUnion]()
-      val insideOptional = SchemaFor[UnionOfOptional]()
-      val bothOptional = SchemaFor[AllOptionals]()
-
-      val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/optionalunion.avsc"))
-
-      outsideOptional.toString(true) shouldBe expected.toString(true)
-      insideOptional.toString(true) shouldBe expected.toString(true).replace("OptionalUnion", "UnionOfOptional")
-      bothOptional.toString(true) shouldBe expected.toString(true).replace("OptionalUnion", "AllOptionals")
-    }
-    "generate array type for a vector of primitives" in {
-      case class VectorPrim(booleans: Vector[Boolean])
-      val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/vector_prim.avsc"))
-      val schema = SchemaFor[VectorPrim]()
-      schema.toString(true) shouldBe expected.toString(true)
-    }
-    "generate array type for an vector of records" in {
-      case class VectorRecord(records: Vector[Record])
-      case class Record(str: String, double: Double)
-      val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/vector_records.avsc"))
-      val schema = SchemaFor[VectorRecord]()
-      schema.toString(true) shouldBe expected.toString(true)
-    }
-    "support types nested in uppercase packages" in {
-      val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/nested_in_uppercase_pkg.avsc"))
-      val schema = SchemaFor[examples.UppercasePkg.Data]()
-      schema.toString(true) shouldBe expected.toString(true)
+    "support namespace annotations on records" in {
+      @AvroNamespace("com.yuval") case class AnnotatedNamespace(s: String)
+      val schema = SchemaFor[AnnotatedNamespace]()
+      schema.getNamespace shouldBe "com.yuval"
     }
   }
-}
 
+  "support scala enums" in {
+    val schema = SchemaFor[ScalaEnums]()
+    val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/scalaenums.avsc"))
+    schema.toString(true) shouldBe expected.toString(true)
+  }
+  "support default values" in {
+    val schema = SchemaFor[DefaultValues]()
+    val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/defaultvalues.avsc"))
+    schema.toString(true) shouldBe expected.toString(true)
+  }
+  "support default option values" in {
+    val schema = SchemaFor[OptionDefaultValues]()
+    val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/optiondefaultvalues.avsc"))
+    schema.toString(true) shouldBe expected.toString(true)
+  }
+  "support recursive types" in {
+    val schema = SchemaFor[Recursive]()
+    val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/recursive.avsc"))
+    schema.toString(true) shouldBe expected.toString(true)
+  }
+  "support mutually recursive types" in {
+    val schema = SchemaFor[MutRec1]()
+    val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/mutrec.avsc"))
+    schema.toString(true) shouldBe expected.toString(true)
+  }
+  "generate schema for underlying field in a value class" in {
+    val schema = SchemaFor[ValueClass]()
+    val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/value_class.avsc"))
+    schema.toString(true) shouldBe expected.toString(true)
+  }
+  "support unions and unions of unions" in {
+    val single = SchemaFor[Union]()
+    val unionOfUnions = SchemaFor[UnionOfUnions]()
+
+    val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/union.avsc"))
+
+    single.toString(true) shouldBe expected.toString(true)
+    unionOfUnions.toString(true) shouldBe expected.toString(true).replace("Union", "UnionOfUnions")
+  }
+  "support mixing optionals with unions, merging appropriately" in {
+    val outsideOptional = SchemaFor[OptionalUnion]()
+    val insideOptional = SchemaFor[UnionOfOptional]()
+    val bothOptional = SchemaFor[AllOptionals]()
+
+    val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/optionalunion.avsc"))
+
+    outsideOptional.toString(true) shouldBe expected.toString(true)
+    insideOptional.toString(true) shouldBe expected.toString(true).replace("OptionalUnion", "UnionOfOptional")
+    bothOptional.toString(true) shouldBe expected.toString(true).replace("OptionalUnion", "AllOptionals")
+  }
+  "generate array type for a vector of primitives" in {
+    case class VectorPrim(booleans: Vector[Boolean])
+    val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/vector_prim.avsc"))
+    val schema = SchemaFor[VectorPrim]()
+    schema.toString(true) shouldBe expected.toString(true)
+  }
+  "generate array type for an vector of records" in {
+    case class VectorRecord(records: Vector[Record])
+    case class Record(str: String, double: Double)
+    val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/vector_records.avsc"))
+    val schema = SchemaFor[VectorRecord]()
+    schema.toString(true) shouldBe expected.toString(true)
+  }
+  "support types nested in uppercase packages" in {
+    val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/nested_in_uppercase_pkg.avsc"))
+    val schema = SchemaFor[examples.UppercasePkg.Data]()
+    schema.toString(true) shouldBe expected.toString(true)
+  }
+}
 
 case class OptionDefaultValues(
   name: String = "sammy",
@@ -384,5 +398,4 @@ case class DefaultValues(
   traits: Seq[String] = Seq("Adventurous", "Helpful"),
   favoriteWine: Wine = Wine.CabSav
 )
-
 

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroSchemaTest.scala
@@ -41,21 +41,13 @@ case class AllOptionals(union: Option[Option[Int] :+: Option[String] :+: CNil])
 class AvroSchemaTest extends WordSpec with Matchers {
 
   case class NestedListString(list: List[String])
-
   case class NestedSetDouble(set: Set[Double])
-
   case class NestedSet(set: Set[Nested])
-
   case class Nested(goo: String)
-
   case class NestedBoolean(b: Boolean)
-
   case class NestedTest(foo: String, nested: Nested)
-
   case class Inner(goo: String)
-
   case class Middle(inner: Inner)
-
   case class Outer(middle: Middle)
 
   "AvroSchema" should {

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroSchemaTest.scala
@@ -6,35 +6,23 @@ import org.scalatest.{Matchers, WordSpec}
 import shapeless.{:+:, CNil}
 
 sealed trait Wibble
-
 case class Wobble(str: String) extends Wibble
-
 case class Wabble(dbl: Double) extends Wibble
-
 case class Wrapper(wibble: Wibble)
 
 sealed trait Tibble
-
 case class Tobble(str: String, place: String) extends Tibble
-
 case class Tabble(str: Double, age: Int) extends Tibble
-
 case class Trapper(tibble: Tibble)
 
 sealed trait Nibble
-
 case class Nobble(str: String, place: String) extends Nibble
-
 case class Nabble(str: String, age: Int) extends Nibble
-
 case class Napper(nibble: Nibble)
 
 case class Level4(str: Map[String, String])
-
 case class Level3(level4: Level4)
-
 case class Level2(level3: Level3)
-
 case class Level1(level2: Level2)
 
 case class Ids(myid: UUID)
@@ -42,17 +30,12 @@ case class Ids(myid: UUID)
 case class Recursive(payload: Int, next: Option[Recursive])
 
 case class MutRec1(payload: Int, children: List[MutRec2])
-
 case class MutRec2(payload: String, children: List[MutRec1])
 
 case class Union(union: Int :+: String :+: Boolean :+: CNil)
-
 case class UnionOfUnions(union: (Int :+: String :+: CNil) :+: Boolean :+: CNil)
-
 case class OptionalUnion(union: Option[Int :+: String :+: CNil])
-
 case class UnionOfOptional(union: Option[Int] :+: String :+: CNil)
-
 case class AllOptionals(union: Option[Option[Int] :+: Option[String] :+: CNil])
 
 class AvroSchemaTest extends WordSpec with Matchers {
@@ -397,22 +380,22 @@ class AvroSchemaTest extends WordSpec with Matchers {
 }
 
 case class OptionDefaultValues(
-                                name: String = "sammy",
-                                description: Option[String] = None,
-                                currency: Option[String] = Some("$")
-                              )
+  name: String = "sammy",
+  description: Option[String] = None,
+  currency: Option[String] = Some("$")
+)
 
 case class DefaultValues(
-                          name: String = "sammy",
-                          age: Int = 21,
-                          isFemale: Boolean = false,
-                          length: Double = 6.2,
-                          timestamp: Long = 1468920998000l,
-                          address: Map[String, String] = Map(
-                            "home" -> "sammy's home address",
-                            "work" -> "sammy's work address"
-                          ),
-                          traits: Seq[String] = Seq("Adventurous", "Helpful"),
-                          favoriteWine: Wine = Wine.CabSav
-                        )
+  name: String = "sammy",
+  age: Int = 21,
+  isFemale: Boolean = false,
+  length: Double = 6.2,
+  timestamp: Long = 1468920998000l,
+  address: Map[String, String] = Map(
+    "home" -> "sammy's home address",
+    "work" -> "sammy's work address"
+  ),
+  traits: Seq[String] = Seq("Adventurous", "Helpful"),
+  favoriteWine: Wine = Wine.CabSav
+)
 

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroSchemaTest.scala
@@ -299,6 +299,14 @@ class AvroSchemaTest extends WordSpec with Matchers {
       val schema = SchemaFor[AnnotatedNamespace]()
       schema.getNamespace shouldBe "com.yuval"
     }
+
+    "support namespace annotations in nested records" in {
+      @AvroNamespace("com.yuval") case class AnnotatedNamespace(s: String, internal: InternalAnnotated)
+      @AvroNamespace("com.yuval.internal") case class InternalAnnotated(i: Int)
+      val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/namespace.avsc"))
+      val schema = SchemaFor[AnnotatedNamespace]()
+      schema.toString(true) shouldBe expected.toString(true)
+    }
   }
 
   "support scala enums" in {

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
@@ -379,6 +379,8 @@ object SchemaFor {
   // returns any aliases present in the list of annotations
   def aliases(annos: Seq[Anno]): Seq[String] = annotationsFor(classOf[AvroAlias], annos).flatMap(_.values.headOption)
 
+  def namespace(annos: Seq[Anno]): Option[String] = annotationsFor(classOf[AvroNamespace], annos).headOption.flatMap(_.values.headOption)
+
   def fixed(annos: Seq[Anno]): Option[Int] = annotationsFor(classOf[AvroFixed], annos).headOption.map(_.values.head.toInt)
 
   def addProps(annos: Seq[Anno], f: (String, String) => Unit): Unit = {
@@ -430,7 +432,8 @@ object SchemaFor {
 
     import scala.collection.JavaConverters._
 
-    val schema = org.apache.avro.Schema.createRecord(name, doc(annos), pack, false)
+    val maybeNamespace = namespace(annos)
+    val schema = org.apache.avro.Schema.createRecord(name, doc(annos), maybeNamespace.getOrElse(pack), false)
     // In recursive fields, the definition of the field depends on the
     // schema, but the definition of the schema depends on the
     // field. Furthermore, Schema and Field are java classes, strict

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/annotations.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/annotations.scala
@@ -10,3 +10,4 @@ case class AvroProp(name: String, value: String) extends StaticAnnotation
 
 case class AvroFixed(size: Int) extends StaticAnnotation
 
+case class AvroNamespace(namespace: String) extends StaticAnnotation


### PR DESCRIPTION
For record types, it is essential to be able to modify namespaces of records, especially if you're avro is meant to be read by multiple languages on different platforms.

This pull request adds the ability to annotate a case class with @AvroNamespace to modify the generated namespace name in the schema.

For example:

```scala
package com.github.yuval
@AvroNamespace("com.yuval") case class Foo(s: String)
```

Will generate:

```json
{
    "type": "record",
    "name": "Foo",
    "namespace": "com.yuval",
    "fields": [
        {
            "name": "s",
            "type": "string"
        }
    ]
}
```
