### PR TITLE
Avoid unnecessary string allocations in `FromValue` implicits

### DIFF
--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/RecordFormatTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/RecordFormatTest.scala
@@ -5,6 +5,11 @@ import shapeless.{Inl, Inr}
 
 class RecordFormatTest extends WordSpec with Matchers {
   case class Composer(name: String, birthplace: String, compositions: Seq[String])
+
+  case class Book(title: String)
+  case class Song(title: String, lyrics: String)
+  case class Author[T](name: String, birthplace: String, work: Seq[T])
+
   "RecordFormat" should {
     "convert to/from record" in {
       val ennio = Composer("ennio morricone", "rome", Seq("legend of 1900", "ecstasy of gold"))
@@ -20,12 +25,18 @@ class RecordFormatTest extends WordSpec with Matchers {
       fmt.from(fmt.to(data)) shouldBe data
     }
 
-    "convert to/from records containg sealed trait hierarchy" in {
+    "convert to/from records containing sealed trait hierarchy" in {
       val wrapper1 = Wrapper(Wobble("abc"))
       val wrapper2 = Wrapper(Wabble(3.14))
       val fmt = RecordFormat[Wrapper]
       fmt.from(fmt.to(wrapper1)) shouldBe wrapper1
       fmt.from(fmt.to(wrapper2)) shouldBe wrapper2
+    }
+
+    "convert to/from records of generic classes" in {
+      val author1 = Author[Book]("Heraclitus", "Ephesus", Seq(Book("Panta Rhei")))
+      val fmt = RecordFormat[Author[Book]]
+      fmt.from(fmt.to(author1)) shouldBe author1
     }
   }
 }

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
@@ -42,7 +42,7 @@ object FromValue extends LowPriorityFromValue {
   }
 
   implicit object BooleanFromValue extends FromValue[Boolean] {
-    override def apply(value: Any, field: Field): Boolean = value.toString.toBoolean
+    override def apply(value: Any, field: Field): Boolean = value.asInstanceOf[Boolean]
   }
 
   implicit object ByteArrayFromValue extends FromValue[Array[Byte]] {
@@ -50,19 +50,19 @@ object FromValue extends LowPriorityFromValue {
   }
 
   implicit object DoubleFromValue extends FromValue[Double] {
-    override def apply(value: Any, field: Field): Double = value.toString.toDouble
+    override def apply(value: Any, field: Field): Double = value.asInstanceOf[Double]
   }
 
   implicit object FloatFromValue extends FromValue[Float] {
-    override def apply(value: Any, field: Field): Float = value.toString.toFloat
+    override def apply(value: Any, field: Field): Float = value.asInstanceOf[Float]
   }
 
   implicit object IntFromValue extends FromValue[Int] {
-    override def apply(value: Any, field: Field): Int = value.toString.toInt
+    override def apply(value: Any, field: Field): Int = value.asInstanceOf[Int]
   }
 
   implicit object LongFromValue extends FromValue[Long] {
-    override def apply(value: Any, field: Field): Long = value.toString.toLong
+    override def apply(value: Any, field: Field): Long = value.asInstanceOf[Long]
   }
 
   implicit object StringFromValue extends FromValue[String] {

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/TypeHelper.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/TypeHelper.scala
@@ -1,0 +1,24 @@
+package com.sksamuel.avro4s
+
+import scala.reflect.macros.whitebox.Context
+
+class TypeHelper[C <: Context](val c: C) {
+  def fieldsOf(tpe: c.universe.Type) = {
+    import c.universe._
+    val primaryConstructorOpt = tpe.members.collectFirst {
+      case method: MethodSymbolApi if method.isPrimaryConstructor => method
+    }
+
+    primaryConstructorOpt.map { constructor =>
+      val constructorTypeContext = constructor.typeSignatureIn(tpe).dealias
+      val constructorArguments = constructorTypeContext.paramLists
+      constructorArguments.headOption.map { symbols =>
+        symbols.map(s => s -> s.typeSignatureIn(constructorTypeContext).dealias)
+      }.getOrElse(Nil)
+    }.getOrElse(Nil)
+  }
+}
+
+object TypeHelper {
+  def apply[C <: Context](c: C): TypeHelper[c.type] = new TypeHelper[c.type](c)
+}


### PR DESCRIPTION
When one of the `FromValue` implicits for primitive types parses the actual type of the value, it first allocates a string and then converts to the primitive type:

For example:

```scala
implicit object IntFromValue extends FromValue[Int] {
  override def apply(value: Any, field: Field): Int = value.toString.toInt
}
```

Under heavy load, this generates a decent amount of garbage strings. As an example, here is a sample from a profile I ran on code which consumes ~ 500,000 avro records:

![Sample profile on Avro heavy app](https://cloud.githubusercontent.com/assets/3448320/26151764/dbac5a88-3b0c-11e7-8399-504ff1d8f4e9.jpg)

We generate nearly 1GB of strings for parsing out `Int`s.

Since [`safeFrom`](https://github.com/sksamuel/avro4s/blob/master/avro4s-macros/src/main/scala/com/sksamuel/avro4s/FromRecord.scala#L143) matches type parameters via `WeakTypeTag`, we can safely cast to the underlying primitive type without needs to allocate an additional string.

This pull request uses `asInstanceOf` for all primitive types instead of `toString`.