### PR TITLE
Inject schema in derivation

### DIFF
--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/ToRecordTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/ToRecordTest.scala
@@ -1,5 +1,6 @@
 package com.sksamuel.avro4s
 
+import org.apache.avro.{AvroRuntimeException, Schema, SchemaBuilder}
 import org.scalatest.{FlatSpec, Matchers}
 
 case class WithBigDecimal(decimal: BigDecimal)
@@ -17,5 +18,19 @@ class ToRecordTest extends FlatSpec with Matchers {
     val schemaFor = SchemaFor[WithBigDecimal]
     val record = ToRecord.withSchemaFor[WithBigDecimal](schemaFor)(obj)
     record.toString shouldBe """{"decimal": {"bytes": "12.34"}}"""
+  }
+
+  "ToRecord with custom schema" should "use the custom schema" in {
+    val obj = WithBigDecimal(12.34)
+    val schemaFor = new SchemaFor[WithBigDecimal] {
+      override def apply(): Schema =
+        SchemaBuilder
+          .record("WithBigDecimal")
+          .fields()
+          .endRecord()
+    }
+
+    val noSchemaDecimalField = intercept[AvroRuntimeException](ToRecord.withSchemaFor[WithBigDecimal](schemaFor)(obj))
+    noSchemaDecimalField.getMessage shouldBe "Not a valid schema field: decimal"
   }
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/ToRecordTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/ToRecordTest.scala
@@ -11,4 +11,11 @@ class ToRecordTest extends FlatSpec with Matchers {
     val record = ToRecord[WithBigDecimal](obj)
     record.toString shouldBe """{"decimal": {"bytes": "12.34"}}"""
   }
+
+  "ToRecord with the derived schema passed in" should "result in the same" in {
+    val obj = WithBigDecimal(12.34)
+    val schemaFor = SchemaFor[WithBigDecimal]
+    val record = ToRecord.withSchemaFor[WithBigDecimal](schemaFor)(obj)
+    record.toString shouldBe """{"decimal": {"bytes": "12.34"}}"""
+  }
 }

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/ToRecord.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/ToRecord.scala
@@ -163,6 +163,7 @@ trait ToRecord[T] extends Serializable {
 object ToRecord {
 
   implicit def apply[T]: ToRecord[T] = macro applyImpl[T]
+  def withSchemaFor[T](schemaFor: SchemaFor[T]): ToRecord[T] = macro withSchemaForImpl[T]
 
   def applyImpl[T: c.WeakTypeTag](c: scala.reflect.macros.whitebox.Context): c.Expr[ToRecord[T]] = {
     import c.universe._
@@ -235,6 +236,90 @@ object ToRecord {
     c.Expr[ToRecord[T]](
       q"""new com.sksamuel.avro4s.ToRecord[$tpe] {
             private val schemaFor : com.sksamuel.avro4s.SchemaFor[$tpe] = com.sksamuel.avro4s.SchemaFor[$tpe]
+            private val converters : Array[shapeless.Lazy[com.sksamuel.avro4s.ToValue[_]]] = Array(..$converters)
+
+            def apply(t : $tpe): org.apache.avro.generic.GenericRecord = {
+
+              val record = new org.apache.avro.generic.GenericData.Record(schemaFor())
+              ..$puts
+              record
+            }
+          }
+        """
+    )
+  }
+
+  def withSchemaForImpl[T: c.WeakTypeTag](c: scala.reflect.macros.whitebox.Context)(schemaFor: c.Expr[SchemaFor[T]]): c.Expr[ToRecord[T]] = {
+    import c.universe._
+    val helper = TypeHelper(c)
+    val tpe = weakTypeTag[T].tpe
+
+    val constructorArgumentsWithTypes = helper.fieldsOf(tpe)
+    val converters: Seq[Tree] = constructorArgumentsWithTypes.map { case (sym, sig) =>
+
+      val fixedAnnotation: Option[AvroFixed] = sig.typeSymbol.annotations.collectFirst {
+        case anno if anno.tree.tpe <:< c.weakTypeOf[AvroFixed] =>
+          anno.tree.children.tail match {
+            case Literal(Constant(size: Int)) :: Nil => AvroFixed(size)
+          }
+      }
+
+      fixedAnnotation match {
+        case Some(AvroFixed(size)) =>
+          q"""{
+            shapeless.Lazy(com.sksamuel.avro4s.ToValue.fixed[$sig])
+          }
+          """
+        case None =>
+          q"""com.sksamuel.avro4s.ToRecord.lazyConverter[$sig]"""
+      }
+    }
+
+    val puts: Seq[Tree] = constructorArgumentsWithTypes.zipWithIndex.map {
+      case ((f, sig), idx) =>
+        val name = f.name.asInstanceOf[c.TermName]
+        val fieldName: String = name.decodedName.toString
+        val fixedAnnotation: Option[AvroFixed] = sig.typeSymbol.annotations.collectFirst {
+          case anno if anno.tree.tpe <:< c.weakTypeOf[AvroFixed] =>
+            anno.tree.children.tail match {
+              case Literal(Constant(size: Int)) :: Nil => AvroFixed(size)
+            }
+        }
+
+        val valueClass = sig.typeSymbol.isClass && sig.typeSymbol.asClass.isDerivedValueClass
+
+        // if a field is a value class we need to handle it here, using a converter
+        // for the underlying value rather than the actual value class
+        if (fixedAnnotation.nonEmpty) {
+          q"""
+          {
+            val converter = converters($idx).asInstanceOf[shapeless.Lazy[com.sksamuel.avro4s.ToValue[$sig]]]
+            record.put($fieldName, converter.value(t.$name : $sig))
+          }
+          """
+        } else if (valueClass) {
+          val valueCstr = sig.typeSymbol.asClass.primaryConstructor.asMethod.paramLists.flatten.head
+          val valueFieldType = valueCstr.typeSignature
+          val valueFieldName = valueCstr.name.asInstanceOf[c.TermName]
+          q"""
+          {
+            val converter = com.sksamuel.avro4s.ToRecord.lazyConverter[$valueFieldType]
+            record.put($fieldName, converter.value(t.$name.$valueFieldName : $valueFieldType))
+          }
+          """
+        } else {
+          q"""
+          {
+            val converter = converters($idx).asInstanceOf[shapeless.Lazy[com.sksamuel.avro4s.ToValue[$sig]]]
+            record.put($fieldName, converter.value(t.$name : $sig))
+          }
+          """
+        }
+    }
+
+    c.Expr[ToRecord[T]](
+      q"""new com.sksamuel.avro4s.ToRecord[$tpe] {
+            private val schemaFor : com.sksamuel.avro4s.SchemaFor[$tpe] = $schemaFor
             private val converters : Array[shapeless.Lazy[com.sksamuel.avro4s.ToValue[_]]] = Array(..$converters)
 
             def apply(t : $tpe): org.apache.avro.generic.GenericRecord = {

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/ToRecord.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/ToRecord.scala
@@ -27,6 +27,8 @@ trait LowPriorityToValue {
   }
 
   def fixed[T]: ToValue[T] = macro LowPriorityToValue.fixedImpl[T]
+
+  def fixedWithSchemaFor[T](schemaFor: SchemaFor[T]): ToValue[T] = macro LowPriorityToValue.fixedImplWithSchemaFor[T]
 }
 
 object LowPriorityToValue {
@@ -45,6 +47,30 @@ object LowPriorityToValue {
       q"""
         {
           val schema = com.sksamuel.avro4s.SchemaFor[$tpe]()
+          new com.sksamuel.avro4s.ToValue[$tpe] {
+            override def apply(t: $tpe): org.apache.avro.generic.GenericFixed = {
+              new org.apache.avro.generic.GenericData.Fixed(schema, t.bytes.array)
+            }
+          }
+        }
+      """)
+  }
+
+  def fixedImplWithSchemaFor[T: c.WeakTypeTag](c: scala.reflect.macros.whitebox.Context)(schemaFor: c.Expr[SchemaFor[T]]): c.Expr[ToValue[T]] = {
+    import c.universe._
+    val tpe = weakTypeTag[T].tpe
+
+    val fixedAnnotation: Option[AvroFixed] = tpe.typeSymbol.annotations.collectFirst {
+      case anno if anno.tree.tpe <:< c.weakTypeOf[AvroFixed] =>
+        anno.tree.children.tail match {
+          case Literal(Constant(size: Int)) :: Nil => AvroFixed(size)
+        }
+    }
+
+    c.Expr[ToValue[T]](
+      q"""
+        {
+          val schema = $schemaFor()
           new com.sksamuel.avro4s.ToValue[$tpe] {
             override def apply(t: $tpe): org.apache.avro.generic.GenericFixed = {
               new org.apache.avro.generic.GenericData.Fixed(schema, t.bytes.array)
@@ -267,7 +293,7 @@ object ToRecord {
       fixedAnnotation match {
         case Some(AvroFixed(size)) =>
           q"""{
-            shapeless.Lazy(com.sksamuel.avro4s.ToValue.fixed[$sig])
+            shapeless.Lazy(com.sksamuel.avro4s.ToValue.fixedWithSchemaFor[$sig]($schemaFor))
           }
           """
         case None =>


### PR DESCRIPTION
When a custom `SchemaFor` is used it might diverge from the ones derived in `ToRecord` and `ToValue`.

With this PR it is possible to supply the manually created ones so they are used in the `ToRecord` and `ToValue` derivation.