### PR TITLE
Add support for java LocalDate type

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ import shapeless.{:+:, CNil}
 |Double|double|
 |Float|float|
 |java.util.UUID|string|
+|java.time.LocalDate|string|
 |Java Enums|enum|
 |sealed trait T|union|
 |sealed trait with only case objects|enum|

--- a/avro4s-core/src/test/resources/localdate.avsc
+++ b/avro4s-core/src/test/resources/localdate.avsc
@@ -1,0 +1,9 @@
+{
+  "type" : "record",
+  "name" : "LocalDateTest",
+  "namespace" : "com.sksamuel.avro4s",
+  "fields" : [ {
+    "name" : "localDate",
+    "type" : "string"
+  } ]
+}

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroInputStreamTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroInputStreamTest.scala
@@ -1,6 +1,7 @@
 package com.sksamuel.avro4s
 
 import java.io.ByteArrayOutputStream
+import java.time.LocalDate
 import java.util.UUID
 
 import org.scalatest.concurrent.TimeLimits
@@ -458,6 +459,15 @@ class AvroInputStreamTest extends WordSpec with Matchers with TimeLimits {
       val bytes = write(data)
 
       val in = AvroInputStream.data[Ids](bytes)
+      in.iterator.toList shouldBe data.toList
+      in.close()
+    }
+    "read LocalDates" in {
+
+      val data = Seq(LocalDateTest(LocalDate.now()), LocalDateTest(LocalDate.now()))
+      val bytes = write(data)
+
+      val in = AvroInputStream.data[LocalDateTest](bytes)
       in.iterator.toList shouldBe data.toList
       in.close()
     }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroOutputStreamTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroOutputStreamTest.scala
@@ -2,6 +2,7 @@ package com.sksamuel.avro4s
 
 import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
+import java.time.LocalDate
 import java.util.UUID
 
 import org.apache.avro.file.{DataFileReader, SeekableByteArrayInput}
@@ -397,6 +398,17 @@ class AvroOutputStreamTest extends WordSpec with Matchers with TimeLimits {
 
       val record = read[Ids](output)
       UUID.fromString(record.get("myid").toString) shouldBe instance.myid
+    }
+    "support LocalDates" in {
+      val instance = LocalDateTest(LocalDate.now())
+
+      val output = new ByteArrayOutputStream
+      val avro = AvroOutputStream.data[LocalDateTest](output)
+      avro.write(instance)
+      avro.close()
+
+      val record = read[LocalDateTest](output)
+      LocalDate.parse(record.get("localDate").toString) shouldBe instance.localDate
     }
     "write Vector of primitives as arrays" in {
       case class VectorPrim(ints: Vector[Int])

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroSchemaTest.scala
@@ -1,5 +1,6 @@
 package com.sksamuel.avro4s
 
+import java.time.LocalDate
 import java.util.UUID
 
 import org.scalatest.{Matchers, WordSpec}
@@ -26,6 +27,8 @@ case class Level2(level3: Level3)
 case class Level1(level2: Level2)
 
 case class Ids(myid: UUID)
+
+case class LocalDateTest(localDate: LocalDate)
 
 case class Recursive(payload: Int, next: Option[Recursive])
 
@@ -142,6 +145,11 @@ class AvroSchemaTest extends WordSpec with Matchers {
     "accept UUIDs" in {
       val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/uuid.avsc"))
       val schema = SchemaFor[Ids]()
+      schema.toString(true) shouldBe expected.toString(true)
+    }
+    "accept LocalDate" in {
+      val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/localdate.avsc"))
+      val schema = SchemaFor[LocalDateTest]()
       schema.toString(true) shouldBe expected.toString(true)
     }
     "generate option as Union[T, Null]" in {

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
@@ -1,6 +1,7 @@
 package com.sksamuel.avro4s
 
 import java.nio.ByteBuffer
+import java.time.LocalDate
 import java.util.UUID
 
 import com.sksamuel.avro4s.ToSchema.defaultScaleAndPrecision
@@ -79,6 +80,10 @@ object FromValue extends LowPriorityFromValue {
 
   implicit object UUIDFromValue extends FromValue[UUID] {
     override def apply(value: Any, field: Field): UUID = UUID.fromString(value.toString)
+  }
+
+  implicit object LocalDateFromValue extends FromValue[LocalDate] {
+    override def apply(value: Any, field: Field): LocalDate = LocalDate.parse(value.toString)
   }
 
   implicit def OptionFromValue[T](implicit fromvalue: FromValue[T]) = new FromValue[Option[T]] {

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
@@ -1,5 +1,6 @@
 package com.sksamuel.avro4s
 
+import java.time.LocalDate
 import java.util
 
 import org.apache.avro.{JsonProperties, LogicalTypes, Schema, SchemaBuilder}
@@ -87,6 +88,10 @@ object ToSchema extends LowPriorityToSchema {
   }
 
   implicit object UUIDToSchema extends ToSchema[java.util.UUID] {
+    protected val schema = Schema.create(Schema.Type.STRING)
+  }
+
+  implicit object LocalDateToSchema extends ToSchema[LocalDate] {
     protected val schema = Schema.create(Schema.Type.STRING)
   }
 

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/ToRecord.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/ToRecord.scala
@@ -1,6 +1,8 @@
 package com.sksamuel.avro4s
 
 import java.nio.ByteBuffer
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 import com.sksamuel.avro4s.ToSchema.defaultScaleAndPrecision
@@ -73,6 +75,10 @@ object ToValue extends LowPriorityToValue {
 
   implicit object UUIDToValue extends ToValue[UUID] {
     override def apply(value: UUID): String = value.toString
+  }
+
+  implicit object LocalDateToValue extends ToValue[LocalDate] {
+    override def apply(value: LocalDate): String = value.format(DateTimeFormatter.ISO_LOCAL_DATE)
   }
 
   implicit def BigDecimalToValue(implicit sp: ScaleAndPrecision = defaultScaleAndPrecision): ToValue[BigDecimal] = {


### PR DESCRIPTION
Hello there,

I thought it may be useful to have support for the java LocalDate inside avro4s.

It may be a good idea to start grouping similar types in a coherent modules `TimeInstances` ? I was looking how circe handled that: 
https://github.com/circe/circe/blob/master/modules/java8/src/main/scala/io/circe/java8/time/TimeInstances.scala
Also another idea to consider would be to have the definition for all the implicits SchemaFor/FromValue/ToValue for a given type in one place rather than having them split in different files by implicit type as it's done now.

Thanks.