### PR TITLE
BigDecimalToValue should use a RoundingMode when scaling a BigDecimal…

### DIFF
--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/ReadmeTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/ReadmeTest.scala
@@ -1,7 +1,10 @@
 package com.sksamuel.avro4s
 
 import java.io.File
+
 import org.scalatest.{Matchers, WordSpec}
+
+import scala.math.BigDecimal.RoundingMode.HALF_EVEN
 
 case class Pizza(name: String, ingredients: Seq[Ingredient], vegetarian: Boolean, vegan: Boolean, calories: Int)
 case class Ingredient(name: String, sugar: Double, fat: Double)
@@ -10,12 +13,12 @@ case class Product(name: String, price: Price, litres: BigDecimal)
 case class Price(currency: String, amount: BigDecimal)
 
 object Price {
-  implicit val sp = ScaleAndPrecision(2,8)
+  implicit val sp = ScaleAndPrecisionAndRoundingMode(2, 8, HALF_EVEN)
   implicit val schema = SchemaFor[Price]
 }
 
 object Product {
-  implicit val sp = ScaleAndPrecision(3,8)
+  implicit val sp = ScaleAndPrecisionAndRoundingMode(3, 8, HALF_EVEN)
   implicit val schema = SchemaFor[Product]
 }
 

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
@@ -4,7 +4,7 @@ import java.nio.ByteBuffer
 import java.time.LocalDate
 import java.util.UUID
 
-import com.sksamuel.avro4s.ToSchema.defaultScaleAndPrecision
+import com.sksamuel.avro4s.ToSchema.defaultScaleAndPrecisionAndRoundingMode
 import org.apache.avro.Schema.Field
 import org.apache.avro.generic.{GenericData, GenericRecord}
 import org.apache.avro.util.Utf8
@@ -40,7 +40,7 @@ trait LowPriorityFromValue {
 
 object FromValue extends LowPriorityFromValue {
 
-  implicit def BigDecimalFromValue(implicit sp: ScaleAndPrecision = defaultScaleAndPrecision): FromValue[BigDecimal] = {
+  implicit def BigDecimalFromValue(implicit sp: ScaleAndPrecisionAndRoundingMode = defaultScaleAndPrecisionAndRoundingMode): FromValue[BigDecimal] = {
     new FromValue[BigDecimal] {
       val decimalConversion = new Conversions.DecimalConversion
       val decimalType = LogicalTypes.decimal(sp.precision, sp.scale)

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
@@ -11,6 +11,7 @@ import shapeless.{:+:, CNil, Coproduct, Generic, HList, Lazy}
 import scala.annotation.implicitNotFound
 import scala.collection.JavaConverters._
 import scala.language.experimental.macros
+import scala.math.BigDecimal.RoundingMode.{HALF_EVEN, RoundingMode}
 import scala.reflect.ClassTag
 import scala.reflect.internal.{Definitions, StdNames, SymbolTable}
 import scala.reflect.macros.whitebox
@@ -32,7 +33,7 @@ trait LowPriorityToSchema {
   }
 }
 
-case class ScaleAndPrecision(scale: Int, precision: Int)
+case class ScaleAndPrecisionAndRoundingMode(scale: Int, precision: Int, roundingMode: RoundingMode)
 
 object ToSchema extends LowPriorityToSchema {
 
@@ -40,9 +41,9 @@ object ToSchema extends LowPriorityToSchema {
     protected val schema = Schema.create(Schema.Type.BOOLEAN)
   }
 
-  lazy val defaultScaleAndPrecision = ScaleAndPrecision(2, 8)
+  lazy val defaultScaleAndPrecisionAndRoundingMode = ScaleAndPrecisionAndRoundingMode(2, 8, HALF_EVEN)
 
-  implicit def BigDecimalToSchema(implicit sp: ScaleAndPrecision = defaultScaleAndPrecision): ToSchema[BigDecimal] = new ToSchema[BigDecimal] {
+  implicit def BigDecimalToSchema(implicit sp: ScaleAndPrecisionAndRoundingMode = defaultScaleAndPrecisionAndRoundingMode): ToSchema[BigDecimal] = new ToSchema[BigDecimal] {
     protected val schema = {
       val schema = Schema.create(Schema.Type.BYTES)
       LogicalTypes.decimal(sp.precision, sp.scale).addToSchema(schema)

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
@@ -11,7 +11,7 @@ import shapeless.{:+:, CNil, Coproduct, Generic, HList, Lazy}
 import scala.annotation.implicitNotFound
 import scala.collection.JavaConverters._
 import scala.language.experimental.macros
-import scala.math.BigDecimal.RoundingMode.{HALF_EVEN, RoundingMode}
+import scala.math.BigDecimal.RoundingMode.{RoundingMode, UNNECESSARY}
 import scala.reflect.ClassTag
 import scala.reflect.internal.{Definitions, StdNames, SymbolTable}
 import scala.reflect.macros.whitebox
@@ -41,7 +41,7 @@ object ToSchema extends LowPriorityToSchema {
     protected val schema = Schema.create(Schema.Type.BOOLEAN)
   }
 
-  lazy val defaultScaleAndPrecisionAndRoundingMode = ScaleAndPrecisionAndRoundingMode(2, 8, HALF_EVEN)
+  lazy val defaultScaleAndPrecisionAndRoundingMode = ScaleAndPrecisionAndRoundingMode(2, 8, UNNECESSARY)
 
   implicit def BigDecimalToSchema(implicit sp: ScaleAndPrecisionAndRoundingMode = defaultScaleAndPrecisionAndRoundingMode): ToSchema[BigDecimal] = new ToSchema[BigDecimal] {
     protected val schema = {

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/ToRecord.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/ToRecord.scala
@@ -86,7 +86,7 @@ object ToValue extends LowPriorityToValue {
     val decimalType = LogicalTypes.decimal(sp.precision, sp.scale)
     new ToValue[BigDecimal] {
       override def apply(value: BigDecimal): ByteBuffer = {
-        val scaledValue = value.setScale(sp.scale, defaultScaleAndPrecisionAndRoundingMode.roundingMode)
+        val scaledValue = value.setScale(sp.scale, sp.roundingMode)
         decimalConversion.toBytes(scaledValue.bigDecimal, null, decimalType)
       }
     }

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/ToRecord.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/ToRecord.scala
@@ -5,7 +5,7 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.UUID
 
-import com.sksamuel.avro4s.ToSchema.defaultScaleAndPrecision
+import com.sksamuel.avro4s.ToSchema.defaultScaleAndPrecisionAndRoundingMode
 import org.apache.avro.generic.GenericData.EnumSymbol
 import org.apache.avro.generic.GenericRecord
 import org.apache.avro.{Conversions, LogicalTypes}
@@ -81,12 +81,13 @@ object ToValue extends LowPriorityToValue {
     override def apply(value: LocalDate): String = value.format(DateTimeFormatter.ISO_LOCAL_DATE)
   }
 
-  implicit def BigDecimalToValue(implicit sp: ScaleAndPrecision = defaultScaleAndPrecision): ToValue[BigDecimal] = {
+  implicit def BigDecimalToValue(implicit sp: ScaleAndPrecisionAndRoundingMode = defaultScaleAndPrecisionAndRoundingMode): ToValue[BigDecimal] = {
     val decimalConversion = new Conversions.DecimalConversion
     val decimalType = LogicalTypes.decimal(sp.precision, sp.scale)
     new ToValue[BigDecimal] {
       override def apply(value: BigDecimal): ByteBuffer = {
-        decimalConversion.toBytes(value.setScale(sp.scale).bigDecimal, null, decimalType)
+        val scaledValue = value.setScale(sp.scale, defaultScaleAndPrecisionAndRoundingMode.roundingMode)
+        decimalConversion.toBytes(scaledValue.bigDecimal, null, decimalType)
       }
     }
   }

--- a/avro4s-macros/src/test/scala/com/sksamuel/avro4s/macros/BigDecimalToValueTest.scala
+++ b/avro4s-macros/src/test/scala/com/sksamuel/avro4s/macros/BigDecimalToValueTest.scala
@@ -10,20 +10,29 @@ import scala.math.BigDecimal.RoundingMode.HALF_EVEN
 class BigDecimalToValueTest extends WordSpec with Matchers {
 
   "BigDecimalToValue" should {
-    "convert a BigDecimal into ByteBuffer (and back) with the default scale" in {
-      val n = BigDecimal(5.00)
-      BigDecimalFromValue.apply(BigDecimalToValue.apply(n)) shouldBe n
+
+    "convert a BigDecimal into ByteBuffer without specifying the scale and precision and rounding mode and rounding is not required" in {
+      val n = BigDecimal(7.8)
+      BigDecimalFromValue.apply(BigDecimalToValue.apply(n)) shouldBe BigDecimal(7.80)
     }
 
-    "convert a BigDecimal into ByteBuffer (and back) defining scale and precision and rounding mode" in {
-      implicit val sp: ScaleAndPrecisionAndRoundingMode = ScaleAndPrecisionAndRoundingMode(3, 8, HALF_EVEN)
+    "fail when trying to convert a BigDecimal into ByteBuffer without specifying the scale and precision and rounding mode and rounding is required" in {
+      val n = BigDecimal(7.851)
+      the[java.lang.ArithmeticException] thrownBy {
+        BigDecimalFromValue.apply(BigDecimalToValue.apply(n))
+      } should have message "Rounding necessary"
+    }
+
+    "convert a BigDecimal into ByteBuffer with specifying the scale and precision and rounding mode and rounding is not required" in {
+      val sp = ScaleAndPrecisionAndRoundingMode(3, 8, HALF_EVEN)
+      val n = BigDecimal(7.85)
+      BigDecimalFromValue(sp)(BigDecimalToValue(sp)(n)) shouldBe BigDecimal(7.850)
+    }
+
+    "convert a BigDecimal into ByteBuffer with specifying the scale and precision and rounding mode and rounding is required" in {
+      val sp = ScaleAndPrecisionAndRoundingMode(3, 8, HALF_EVEN)
       val n = BigDecimal(7.8516)
       BigDecimalFromValue(sp)(BigDecimalToValue(sp)(n)) shouldBe BigDecimal(7.852)
-    }
-
-    "convert a BigDecimal into ByteBuffer without explicitly specifying the scale and precision and rounding mode" in {
-      val n = BigDecimal(7.851)
-      BigDecimalFromValue.apply(BigDecimalToValue.apply(n)) shouldBe BigDecimal(7.85)
     }
   }
 }

--- a/avro4s-macros/src/test/scala/com/sksamuel/avro4s/macros/BigDecimalToValueTest.scala
+++ b/avro4s-macros/src/test/scala/com/sksamuel/avro4s/macros/BigDecimalToValueTest.scala
@@ -1,9 +1,11 @@
 package com.sksamuel.avro4s.macros
 
 import com.sksamuel.avro4s.FromValue.BigDecimalFromValue
-import com.sksamuel.avro4s.ScaleAndPrecision
+import com.sksamuel.avro4s.ScaleAndPrecisionAndRoundingMode
 import com.sksamuel.avro4s.ToValue.BigDecimalToValue
 import org.scalatest.{Matchers, WordSpec}
+
+import scala.math.BigDecimal.RoundingMode.HALF_EVEN
 
 class BigDecimalToValueTest extends WordSpec with Matchers {
 
@@ -13,17 +15,15 @@ class BigDecimalToValueTest extends WordSpec with Matchers {
       BigDecimalFromValue.apply(BigDecimalToValue.apply(n)) shouldBe n
     }
 
-    "convert a BigDecimal into ByteBuffer (and back) defining scale and precision" in {
-      implicit val sp: ScaleAndPrecision = ScaleAndPrecision(3, 8)
-      val n = BigDecimal(7.851).setScale(3)
-      BigDecimalFromValue(sp)(BigDecimalToValue(sp)(n)) shouldBe n
+    "convert a BigDecimal into ByteBuffer (and back) defining scale and precision and rounding mode" in {
+      implicit val sp: ScaleAndPrecisionAndRoundingMode = ScaleAndPrecisionAndRoundingMode(3, 8, HALF_EVEN)
+      val n = BigDecimal(7.8516)
+      BigDecimalFromValue(sp)(BigDecimalToValue(sp)(n)) shouldBe BigDecimal(7.852)
     }
 
-    "fail when trying to convert a BigDecimal into ByteBuffer without specifying the scale and precision" in {
+    "convert a BigDecimal into ByteBuffer without explicitly specifying the scale and precision and rounding mode" in {
       val n = BigDecimal(7.851)
-      the[java.lang.ArithmeticException] thrownBy {
-        BigDecimalFromValue.apply(BigDecimalToValue.apply(n))
-      } should have message "Rounding necessary"
+      BigDecimalFromValue.apply(BigDecimalToValue.apply(n)) shouldBe BigDecimal(7.85)
     }
   }
 }


### PR DESCRIPTION
Applying a scale to BigDecimal values will throw an exception if the number needs to be rounded unless a rounding mode is also specified.