### PR TITLE
WIP: Allow optionally specifying a reader-schema when creating FromRecords

### DIFF
--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
@@ -8,7 +8,7 @@ import com.sksamuel.avro4s.ToSchema.defaultScaleAndPrecision
 import org.apache.avro.Schema.Field
 import org.apache.avro.generic.{GenericData, GenericRecord}
 import org.apache.avro.util.Utf8
-import org.apache.avro.{Conversions, LogicalTypes}
+import org.apache.avro.{Conversions, LogicalTypes, Schema}
 import shapeless.ops.coproduct.Reify
 import shapeless.ops.hlist.ToList
 import shapeless.{:+:, CNil, Coproduct, Generic, HList, Inr, Lazy}
@@ -45,7 +45,11 @@ object FromValue extends LowPriorityFromValue {
       val decimalConversion = new Conversions.DecimalConversion
       val decimalType = LogicalTypes.decimal(sp.precision, sp.scale)
       override def apply(value: Any, field: Field): BigDecimal = {
-        decimalConversion.fromBytes(value.asInstanceOf[ByteBuffer], null, decimalType)
+        if (value == null && field.defaultVal() != null) {
+          decimalConversion.fromBytes(ByteBuffer.wrap(field.defaultVal.asInstanceOf[Array[Byte]]), null, decimalType)
+        } else {
+          decimalConversion.fromBytes(value.asInstanceOf[ByteBuffer], null, decimalType)
+        }
       }
     }
   }
@@ -55,7 +59,9 @@ object FromValue extends LowPriorityFromValue {
   }
 
   implicit object ByteArrayFromValue extends FromValue[Array[Byte]] {
-    override def apply(value: Any, field: Field): Array[Byte] = value.asInstanceOf[ByteBuffer].array
+    override def apply(value: Any, field: Field): Array[Byte] = {
+      value.asInstanceOf[ByteBuffer].array
+    }
   }
 
   implicit object DoubleFromValue extends FromValue[Double] {
@@ -75,7 +81,13 @@ object FromValue extends LowPriorityFromValue {
   }
 
   implicit object StringFromValue extends FromValue[String] {
-    override def apply(value: Any, field: Field): String = value.toString
+    override def apply(value: Any, field: Field): String = {
+      if (value == null && field.defaultVal != null) {
+        field.defaultVal.toString
+      } else {
+        value.toString
+      }
+    }
   }
 
   implicit object UUIDFromValue extends FromValue[UUID] {
@@ -257,7 +269,22 @@ object FromRecord {
 
   implicit def apply[T]: FromRecord[T] = macro applyImpl[T]
 
+  def withReaderSchema[T](implicit readerSchema: Option[Schema]): FromRecord[T] = macro applyImplWithReaderSchema[T]
+
+  def withInferredReaderSchema[T]: FromRecord[T] = macro applyImplWithInferredReaderSchema[T]
+
   def applyImpl[T: c.WeakTypeTag](c: scala.reflect.macros.whitebox.Context): c.Expr[FromRecord[T]] = {
+    import c.universe._
+    applyImplWithReaderSchema[T](c)(c.Expr[Option[Schema]](q"None"))
+  }
+
+  def applyImplWithInferredReaderSchema[T: c.WeakTypeTag](c: scala.reflect.macros.whitebox.Context): c.Expr[FromRecord[T]] = {
+    import c.universe._
+    val schemaFor = SchemaFor.applyImpl[T](c)
+    applyImplWithReaderSchema[T](c)(c.Expr[Option[Schema]](q"Some($schemaFor.apply())"))
+  }
+
+  def applyImplWithReaderSchema[T: c.WeakTypeTag](c: scala.reflect.macros.whitebox.Context)(readerSchema: c.Expr[Option[Schema]]): c.Expr[FromRecord[T]] = {
     import c.universe._
     val helper = TypeHelper(c)
     val tpe = weakTypeTag[T].tpe
@@ -313,7 +340,7 @@ object FromRecord {
           q"""
           {
             val converter = com.sksamuel.avro4s.FromRecord.lazyConverter[$valueFieldType]
-            val value = converter.value(record.get($decoded), record.getSchema.getField($decoded))
+            val value = converter.value(record.get($decoded), schema.getField($decoded))
             new $sig(value)
           }
           """
@@ -321,7 +348,7 @@ object FromRecord {
           q"""
           {
             val converter = converters($idx).asInstanceOf[shapeless.Lazy[com.sksamuel.avro4s.FromValue[$sig]]]
-            converter.value(record.get($decoded), record.getSchema.getField($decoded))
+            converter.value(record.get($decoded), schema.getField($decoded))
           }
           """
         }
@@ -329,9 +356,11 @@ object FromRecord {
 
     c.Expr[FromRecord[T]](
       q"""new com.sksamuel.avro4s.FromRecord[$tpe] {
+
             private val converters: Array[shapeless.Lazy[com.sksamuel.avro4s.FromValue[_]]] = Array(..$converters)
 
             def apply(record: org.apache.avro.generic.GenericRecord): $tpe = {
+              val schema = $readerSchema.getOrElse(record.getSchema)
               $companion.apply(..$fromValues)
             }
           }


### PR DESCRIPTION
Issue #110

Allow optionally specifying a reader-schema when creating FromRecords. Also, add `null` handling for `FromValue` instances (WIP).

@sksamuel I have added some initial changes. The macro related changes are working as expected. I ran some tests. If you don't mind, can you please take a look at how I have handled `null` values for some of the `FromValue` instances here. If you think I'm going in the right direction, I can make similar changes elsewhere.