### PR TITLE
Fix unused val warning in generated code

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Avro4s is a schema/class generation and serializing/deserializing library for [A
 
 The features of the library are:
 * Schema generation from classes at compile time
-* Class generation from schemas at build time
+* Class generation from schemas at build time(through [sbt](https://github.com/sksamuel/sbt-avro4s))
 * Boilerplate free serialization of classes to Avro
 * Boilerplate free deserialization of Avro to classes
 

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
@@ -348,7 +348,7 @@ object SchemaFor {
                   $pack,
                   shapeless.Lazy {
                     val selfSchema = incompleteSchema
-                    implicit val selfToSchema: com.sksamuel.avro4s.ToSchema[$tType] = new com.sksamuel.avro4s.ToSchema[$tType] {
+                    implicit val _: com.sksamuel.avro4s.ToSchema[$tType] = new com.sksamuel.avro4s.ToSchema[$tType] {
                       val schema: org.apache.avro.Schema = selfSchema
                     }
                     Seq(..$fieldSchemaPartTrees)


### PR DESCRIPTION
Fixes #125 

This fixes a major pain to adoption for anyone whos project contains flags to mark unused vals as errors.

Also one small documentation link that would have saved me some time.