### PR TITLE
Making FromValue serializable (and therefore FromRecord).

### DIFF
--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
@@ -20,7 +20,7 @@ import scala.reflect.runtime.universe._
 
 // turns an avro value into a scala value
 // type T is the target scala type
-trait FromValue[T] {
+trait FromValue[T] extends Serializable {
   def apply(value: Any, field: Field = null): T
 }
 


### PR DESCRIPTION
I made FromValue serializable which enables you to give FromRecord as a context bound but still have a serializable class.

As an example see this gist to use it with Apache Flink (and a KafkaConsumer/Producer):
https://gist.github.com/wzorgdrager/c27805ae9d627b57e736fe09dd09aad9 