### PR TITLE
support optional enums

### DIFF
--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/ToRecord.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/ToRecord.scala
@@ -2,13 +2,13 @@ package com.sksamuel.avro4s
 
 import java.nio.ByteBuffer
 import java.time.format.DateTimeFormatter
-import java.time.{LocalDate, LocalDateTime, Schema}
+import java.time.{LocalDate, LocalDateTime}
 import java.util.UUID
 
 import com.sksamuel.avro4s.ToSchema.defaultScaleAndPrecisionAndRoundingMode
 import org.apache.avro.generic.GenericData.EnumSymbol
 import org.apache.avro.generic.GenericRecord
-import org.apache.avro.{Conversions, LogicalTypes}
+import org.apache.avro.{Conversions, LogicalTypes, Schema}
 import shapeless.ops.coproduct.Reify
 import shapeless.ops.hlist.ToList
 import shapeless.{:+:, CNil, Coproduct, Generic, HList, Inl, Inr, Lazy}

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/ToRecord.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/ToRecord.scala
@@ -191,7 +191,7 @@ object ToValue extends LowPriorityToValue {
       Schema.createEnum(name, null, namespace, symbols)
     }
 
-    override def apply(value: T): Any = new EnumSymbol(null, value.toString)
+    override def apply(value: T): Any = new EnumSymbol(schema, value.toString)
   }
 }
 

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/ToRecord.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/ToRecord.scala
@@ -1,19 +1,21 @@
 package com.sksamuel.avro4s
 
 import java.nio.ByteBuffer
-import java.time.format.DateTimeFormatter
 import java.time.{LocalDate, LocalDateTime}
+import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 import com.sksamuel.avro4s.ToSchema.defaultScaleAndPrecisionAndRoundingMode
 import org.apache.avro.generic.GenericData.EnumSymbol
 import org.apache.avro.generic.GenericRecord
-import org.apache.avro.{Conversions, LogicalTypes}
+import org.apache.avro.{Conversions, LogicalTypes, Schema}
 import shapeless.ops.coproduct.Reify
-import shapeless.{:+:, CNil, Coproduct, Generic, Inl, Inr, Lazy}
+import shapeless.ops.hlist.ToList
+import shapeless.{:+:, CNil, Coproduct, Generic, HList, Inl, Inr, Lazy}
 
 import scala.collection.JavaConverters._
 import scala.language.experimental.macros
+import scala.reflect.ClassTag
 
 trait ToValue[A] {
   def apply(value: A): Any = value
@@ -22,11 +24,11 @@ trait ToValue[A] {
 trait LowPriorityToValue {
 
   implicit def genCoproduct[T, C <: Coproduct](implicit gen: Generic.Aux[T, C],
-                                               coproductToValue: Lazy[ToValue[C]]): ToValue[T] = new ToValue[T] {
-    override def apply(value: T): Any = coproductToValue.value(gen.to(value))
+                                               coproductToValue: ToValue[C]): ToValue[T] = new ToValue[T] {
+    override def apply(value: T): Any = coproductToValue(gen.to(value))
   }
 
-  implicit def applyUsingMacro[T](implicit toRecord: ToRecord[T]): ToValue[T] = new ToValue[T] {
+  implicit def apply[T](implicit toRecord: ToRecord[T]): ToValue[T] = new ToValue[T] {
     override def apply(value: T): GenericRecord = toRecord(value)
   }
 
@@ -167,16 +169,30 @@ object ToValue extends LowPriorityToValue {
   }
 
   // A :+: B is either Inl(value: A) or Inr(value: B), continuing the recursion
-  implicit def CoproductToValue[S, T <: Coproduct](implicit curToValue: Lazy[ToValue[S]], restToValue: Lazy[ToValue[T]]): ToValue[S :+: T] = new ToValue[S :+: T] {
+  implicit def CoproductToValue[S, T <: Coproduct](implicit curToValue: ToValue[S], restToValue: ToValue[T]): ToValue[S :+: T] = new ToValue[S :+: T] {
     override def apply(value: S :+: T): Any = value match {
-      case Inl(s) => curToValue.value(s)
-      case Inr(t) => restToValue.value(t)
+      case Inl(s) => curToValue(s)
+      case Inr(t) => restToValue(t)
     }
   }
 
-  implicit def genTraitObjectEnum[T, C <: Coproduct](implicit gen: Generic.Aux[T, C],
-                                                     objs: Reify[C]): ToValue[T] = new ToValue[T] {
-    override def apply(value: T): Any = new EnumSymbol(null, value.toString)
+  implicit def genTraitObjectEnum[T, C <: Coproduct, L <: HList](implicit ct: ClassTag[T], gen: Generic.Aux[T, C],
+                                                     objs: Reify.Aux[C, L],toList: ToList[L, T]): ToValue[T] = new ToValue[T] {
+
+    import scala.reflect.runtime.universe._
+
+    protected val schema: Schema = {
+      val tpe = weakTypeTag[T]
+      val namespace = tpe.tpe.typeSymbol.annotations.map(_.toString)
+        .find(_.startsWith("com.sksamuel.avro4s.AvroNamespace"))
+        .map(_.stripPrefix("com.sksamuel.avro4s.AvroNamespace(\"").stripSuffix("\")"))
+        .getOrElse(ct.runtimeClass.getPackage.getName)
+      val name = ct.runtimeClass.getSimpleName
+      val symbols = toList(objs()).map(_.toString).asJava
+      Schema.createEnum(name, null, namespace, symbols)
+    }
+
+    override def apply(value: T): Any = new EnumSymbol(schema, value.toString)
   }
 }
 


### PR DESCRIPTION
Sorry. I can only speak English a little.

I use avro4s last version (1.8.3)

GenericRequestor writing  NullPointerException.

Cause was that the schema was null.
https://github.com/sksamuel/avro4s/blob/master/avro4s-macros/src/main/scala/com/sksamuel/avro4s/ToRecord.scala#L179


I tried change to refer SchemaFor#genTraitObjectEnum method.
https://github.com/sksamuel/avro4s/blob/master/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala#L205-L220


#### exception log

``` 

java.lang.NullPointerException: null of union in field category of example.app
	at org.apache.avro.generic.GenericDatumWriter.npe(GenericDatumWriter.java:145)
	at org.apache.avro.generic.GenericDatumWriter.writeWithoutConversion(GenericDatumWriter.java:139)
	at org.apache.avro.generic.GenericDatumWriter.write(GenericDatumWriter.java:75)
	at org.apache.avro.generic.GenericDatumWriter.write(GenericDatumWriter.java:62)
	at org.apache.avro.ipc.generic.GenericRequestor.writeRequest(GenericRequestor.java:85)
	at org.apache.avro.ipc.Requestor$Request.getBytes(Requestor.java:473)
	at org.apache.avro.ipc.Requestor.request(Requestor.java:147)
	at org.apache.avro.ipc.Requestor.request(Requestor.java:101)
	at org.apache.avro.ipc.generic.GenericRequestor.request(GenericRequestor.java:58)
	at example.app.Avro4sMain$.main(ExampleMain.scala:161)
	at example.app.Avro4sMain.main(ExampleMain.scala)
Caused by: java.lang.NullPointerException
	at org.apache.avro.generic.GenericData.getSchemaName(GenericData.java:751)
	at org.apache.avro.generic.GenericData.resolveUnion(GenericData.java:737)
	at org.apache.avro.generic.GenericDatumWriter.resolveUnion(GenericDatumWriter.java:205)
	at org.apache.avro.generic.GenericDatumWriter.writeWithoutConversion(GenericDatumWriter.java:123)
	at org.apache.avro.generic.GenericDatumWriter.write(GenericDatumWriter.java:75)
	at org.apache.avro.generic.GenericDatumWriter.writeField(GenericDatumWriter.java:166)
	at org.apache.avro.generic.GenericDatumWriter.writeRecord(GenericDatumWriter.java:156)
	at org.apache.avro.generic.GenericDatumWriter.writeWithoutConversion(GenericDatumWriter.java:118)
	... 9 more
```

using case class code
```
sealed abstract class Category(value: String)
object Category {

  case object Cate1 extends Category("cate1")
  case object Cate2 extends Category("cate2")
  case object Cate3 extends Category("cate3")

  val values = List(Cate1,Cate2,Cate3)
}

case class Item(
                 category: Option[Category]
               )



lazy val requestor = new GenericRequestor(... )

val to = ToRecord[Item]

val cateNone = Item(None)
val message1: GenericRecord = to(cateNone)
requestor.request("avrosample", message1) // OK


val cateSome = Item(Some(Cate1))
val message2: GenericRecord = to(cateSome)
requestor.request("avrosample", message2) // write in null pointer exception

```


workaround in version 1.8.3 .
make ToValue
```
object Category {
  case object Cate1 extends Category("cate1")
  case object Cate2 extends Category("cate2")
  case object Cate3 extends Category("cate3")

  val values = List(Cate1,Cate2,Cate3)

  // buggy code
  val categorySchema = new ToSchema[Category] {
    import collection.JavaConverters._
    val valueNames = Category.values.map(_.getClass.getSimpleName.replace("$","")).asJava
    val schema = Schema.createEnum("Category", "" , Category.getClass.getPackage.getName , valueNames)
  }

  // need ToRecord call Scope
  implicit val toValue =  new ToValue[Category] {
    override def apply(value: Category): Any = new EnumSymbol(categorySchema(), value.toString)
  }
}
```

Thank you for always useful library.