### PR TITLE
Fix how option default value are handle

### DIFF
--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroOutputStreamTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroOutputStreamTest.scala
@@ -75,6 +75,20 @@ class AvroOutputStreamTest extends WordSpec with Matchers with TimeLimits {
       buffer.get(bytes)
       BigDecimal(BigInt(bytes), 2) shouldBe BigDecimal(123.45)
     }
+    "write big decimal with default value" in {
+      case class Test(dec: BigDecimal = BigDecimal(1234.56))
+
+      val output = new ByteArrayOutputStream
+      val avro = AvroOutputStream.data[Test](output)
+      avro.write(Test())
+      avro.close()
+
+      val record = read[Test](output)
+      val buffer = record.get("dec").asInstanceOf[ByteBuffer]
+      val bytes = Array.ofDim[Byte](buffer.remaining())
+      buffer.get(bytes)
+      BigDecimal(BigInt(bytes), 2) shouldBe BigDecimal(1234.56)
+    }
     "write out strings" in {
       case class Test(str: String)
 
@@ -168,6 +182,34 @@ class AvroOutputStreamTest extends WordSpec with Matchers with TimeLimits {
 
       val record2 = read[EitherCaseClasses](output2)
       record2.get("e").toString shouldBe """{"dec": {"bytes": """" + """\""" + """u0005°"}}"""
+    }
+    "write a Some as populated union with BigDecimal logical type" in {
+      case class Test(opt: Option[BigDecimal])
+
+      val output = new ByteArrayOutputStream
+      val avro = AvroOutputStream.data[Test](output)
+      avro.write(Test(Some(123.45)))
+      avro.close()
+
+      val record = read[Test](output)
+      val buffer = record.get("opt").asInstanceOf[ByteBuffer]
+      val bytes = Array.ofDim[Byte](buffer.remaining())
+      buffer.get(bytes)
+      BigDecimal(BigInt(bytes), 2) shouldBe BigDecimal(123.45)
+    }
+    "write a Some as populated union with BigDecimal logical type with default value" in {
+      case class Test(opt: Option[BigDecimal]= Some(1234.56))
+
+      val output = new ByteArrayOutputStream
+      val avro = AvroOutputStream.data[Test](output)
+      avro.write(Test())
+      avro.close()
+
+      val record = read[Test](output)
+      val buffer = record.get("opt").asInstanceOf[ByteBuffer]
+      val bytes = Array.ofDim[Byte](buffer.remaining())
+      buffer.get(bytes)
+      BigDecimal(BigInt(bytes), 2) shouldBe BigDecimal(1234.56)
     }
     "write a Some as populated union" in {
       case class Test(opt: Option[Double])

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
@@ -9,7 +9,7 @@ import shapeless.ops.coproduct.Reify
 import shapeless.ops.hlist.ToList
 import shapeless.{:+:, CNil, Coproduct, Generic, HList, Lazy}
 
-import scala.annotation.implicitNotFound
+import scala.annotation.{implicitNotFound, tailrec}
 import scala.collection.JavaConverters._
 import scala.language.experimental.macros
 import scala.math.BigDecimal.RoundingMode.{RoundingMode, UNNECESSARY}
@@ -493,6 +493,7 @@ object SchemaFor {
                            default: Any,
                            parentNamespace: String): Schema.Field = {
 
+    @tailrec
     def toDefaultValue(value: Any): Any = value match {
       case x: Int => x
       case x: Long => x
@@ -500,7 +501,7 @@ object SchemaFor {
       case x: Double => x
       case x: Seq[_] => x.asJava
       case x: Map[_, _] => x.asJava
-      case Some(x) => x
+      case Some(x) => toDefaultValue(x)
       case None => JsonProperties.NULL_VALUE
       case _ => value.toString
     }


### PR DESCRIPTION
When trying to create a schema for a `union` type like:

```avro
record test {
  union { null, decimal(9,2) } dec = 222.22;
}
```
```scala
case class Test(opt: Option[BigDecimal] = Some(1234.56))
```
The following exception happens:
```
[info] [info] A case class with `logicalType` fields and default values from .avdl should
[info] [error]   ! deserialize correctly
[info] [error]    org.apache.avro.AvroRuntimeException: Unknown datum class: class scala.math.BigDecimal (JacksonUtils.java:87)
[info] [error] org.apache.avro.util.internal.JacksonUtils.toJson(JacksonUtils.java:87)
[info] [error] org.apache.avro.util.internal.JacksonUtils.toJsonNode(JacksonUtils.java:48)
[info] [error] org.apache.avro.Schema$Field.<init>(Schema.java:423)
[info] [error] org.apache.avro.Schema$Field.<init>(Schema.java:415)
[info] [error] com.sksamuel.avro4s.SchemaFor$.fieldBuilder(SchemaFor.scala:519)
[info] [error] com.sksamuel.avro4s.SchemaFor$.fieldBuilder(SchemaFor.scala:487)
[info] [error] StandardPrimitivesSpec$$anon$13$$anon$33.$anonfun$x$7$1(StandardPrimitivesSpec.scala:76)
[info] [error] shapeless.Lazy$$anon$1.value$lzycompute(lazy.scala:123)
[info] [error] shapeless.Lazy$$anon$1.value(lazy.scala:123)
[info] [error] shapeless.Lazy.$anonfun$map$1(lazy.scala:116)
[info] [error] shapeless.Lazy$$anon$1.value$lzycompute(lazy.scala:123)
[info] [error] shapeless.Lazy$$anon$1.value(lazy.scala:123)
[info] [error] StandardPrimitivesSpec$$anon$13$$anon$33.apply(StandardPrimitivesSpec.scala:76)
[info] [error] StandardPrimitivesSpec$$anon$13.apply(StandardPrimitivesSpec.scala:76)
[info] [error] StandardPrimitivesSpec$$anon$13.apply(StandardPrimitivesSpec.scala:76)
[info] [error] com.sksamuel.avro4s.RecordFormat$$anon$1.to(RecordFormat.scala:13)
[info] [error] StandardPrimitivesSpec.$anonfun$new$14(StandardPrimitivesSpec.scala:77)
```

The problem here is that `BigDecimal` scala type inside an `Option` are not properly handle in [`toDefaultValue`](https://github.com/sksamuel/avro4s/blob/9bb584b10e83428dc1d6e4255a39dc906895c29c/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala#L503) method, leaving `BigDecimal` types as `scala.math.BigDecimal` for avro java library, instead of `String` type, as it is applied for every non primitve type in `case _ => value.toString`.
```scala
    def toDefaultValue(value: Any): Any = value match {
      // ... other cases
      case Some(x) => x
      case None => JsonProperties.NULL_VALUE
      case _ => value.toString
    }
```
Looking at code history, I think the bug was introduced in #77, when `toDefaultValue` was refactor, removing the recursive call for types inside `Some`.

This PR fix this bug making the function tail recursive for `Some` default values, adding more tests as well.
```scala
    @tailrec
    def toDefaultValue(value: Any): Any = value match {
      // ... other cases
      case Some(x) => toDefaultValue(x)
      case None => JsonProperties.NULL_VALUE
      case _ => value.toString
    }
```

Please, feel free to comment or suggest any changes or question you may have.