### PR TITLE
Support Scala Object Namespaces per default

### DIFF
--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
@@ -179,7 +179,7 @@ object FromValue extends LowPriorityFromValue {
     val from = implicitly[FromValue[T]]
 
     def typeName: String = {
-      val nearestPackage = Stream.iterate(tpe.typeSymbol.owner)(_.owner).dropWhile(!_.isPackage).head
+      val nearestPackage = Stream.iterate(tpe.typeSymbol.owner)(_.owner).dropWhile(x => !x.isPackage && !x.isModuleClass).head
       s"${nearestPackage.fullName}.${tpe.typeSymbol.name.decodedName}"
     }
 

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
@@ -358,7 +358,11 @@ object SchemaFor {
     val name = underlyingType.typeSymbol.name.decodedName.toString + genericNameSuffix(underlyingType)
 
     // the default namespace is just the package name
-    val defaultNamespace = Stream.iterate(underlyingType.typeSymbol.owner)(_.owner).dropWhile(!_.isPackage).head.fullName
+    val defaultNamespace = Stream
+      .iterate(underlyingType.typeSymbol.owner)(_.owner)
+      .dropWhile(x => !x.isPackage && !x.isModuleClass)
+      .head
+      .fullName
 
     // we read all annotations into quasi-quotable Anno dtos
     val annos = annotations(underlyingType.typeSymbol)


### PR DESCRIPTION
Given something like 
```Scala
    case class Outer(inner: Outer.Inner)
    object Outer {
      final case class Inner(s: String)
    }
```
I think users expect the resulting Avro Schema to be something like:
 ```Javascript
{
  "type" : "record",
  "name" : "Outer",
  "namespace" : "com.sksamuel.avro4s",
  "fields" : [ {
    "name" : "inner",
    "type" : {
      "type" : "record",
      "namespace" : "com.sksamuel.avro4s.AvroSchemaTest.Outer",
      "name" : "Inner",
      "fields" : [ {
        "name" : "s",
        "type" : "string"
      } ]
    }
  } ]
}
```
Otherwise this would quickly lead to name clashes at Avro side while the Scala side remains fine. We ran into this while using a hand packaged version of avro4s which fully supports nested ADTs for Scala 2.12.

Of course, this patch is not very useful until the [patches](https://github.com/sksamuel/avro4s/compare/master...2chilled:avro_namespace_fix) for ADT support are merged into master. I suspect the requirement for this to happen is 2.11 support. Nevertheless, I think this improves Avro namespacing and prevents our fork from diverging too much.