### PR TITLE
Fix #215: make ToRecord macro obey AvroName annotation

### DIFF
--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroNameTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/AvroNameTest.scala
@@ -13,4 +13,11 @@ class AvroNameTest extends WordSpec with Matchers {
       schema.toString(true) shouldBe expected.toString(true)
     }
   }
+
+  "ToRecord" should {
+    "correctly be able to produce a record" in {
+      val toRecord = ToRecord[Foo]
+      toRecord(Foo("woop", "scoop"))
+    }
+  }
 }

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/ToRecord.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/ToRecord.scala
@@ -205,7 +205,7 @@ object ToRecord {
       case ((sym, sig), idx) =>
 
         val name = sym.name.asInstanceOf[c.TermName]
-        val fieldName: String = name.decodedName.toString
+        val fieldName = helper.avroName(sym).getOrElse(q"${name.decodedName.toString}")
         val valueClass = sig.typeSymbol.isClass && sig.typeSymbol.asClass.isDerivedValueClass
         val typeFixed = helper.fixed(sig.typeSymbol)
         val fieldFixed = helper.fixed(sym)

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/TypeHelper.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/TypeHelper.scala
@@ -47,6 +47,16 @@ class TypeHelper[C <: whitebox.Context](val c: C) {
         case Literal(Constant(size: Int)) :: Nil => AvroFixed(size)
       }
   }
+
+  def avroName(sym: c.Symbol): Option[Tree] =
+    sym
+      .annotations
+      .find(_.tree.tpe == typeOf[AvroName])
+      .map(_.tree).map {
+        case Apply(Select(New(_), _), List(name)) => name
+        case _ =>
+          c.abort(c.enclosingPosition, "Unexpected macro application")
+      }
 }
 
 object TypeHelper {


### PR DESCRIPTION
This PR fixes the serialization issues we had with `@AvroName`

@sksamuel -- would it be possible for you to make a release with this fix once merged?