### PR TITLE
Respect avroname in sealed case object enums

### DIFF
--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/SealedTraitSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/SealedTraitSchemaTest.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.avro4s.schema
 
-import com.sksamuel.avro4s.AvroSchema
+import com.sksamuel.avro4s.{AvroSchema, AvroName}
 import org.scalatest.{FunSuite, Matchers}
 
 class SealedTraitSchemaTest extends FunSuite with Matchers {
@@ -37,7 +37,8 @@ class SealedTraitSchemaTest extends FunSuite with Matchers {
 }
 
 sealed trait Dibble
-case object Dobble extends Dibble
+@AvroName("Dobble")
+case object Dobbles extends Dibble
 case object Dabble extends Dibble
 
 sealed trait Wibble

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/Decoder.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/Decoder.scala
@@ -299,7 +299,7 @@ object Decoder extends CoproductDecoders with TupleDecoders {
     private def getTypeName[T](clazz: Class[T]): String = {
       val mirror = runtimeMirror(clazz.getClassLoader)
       val tpe = mirror.classSymbol(clazz).toType
-      AvroNameResolver.forClass(tpe).asInstanceOf[String]
+      AvroNameResolver.forClass(tpe).toString
     }
 
   }

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/Decoder.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/Decoder.scala
@@ -289,8 +289,19 @@ object Decoder extends CoproductDecoders with TupleDecoders {
                                                                      toList: ToList[L, T]): Decoder[T] = new Decoder[T] {
     override def decode(value: Any, schema: Schema): T = {
       val name = value.toString
-      toList(objs()).find(_.toString == name).getOrElse(sys.error(s"Uknown type $name"))
+      val variants = toList(objs())
+      variants.find(v => {
+        println(getTypeName(v.getClass))
+        getTypeName(v.getClass) == name
+      }).getOrElse(sys.error(s"Unknown type $name"))
     }
+
+    private def getTypeName[T](clazz: Class[T]): String = {
+      val mirror = runtimeMirror(clazz.getClassLoader)
+      val tpe = mirror.classSymbol(clazz).toType
+      AvroNameResolver.forClass(tpe).asInstanceOf[String]
+    }
+
   }
 
   implicit def applyMacro[T <: Product]: Decoder[T] = macro applyMacroImpl[T]

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/Decoder.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/Decoder.scala
@@ -291,7 +291,6 @@ object Decoder extends CoproductDecoders with TupleDecoders {
       val name = value.toString
       val variants = toList(objs())
       variants.find(v => {
-        println(getTypeName(v.getClass))
         getTypeName(v.getClass) == name
       }).getOrElse(sys.error(s"Unknown type $name"))
     }

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
@@ -221,7 +221,13 @@ object SchemaFor extends TupleSchemaFor with CoproductSchemaFor {
     val packageName = ct.runtimeClass.getPackage.getName
     val namespace = extractor.namespace.getOrElse(packageName)
     val name = extractor.name.getOrElse(ct.runtimeClass.getSimpleName)
-    val symbols = toList(objs()).map(_.toString)
+    val symbols = toList(objs()).map(v => symbolName(v.getClass))
+
+    private def symbolName[T](clazz: Class[T]): String = {
+      val mirror = runtimeMirror(clazz.getClassLoader)
+      val tpe = mirror.classSymbol(clazz).toType
+      AvroNameResolver.forClass(tpe).toString
+    }
 
     override def schema: Schema = SchemaBuilder.enumeration(name).namespace(namespace).symbols(symbols: _*)
   }


### PR DESCRIPTION
I noticed that `@AvroName` is not respected in enum branches for `case object` style enums. I've added a few test cases and got them passing but I don't know if the solution I've come up with is the best one. Please let me know if there are changes I should make.