### PR TITLE
Decode UUIDs from org.apache.avro.utl.Utf8

### DIFF
--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/UUIDDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/UUIDDecoderTest.scala
@@ -5,6 +5,8 @@ import java.util.UUID
 import com.sksamuel.avro4s.AvroSchema
 import com.sksamuel.avro4s.Decoder
 import org.apache.avro.generic.GenericData
+import org.apache.avro.generic.GenericData
+import org.apache.avro.util.{Utf8}
 import org.scalatest.{Matchers, WordSpec}
 
 class UUIDDecoderTest extends WordSpec with Matchers {
@@ -17,6 +19,13 @@ class UUIDDecoderTest extends WordSpec with Matchers {
       val schema = AvroSchema[UUIDTest]
       val record = new GenericData.Record(schema)
       record.put("uuid", uuid.toString)
+      Decoder[UUIDTest].decode(record, schema) shouldBe UUIDTest(uuid)
+    }
+    "decode UUIDSs encoded as Utf8" in {
+      val uuid = UUID.randomUUID()
+      val schema = AvroSchema[UUIDTest]
+      val record = new GenericData.Record(schema)
+      record.put("uuid", new Utf8(uuid.toString))
       Decoder[UUIDTest].decode(record, schema) shouldBe UUIDTest(uuid)
     }
     "decode seq of uuids" in {

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/Decoder.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/Decoder.scala
@@ -174,6 +174,7 @@ object Decoder extends CoproductDecoders with TupleDecoders {
     override def decode(value: Any, schema: Schema): UUID = {
       value match {
         case s: String => UUID.fromString(s)
+        case u: Utf8 => UUID.fromString(u.toString)
         case bytebuf: ByteBuffer => UUID.fromString(new String(bytebuf.array))
         case a: Array[Byte] => UUID.fromString(new String(a))
         case null => sys.error("Cannot decode <null> as a UUID")


### PR DESCRIPTION
Another small PR. Noticed that there's no branch to handle `Utf8` when decoding `UUID`s so added a test and implementation.