### PR TITLE
WIP: Fix Inconsistency in namespace calculation between `Encoder` and `SchemaFor`

### DIFF
--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/SealedTraitEncoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/SealedTraitEncoderTest.scala
@@ -54,6 +54,18 @@ class SealedTraitEncoderTest extends FunSuite with Matchers {
     Encoder[Dibble].encode(Dobble, schema) shouldBe new GenericData.EnumSymbol(schema, Dobble)
     Encoder[Dibble].encode(Dabble, schema) shouldBe new GenericData.EnumSymbol(schema, Dabble)
   }
+
+  test("classes nested in objects should be encoded with consistent package name") {
+    sealed trait Inner
+    case class InnerOne(value: Double) extends Inner
+    case class InnerTwo(height: Double) extends Inner
+    case class Outer(inner: Inner)
+    val schema = AvroSchema[Outer]
+    val record = Encoder[Outer].encode(Outer(InnerOne(1.23)), schema).asInstanceOf[GenericRecord]
+    val inner = record.get("inner").asInstanceOf[GenericRecord]
+    inner.get("value") shouldBe 1.23
+  }
+
 }
 
 sealed trait Dibble

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
@@ -255,6 +255,7 @@ object SchemaFor extends TupleSchemaFor with CoproductSchemaFor {
 
       val isValueClass = reflect.isValueClass(tpe)
       val recordName = reflect.recordName(tpe)
+      val defaultNamespace = fullName.split('.').dropRight(1).mkString(".")
 
       val fields = reflect
         .constructorParameters(tpe)
@@ -281,9 +282,9 @@ object SchemaFor extends TupleSchemaFor with CoproductSchemaFor {
           // if the default getter exists then we can use it to generate the default value
           if (defaultGetterMethod.isMethod) {
             val moduleSym = tpe.typeSymbol.companion
-            q"""{ _root_.com.sksamuel.avro4s.SchemaFor.schemaFieldWithDefault[$fieldTpe]($fieldName, $packageName, Seq(..$annos), $moduleSym.$defaultGetterMethod) }"""
+            q"""{ _root_.com.sksamuel.avro4s.SchemaFor.schemaFieldWithDefault[$fieldTpe]($fieldName, $defaultNamespace, Seq(..$annos), $moduleSym.$defaultGetterMethod) }"""
           } else {
-            q"""{ _root_.com.sksamuel.avro4s.SchemaFor.schemaFieldNoDefault[$fieldTpe]($fieldName, $packageName, Seq(..$annos)) }"""
+            q"""{ _root_.com.sksamuel.avro4s.SchemaFor.schemaFieldNoDefault[$fieldTpe]($fieldName, $defaultNamespace, Seq(..$annos)) }"""
           }
         }
 
@@ -293,7 +294,7 @@ object SchemaFor extends TupleSchemaFor with CoproductSchemaFor {
       c.Expr[SchemaFor[T]](
         q"""
         new _root_.com.sksamuel.avro4s.SchemaFor[$tpe] {
-          private val _schema = _root_.com.sksamuel.avro4s.SchemaFor.buildSchema($recordName, $packageName, Seq(..$fields), Seq(..$annos), $isValueClass)
+          private val _schema = _root_.com.sksamuel.avro4s.SchemaFor.buildSchema($recordName, $defaultNamespace, Seq(..$fields), Seq(..$annos), $isValueClass)
           override def schema: _root_.org.apache.avro.Schema = _schema
         }
       """)


### PR DESCRIPTION
There appears to be an inconsistency in the way that namespaces are calculated for case classes that are defined inside an object between `SchemaFor[T]` and `Encoder[T]`. This merge request contains a test case that reproduces it. Specifically the inconsistency is below:

`Encoder.applyMacroImpl`
```scala
  def applyMacroImpl[T: c.WeakTypeTag](c: scala.reflect.macros.whitebox.Context): c.Expr[Encoder[T]] = {

    import c.universe._

    val reflect = ReflectHelper(c)
    val tpe = weakTypeTag[T].tpe
    val fullName = tpe.typeSymbol.fullName
    ...
          } else {
        c.Expr[Encoder[T]](
          q"""
            new _root_.com.sksamuel.avro4s.Encoder[$tpe] {
              override def encode(t: $tpe, schema: org.apache.avro.Schema): AnyRef = {
                _root_.com.sksamuel.avro4s.Encoder.buildRecord(schema, Seq(..$fields), $fullName)
              }
            }
        """
        )
```

And 

`SchemaFor.applyMacroImpl`
```scala
  def applyMacroImpl[T: c.WeakTypeTag](c: whitebox.Context): c.Expr[SchemaFor[T]] = {
    import c.universe
    import c.universe._

    val reflect = ReflectHelper(c)
    val tpe = weakTypeOf[T]
    val fullName = tpe.typeSymbol.fullName
    val packageName = reflect.packageName(tpe)
    ...
          // if the default getter exists then we can use it to generate the default value
          if (defaultGetterMethod.isMethod) {
            val moduleSym = tpe.typeSymbol.companion
            q"""{ _root_.com.sksamuel.avro4s.SchemaFor.schemaFieldWithDefault[$fieldTpe]($fieldName, $packageName, Seq(..$annos), $moduleSym.$defaultGetterMethod) }"""
          } else {
            q"""{ _root_.com.sksamuel.avro4s.SchemaFor.schemaFieldNoDefault[$fieldTpe]($fieldName, $packageName, Seq(..$annos)) }"""
          }
        }
```

You can see that in `Encoder` the `TermSymbol.fullName` is used whereas in `SchemaFor` `ReflectHelper.packageName` is used. `ReflectHelper.packageName` returns (unsurprisingly) the package name - i.e not including the surrounding object that a case class nested in an object contains in it's full name.

This means that for example the following code

```
package mypackage 

object Outer {
    case class MyRecord(value: Double)
    val schema = SchemaFor[MyRecord]
}
```

would produce a schema with the namespace of `MyRecord` being set to `mypackage`, but when attempting to encode `Encoder[MyRecord]` would be looking for a record with namespace `mypackage.Outer`. (This only manifests in sealed trait unions I think because otherwise there is no reason for `Encoder` to look up the record).

I've included a possible fix in this merge request. There are a lot of failing tests because this change changes a lot of namespaces. Before I went ahead and fixed all those tests I thought it would be worth asking whether it's actually desirable to have the namespace include the surrounding object? Would it be better to issue a warning of some kind?