### PR TITLE
Respect AvroName when generating and encoding enum symbols 

### DIFF
--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/AvroNameEncoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/AvroNameEncoderTest.scala
@@ -23,6 +23,12 @@ class AvroNameEncoderTest extends FunSuite with Matchers {
     val contents = abox.get("contents").asInstanceOf[GenericRecord]
     contents.get("length") shouldBe 1.23
   }
+
+  test("encoding sealed traits of case objects should take into account AvroName") {
+    val schema = AvroSchema[Ship]
+    val record = Encoder[Ship].encode(Ship(Atlantic), schema).asInstanceOf[GenericRecord]
+    record.get("location").toString shouldBe "atlantic"
+  }
 }
 
 @AvroNamespace("storage.boxes")
@@ -36,5 +42,12 @@ case class Cucumber(length: Double) extends Food
 @AvroNamespace("storage.boxes")
 @AvroName("blackberry")
 case class Blackberry(colour: String) extends Food
+
+sealed trait Ocean
+@AvroName("atlantic")
+case object Atlantic extends Ocean
+@AvroName("pacific")
+case object Pacific extends Ocean
+case class Ship(location: Ocean)
 
 

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/Encoder.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/Encoder.scala
@@ -55,16 +55,15 @@ object Encoder extends CoproductEncoders with TupleEncoders {
 
     protected val schema: Schema = {
       val tpe = weakTypeTag[T]
-      val namespace = tpe.tpe.typeSymbol.annotations.map(_.toString)
-        .find(_.startsWith("com.sksamuel.avro4s.AvroNamespace"))
-        .map(_.stripPrefix("com.sksamuel.avro4s.AvroNamespace(\"").stripSuffix("\")"))
-        .getOrElse(ct.runtimeClass.getPackage.getName)
-      val name = ct.runtimeClass.getSimpleName
-      val symbols = toList(objs()).map(_.toString).asJava
-      Schema.createEnum(name, null, namespace, symbols)
+      val nr = NameResolution(tpe.tpe)
+      val symbols = toList(objs()).map(v => NameResolution(v.getClass).name).asJava
+      Schema.createEnum(nr.name, null, nr.namespace, symbols)
     }
 
-    override def encode(value: T, schema: Schema): EnumSymbol = new EnumSymbol(schema, value.toString)
+    override def encode(value: T, schema: Schema): EnumSymbol = new EnumSymbol(
+      schema,
+      NameResolution(value.getClass).name
+    )
   }
 
   implicit object StringEncoder extends Encoder[String] {

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/NameResolution.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/NameResolution.scala
@@ -71,4 +71,10 @@ object NameResolution {
     ReflectHelper.defaultNamespace(tpe.typeSymbol),
     ReflectHelper.annotations(tpe.typeSymbol)
   )
+
+  def apply[A](clazz: Class[A]): NameResolution = {
+    val mirror = universe.runtimeMirror(clazz.getClassLoader)
+    val tpe = mirror.classSymbol(clazz).toType
+    NameResolution(tpe)
+  }
 }


### PR DESCRIPTION
Respect AvroName when generating and encoding enum symbols for sealed trait case object hierarchies