### PR TITLE
Diverging implicit expansion for sealed case class

### DIFF
--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/SealedTraitDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/SealedTraitDecoderTest.scala
@@ -75,6 +75,10 @@ class SealedTraitDecoderTest extends FunSuite with Matchers {
     Decoder[ThingHolder].decode(record1, schema) shouldBe ThingHolder(WhimWham)
     Decoder[ThingHolder].decode(record2, schema) shouldBe ThingHolder(Widget)
   }
+
+  test("sealed trait classes with optional elements inside case classes should derive withou implicit divergence") {
+    val d = Decoder[Coat]
+  }
 }
 
 sealed trait Wibble
@@ -111,3 +115,8 @@ sealed trait Thingy
 case object WhimWham extends Thingy
 @AvroName("widget")
 case object Widget extends Thingy
+
+case class Coat(liner: CoatLiner)
+sealed trait CoatLiner
+case class WoolenLiner(thickness: Double, colour: Option[String]) extends CoatLiner
+case class CottonLiner(washable: Boolean) extends CoatLiner

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/SealedTraitEncoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/SealedTraitEncoderTest.scala
@@ -62,14 +62,13 @@ class SealedTraitEncoderTest extends FunSuite with Matchers {
     width.get("width") shouldBe 1.23
   }
 
-  test("sealed trait classes with optional elements inside case classes should be encoded correctly") {
+  test("sealed trait classes with optional elements inside case classes should derive without divergence") {
     case class Outer(inner: Inner)
     sealed trait Inner
     case class InnerOne(value: Double, optVal: Option[Float]) extends Inner
     case class InnerTwo(height: Double) extends Inner
     val e = Encoder[Outer]
     val schema = AvroSchema[Outer]
-    val record = Encoder[Outer].encode(Outer(InnerOne(1.23, None)), schema).asInstanceOf[GenericRecord]
   }
 
   test("classes nested in objects should be encoded correctly") {

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/SealedTraitEncoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/SealedTraitEncoderTest.scala
@@ -67,6 +67,7 @@ class SealedTraitEncoderTest extends FunSuite with Matchers {
     sealed trait Inner
     case class InnerOne(value: Double, optVal: Option[Float]) extends Inner
     case class InnerTwo(height: Double) extends Inner
+    val e = Encoder[Outer]
     val schema = AvroSchema[Outer]
     val record = Encoder[Outer].encode(Outer(InnerOne(1.23, None)), schema).asInstanceOf[GenericRecord]
   }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/SealedTraitEncoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/SealedTraitEncoderTest.scala
@@ -62,6 +62,15 @@ class SealedTraitEncoderTest extends FunSuite with Matchers {
     width.get("width") shouldBe 1.23
   }
 
+  test("sealed trait classes with optional elements inside case classes should be encoded correctly") {
+    case class Outer(inner: Inner)
+    sealed trait Inner
+    case class InnerOne(value: Double, optVal: Option[Float]) extends Inner
+    case class InnerTwo(height: Double) extends Inner
+    val schema = AvroSchema[Outer]
+    val record = Encoder[Outer].encode(Outer(InnerOne(1.23, None)), schema).asInstanceOf[GenericRecord]
+  }
+
   test("classes nested in objects should be encoded correctly") {
     sealed trait Inner
     case class InnerOne(value: Double) extends Inner

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/Encoder.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/Encoder.scala
@@ -12,7 +12,7 @@ import org.apache.avro.util.Utf8
 import org.apache.avro.{Conversions, LogicalTypes, Schema}
 import shapeless.ops.coproduct.Reify
 import shapeless.ops.hlist.ToList
-import shapeless.{Coproduct, Generic, HList}
+import shapeless.{Coproduct, Generic, HList, Lazy}
 
 import scala.language.experimental.macros
 import scala.math.BigDecimal.RoundingMode
@@ -370,18 +370,18 @@ object Encoder extends CoproductEncoders with TupleEncoders {
     *
     */
   def encodeField[T](t: T, fieldName: String, schema: Schema, fullName: String)
-                    (implicit encoder: Encoder[T]): AnyRef = {
+                    (implicit encoder: Lazy[Encoder[T]]): AnyRef = {
     schema.getType match {
       case Schema.Type.UNION =>
         val subschema = SchemaHelper.extractTraitSubschema(fullName, schema)
         val field = subschema.getField(fieldName)
-        encoder.encode(t, field.schema)
+        encoder.value.encode(t, field.schema)
       case Schema.Type.RECORD =>
         val field = schema.getField(fieldName)
-        encoder.encode(t, field.schema)
+        encoder.value.encode(t, field.schema)
       // otherwise we are encoding a simple field
       case _ =>
-        encoder.encode(t, schema)
+        encoder.value.encode(t, schema)
     }
   }
 


### PR DESCRIPTION
I can't figure out what's causing this so haven't got a fix yet, but this is a testcase for something that's biting me at the moment. Causes errors like this:

```
[error] <base dir>/avro4s/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/SealedTraitEncoderTest.scala:70: diverging implicit expansion for type com.sksamuel.avro4s.SchemaFor[Outer]
[error] starting with macro method applyMacro in object SchemaFor
[error]     val schema = AvroSchema[Outer]
```