### PR TITLE
fix Option TraitObjectEnum not serializing

### DIFF
--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/ToRecord.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/ToRecord.scala
@@ -174,9 +174,10 @@ object ToValue extends LowPriorityToValue {
     }
   }
 
-  implicit def genTraitObjectEnum[T, C <: Coproduct](implicit gen: Generic.Aux[T, C],
+  implicit def genTraitObjectEnum[T, C <: Coproduct](implicit toSchema: ToSchema[T],
+                                                     gen: Generic.Aux[T, C],
                                                      objs: Reify[C]): ToValue[T] = new ToValue[T] {
-    override def apply(value: T): Any = new EnumSymbol(null, value.toString)
+    override def apply(value: T): Any = new EnumSymbol(toSchema(), value.toString)
   }
 }
 


### PR DESCRIPTION
Hey there !
This might be a bit of a long shot.. 
When the fix for `Option[ Enum ]` made it in to version `1.8.3`, it was not applied to `TraitObjectEnum`.
I have a project that makes extensive use of trait object enums and is not ready to migrate to 1.9+

Is it possible to sneak this PR in as a minor release fix?  
I realize that you are probably no longer supporting this version.. 
but you can always ask :)

Thanks!