### PR TITLE
Issue 243 - AvroProps Annotation

### DIFF
--- a/avro4s-core/src/test/resources/multi_props_annotation_field.avsc
+++ b/avro4s-core/src/test/resources/multi_props_annotation_field.avsc
@@ -1,0 +1,22 @@
+{
+  "type": "record",
+  "name": "MultipleAnnotations",
+  "namespace": "com.sksamuel.avro4s.schema.AvroPropSchemaTest",
+  "fields": [
+    {
+      "name": "str",
+      "type": "string",
+      "cold": "play",
+      "kate": "bush",
+      "led": "zeppelin"
+    },
+    {
+      "name": "long",
+      "type": "long"
+    },
+    {
+      "name": "int",
+      "type": "int"
+    }
+  ]
+}

--- a/avro4s-core/src/test/resources/multi_props_annotation_field.avsc
+++ b/avro4s-core/src/test/resources/multi_props_annotation_field.avsc
@@ -8,7 +8,7 @@
       "type": "string",
       "cold": "play",
       "kate": "bush",
-      "led": "zeppelin"
+      "great": "true"
     },
     {
       "name": "long",

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/AvroPropSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/AvroPropSchemaTest.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.avro4s.schema
 
-import com.sksamuel.avro4s.{AvroProp, AvroSchema}
+import com.sksamuel.avro4s.{AvroProp, AvroProps, AvroSchema}
 import org.scalatest.{Matchers, WordSpec}
 
 class AvroPropSchemaTest extends WordSpec with Matchers {
@@ -17,6 +17,13 @@ class AvroPropSchemaTest extends WordSpec with Matchers {
       val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/props_annotation_field.avsc"))
       val schema = AvroSchema[Annotated]
       schema.toString(true) shouldBe expected.toString(true)
+    }
+    "should support multiple annotations" in {
+      case class MultipleAnnotations(@AvroProps(Map("cold" -> "play", "kate" -> "bush")) @AvroProp("led", "zeppelin") str: String, long: Long, int:Int)
+      val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/multi_props_annotation_field.avsc"))
+      val schema = AvroSchema[MultipleAnnotations]
+      schema.toString(true) shouldBe expected.toString(true)
+
     }
   }
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/AvroPropSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/AvroPropSchemaTest.scala
@@ -19,7 +19,7 @@ class AvroPropSchemaTest extends WordSpec with Matchers {
       schema.toString(true) shouldBe expected.toString(true)
     }
     "should support multiple annotations" in {
-      case class MultipleAnnotations(@AvroProps(Map("cold" -> "play", "kate" -> "bush")) @AvroProp("led", "zeppelin") str: String, long: Long, int:Int)
+      case class MultipleAnnotations(@AvroProps(Map("cold" -> "play", "kate" -> "bush")) @AvroProp("great", "true") str: String, long: Long, int:Int)
       val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/multi_props_annotation_field.avsc"))
       val schema = AvroSchema[MultipleAnnotations]
       schema.toString(true) shouldBe expected.toString(true)

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/AnnotationExtractors.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/AnnotationExtractors.scala
@@ -1,5 +1,7 @@
 package com.sksamuel.avro4s
 
+import scala.util.matching.Regex
+
 case class Anno(className: String, args: Map[String,String])
 
 class AnnotationExtractors(annos: Seq[Anno]) {
@@ -19,9 +21,27 @@ class AnnotationExtractors(annos: Seq[Anno]) {
 
   def name: Option[String] = findFirst("name",classOf[AvroNameable])
 
-  def props: Map[String, String] = annos.filter(c => classOf[AvroProperty].isAssignableFrom(Class.forName(c.className))).map { anno =>
-    anno.args("key").toString -> anno.args("value").toString
-  }.toMap
+  def props: Map[String, String] = annos.filter(c => classOf[AvroProperty].isAssignableFrom(Class.forName(c.className))).flatMap(x => stringToMap(x.args("properties"))).toMap
+
+  private def stringToMap(string: String): Map[String,String] = {
+    //Get the map elements
+    AnnotationExtractors.betweenParentheses.findFirstIn(string)
+      //Drop the surrounding ()
+      .map(_.drop(1).dropRight(1)) match {
+      case Some(mapElements) =>
+        //Get list of tuples (ie a -> b)
+        mapElements.split(", ").toList
+          //Break make into tuples and convert into map
+        .flatMap(_.split(AnnotationExtractors.arrowsNotInQuotes)).grouped(2).collect { case a :: b :: Nil => (a,b) }.toMap
+      case None => Map.empty
+    }
+  }
+
 
   def erased: Boolean = exists(classOf[AvroErasedName])
+}
+
+object AnnotationExtractors {
+  private val betweenParentheses: Regex = "\\(([^\\)]+)\\)".r
+  private val arrowsNotInQuotes: String = "\\s(?!\\B\"[^\"]*)->(?![^\"]*\"\\B)\\s"
 }

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/ReflectHelper.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/ReflectHelper.scala
@@ -1,10 +1,13 @@
 package com.sksamuel.avro4s
 
+import org.codehaus.jackson.map.ObjectMapper
+
 import scala.reflect.internal.{Definitions, StdNames, SymbolTable}
 import scala.reflect.macros.whitebox
 import scala.reflect.runtime.universe
 import scala.reflect.runtime.currentMirror
 import scala.tools.reflect.ToolBox
+import collection.JavaConverters._
 
 class ReflectHelper[C <: whitebox.Context](val c: C) {
   import c.universe
@@ -144,6 +147,13 @@ class ReflectHelper[C <: whitebox.Context](val c: C) {
     val tb = currentMirror.mkToolBox()
 
     val args = tb.compile(tb.parse(a.toString)).apply() match {
+      case c: AvroProperty => c.getAllFields.map { case (k, v) =>
+        if (k.equals("properties"))
+        //Needs to be converted to Java due to the fact the jackson serializes other properties then just the information found in the map
+          (k, new ObjectMapper().writeValueAsString(v.asInstanceOf[Map[String,String]].asJava))
+        else
+          (k, v.toString)
+      }
       case c: AvroFieldReflection => c.getAllFields.map{case (k,v) => (k,v.toString)}
       case _ => Map.empty[String, String]
     }
@@ -155,6 +165,13 @@ class ReflectHelper[C <: whitebox.Context](val c: C) {
     val tb = currentMirror.mkToolBox()
 
     val args = tb.compile(tb.parse(a.toString)).apply() match {
+      case c: AvroProperty => c.getAllFields.map { case (k, v) =>
+        if (k.equals("properties"))
+        //Needs to be converted to Java due to the fact the jackson serializes other properties then just the information found in the map
+          (k, new ObjectMapper().writeValueAsString(v.asInstanceOf[Map[String,String]].asJava))
+        else
+          (k, v.toString)
+      }
       case c: AvroFieldReflection => c.getAllFields.map{case (k,v) => (k,v.toString)}
       case _ => Map.empty[String, String]
     }
@@ -183,6 +200,13 @@ object ReflectHelper {
     val name = a.tree.tpe.typeSymbol.fullName
     val tb = currentMirror.mkToolBox()
     val args = tb.compile(tb.parse(a.toString)).apply() match {
+      case c: AvroProperty => c.getAllFields.map { case (k, v) =>
+        if (k.equals("properties"))
+          //Needs to be converted to Java due to the fact the jackson serializes other properties then just the information found in the map
+          (k, new ObjectMapper().writeValueAsString(v.asInstanceOf[Map[String,String]].asJava))
+        else
+          (k, v.toString)
+      }
       case c: AvroFieldReflection => c.getAllFields.map{case (k,v) => (k,v.toString)}
       case _ => Map.empty[String, String]
     }

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/annotations.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/annotations.scala
@@ -76,11 +76,14 @@ trait AvroNamespaceable extends AvroFieldReflection {
   val namespace: String
 }
 
-case class AvroProp(override val key: String, override val value:String) extends AvroProperty
+case class AvroProp(key: String, value:String) extends AvroProperty {
+  override val properties: Map[String, String] = Map(key -> value)
+}
+
+case class AvroProps(override val properties: Map[String,String]) extends AvroProperty
 
 trait AvroProperty extends AvroFieldReflection{
-  val key: String
-  val value: String
+  val properties: Map[String,String]
 }
 
 
@@ -111,5 +114,5 @@ sealed trait AvroFieldReflection extends StaticAnnotation {
     fields
   }
 
-  def getAllFields = getClassFields(this.getClass)
+  def getAllFieldsz:Map[String,Any] = getClassFields(this.getClass)
 }

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/annotations.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/annotations.scala
@@ -114,5 +114,5 @@ sealed trait AvroFieldReflection extends StaticAnnotation {
     fields
   }
 
-  def getAllFieldsz:Map[String,Any] = getClassFields(this.getClass)
+  def getAllFields:Map[String,Any] = getClassFields(this.getClass)
 }


### PR DESCRIPTION
Added AvroProps annotation and made AvroProp a specialized version of the base trait (while maintaining backwards compatibility). Since Map[String,Any] was not allowed from the compiler in Anno I had to serialize and deserialize the properties field when creating the Anno case class. I initially did it manually but thought of a number of edge cases, so instead I opted to using the jackson library already present in the Avro library to do this work. Since I didn't think it prudent to add more dependencies I opted with using the base java version and covering some of the inconsistencies when it comes to (de)serializing. If this becomes common practice in the future to have annotations with more complicated property types then "String" adding the module for jackson scala should likely be revisited as I'm sure the more complicated types will result in more weirdness. In lew of this I added comments to show why some of the odd bits of code are present. Let me know if you think there is a better way of going about this issue. Thanks!