### PR TITLE
Improve encode performance

### DIFF
--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaHelper.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaHelper.scala
@@ -9,11 +9,21 @@ object SchemaHelper {
   import scala.collection.JavaConverters._
 
   def extractTraitSubschema(fullName: String, schema: Schema): Schema = {
-    import scala.collection.JavaConverters._
     require(schema.getType == Schema.Type.UNION, s"Can only extract subschemas from a UNION but was given $schema")
-    schema.getTypes.asScala
-      .find(_.getFullName == fullName)
-      .getOrElse(sys.error(s"Cannot find subschema for type name $fullName in ${schema.getTypes}"))
+
+    val types = schema.getTypes
+    val size = types.size
+
+    var i = 0
+    while(i < size && types.get(i).getFullName != fullName) {
+      i = i + 1
+    }
+
+    if (i == size) {
+      sys.error(s"Cannot find subschema for type name $fullName in ${schema.getTypes}")
+    } else {
+      types.get(i)
+    }
   }
 
   /**

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaHelper.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaHelper.scala
@@ -14,6 +14,11 @@ object SchemaHelper {
     val types = schema.getTypes
     val size = types.size
 
+    require(size > 0, s"Cannot extract subschema from empty UNION $schema")
+
+    // Finds the matching schema and keeps track a null type if any.
+    // If no matching schema is found in a union of size 2 the other type is returned, regardless of its name.
+    // See https://github.com/sksamuel/avro4s/issues/268
     var result: Schema = null
     var nullIndex: Int = -1
     var i = 0
@@ -29,9 +34,9 @@ object SchemaHelper {
 
     } while (i < size && result == null)
 
-    if (result != null) {
+    if (result != null) { // Return the name based match
       result
-    } else if (nullIndex != -1 && size == 2) {
+    } else if (nullIndex != -1 && size == 2) { // Return the non null type.
       types.get(i - nullIndex)
     } else {
       sys.error(s"Cannot find subschema for type name $fullName in ${schema.getTypes}")


### PR DESCRIPTION
Some changes to improve encoder performance. This gives a 10 to 30 percent speedup in my benchmark cases. I suspect larger schemas will see a bigger improvement.

Reuse generated field encoders in the record macro (same way as the decoder performance pr i made)
Microoptimized SchemaHelper.extractTraitSubschema. This is called for each encoded field and popped out in yourkit. The code is not very idomatic scala anymore.

Benchmark results:
```
2.0.3:

[info] Benchmark                                                  Mode  Cnt     Score    Error   Units
[info] EncodeBench.measureEncodeCaseClass                        thrpt    5  2015.377 ±  5.290  ops/ms
[info] EncodeBench.measureEncodeCaseClassWithCaseClassCoproduct  thrpt    5  1769.699 ± 15.953  ops/ms
[info] EncodeBench.measureEncodeCaseClassWithCoproduct           thrpt    5  2408.834 ± 23.742  ops/ms

Master (small degradation on coproduct tests after https://github.com/sksamuel/avro4s/issues/268)

[info] Benchmark                                                  Mode  Cnt     Score    Error   Units
[info] EncodeBench.measureEncodeCaseClass                        thrpt    5  2127.535 ± 20.784  ops/ms
[info] EncodeBench.measureEncodeCaseClassWithCaseClassCoproduct  thrpt    5  1663.093 ± 15.223  ops/ms
[info] EncodeBench.measureEncodeCaseClassWithCoproduct           thrpt    5  2379.223 ± 32.377  ops/ms

PR:

[info] Benchmark                                                  Mode  Cnt     Score     Error   Units
[info] EncodeBench.measureEncodeCaseClass                        thrpt    5  2813.113 ±  52.937  ops/ms
[info] EncodeBench.measureEncodeCaseClassWithCaseClassCoproduct  thrpt    5  2477.972 ±  22.984  ops/ms
[info] EncodeBench.measureEncodeCaseClassWithCoproduct           thrpt    5  2654.938 ± 130.230  ops/ms

```