### PR TITLE
Fix tuple encoders

### DIFF
--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/TupleEncoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/TupleEncoderTest.scala
@@ -8,18 +8,18 @@ import org.scalatest.{FunSuite, Matchers}
 class TupleEncoderTest extends FunSuite with Matchers {
 
   test("encode tuple2") {
-    case class Test(z: (String, Int))
+    case class Test(z: (String, Option[Int]))
     val schema = AvroSchema[Test]
-    val record = Encoder[Test].encode(Test("hello", 55), schema).asInstanceOf[GenericRecord]
+    val record = Encoder[Test].encode(Test("hello", Some(55)), schema).asInstanceOf[GenericRecord]
     val z = record.get("z").asInstanceOf[GenericRecord]
     z.get("_1") shouldBe new Utf8("hello")
     z.get("_2") shouldBe 55
   }
 
   test("encode tuple3") {
-    case class Test(z: (String, Int, Long))
+    case class Test(z: (String, Option[Int], Long))
     val schema = AvroSchema[Test]
-    val record = Encoder[Test].encode(Test("hello", 55, 9999999L), schema).asInstanceOf[GenericRecord]
+    val record = Encoder[Test].encode(Test("hello", Some(55), 9999999L), schema).asInstanceOf[GenericRecord]
     val z = record.get("z").asInstanceOf[GenericRecord]
     z.get("_1") shouldBe new Utf8("hello")
     z.get("_2") shouldBe 55
@@ -27,9 +27,9 @@ class TupleEncoderTest extends FunSuite with Matchers {
   }
 
   test("encode tuple4") {
-    case class Test(z: (String, Int, Boolean, Double))
+    case class Test(z: (String, Option[Int], Boolean, Double))
     val schema = AvroSchema[Test]
-    val record = Encoder[Test].encode(Test("hello", 55, true, 0.24), schema).asInstanceOf[GenericRecord]
+    val record = Encoder[Test].encode(Test("hello", Some(55), true, 0.24), schema).asInstanceOf[GenericRecord]
     val z = record.get("z").asInstanceOf[GenericRecord]
     z.get("_1") shouldBe new Utf8("hello")
     z.get("_2") shouldBe 55
@@ -38,9 +38,9 @@ class TupleEncoderTest extends FunSuite with Matchers {
   }
 
   test("encode tuple5") {
-    case class Test(z: (String, Int, String, Boolean, String))
+    case class Test(z: (String, Option[Int], String, Boolean, String))
     val schema = AvroSchema[Test]
-    val record = Encoder[Test].encode(Test("a", 55, "b", true, "c"), schema).asInstanceOf[GenericRecord]
+    val record = Encoder[Test].encode(Test("a", Some(55), "b", true, "c"), schema).asInstanceOf[GenericRecord]
     val z = record.get("z").asInstanceOf[GenericRecord]
     z.get("_1") shouldBe new Utf8("a")
     z.get("_2") shouldBe 55

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/TupleEncoders.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/TupleEncoders.scala
@@ -6,25 +6,51 @@ trait TupleEncoders {
 
   implicit def tuple2Encoder[A, B](implicit encA: Encoder[A], encB: Encoder[B]) = new Encoder[(A, B)] {
     override def encode(t: (A, B), schema: Schema): AnyRef = {
-      ImmutableRecord(schema, Vector(encA.encode(t._1, schema), encB.encode(t._2, schema)))
+      ImmutableRecord(
+        schema,
+        Vector(
+          encA.encode(t._1, schema.getField("_1").schema()),
+          encB.encode(t._2, schema.getField("_2").schema()))
+      )
     }
   }
 
   implicit def tuple3Encoder[A, B, C](implicit encA: Encoder[A], encB: Encoder[B], encC: Encoder[C]) = new Encoder[(A, B, C)] {
     override def encode(t: (A, B, C), schema: Schema): AnyRef = {
-      ImmutableRecord(schema, Vector(encA.encode(t._1, schema), encB.encode(t._2, schema), encC.encode(t._3, schema)))
+      ImmutableRecord(
+        schema,
+        Vector(
+          encA.encode(t._1, schema.getField("_1").schema()),
+          encB.encode(t._2, schema.getField("_2").schema()),
+          encC.encode(t._3, schema.getField("_3").schema()))
+      )
     }
   }
 
   implicit def tuple4Encoder[A, B, C, D](implicit encA: Encoder[A], encB: Encoder[B], encC: Encoder[C], encD: Encoder[D]) = new Encoder[(A, B, C, D)] {
     override def encode(t: (A, B, C, D), schema: Schema): AnyRef = {
-      ImmutableRecord(schema, Vector(encA.encode(t._1, schema), encB.encode(t._2, schema), encC.encode(t._3, schema), encD.encode(t._4, schema)))
+      ImmutableRecord(
+        schema,
+        Vector(
+          encA.encode(t._1, schema.getField("_1").schema()),
+          encB.encode(t._2, schema.getField("_2").schema()),
+          encC.encode(t._3, schema.getField("_3").schema()),
+          encD.encode(t._4, schema.getField("_4").schema()))
+      )
     }
   }
 
   implicit def tuple5Encoder[A, B, C, D, E](implicit encA: Encoder[A], encB: Encoder[B], encC: Encoder[C], encD: Encoder[D], encE: Encoder[E]) = new Encoder[(A, B, C, D, E)] {
     override def encode(t: (A, B, C, D, E), schema: Schema): AnyRef = {
-      ImmutableRecord(schema, Vector(encA.encode(t._1, schema), encB.encode(t._2, schema), encC.encode(t._3, schema), encD.encode(t._4, schema), encE.encode(t._5, schema)))
+      ImmutableRecord(
+        schema,
+        Vector(
+          encA.encode(t._1, schema.getField("_1").schema()),
+          encB.encode(t._2, schema.getField("_2").schema()),
+          encC.encode(t._3, schema.getField("_3").schema()),
+          encD.encode(t._4, schema.getField("_4").schema()),
+          encE.encode(t._5, schema.getField("_5").schema()))
+      )
     }
   }
 }


### PR DESCRIPTION
Tuple encoders pass common tuple schema to tuple members encoders, it's
ok when members are primitive types because their encoders don't use
schema to encode value, String fallbacks to Utf8. For example if we use
Option as member of tuple it requires UNION schema to encode but gets RECORD.

To fix this every member of tuple should take only it's part of schema.