### PR TITLE
Fix bigdecimal encoder and decoder

### DIFF
--- a/avro4s-core/src/test/resources/bigdecimal-scale-and-precision.json
+++ b/avro4s-core/src/test/resources/bigdecimal-scale-and-precision.json
@@ -1,0 +1,16 @@
+{
+  "type": "record",
+  "name": "Test",
+  "namespace": "com.sksamuel.avro4s.schema.BigDecimalSchemaTest",
+  "fields": [
+    {
+      "name": "decimal",
+      "type": {
+        "type": "bytes",
+        "logicalType": "decimal",
+        "precision": 20,
+        "scale": 8
+      }
+    }
+  ]
+}

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/BigDecimalDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/BigDecimalDecoderTest.scala
@@ -25,5 +25,9 @@ class BigDecimalDecoderTest extends FlatSpec with Matchers {
     val record = new GenericData.Record(schema)
     record.put("big", bytes)
     Decoder[OptionalBigDecimal].decode(record, schema) shouldBe OptionalBigDecimal(Option(BigDecimal(123.45)))
+
+    val emptyRecord = new GenericData.Record(schema)
+    emptyRecord.put("big", null)
+    Decoder[OptionalBigDecimal].decode(emptyRecord, schema) shouldBe OptionalBigDecimal(None)
   }
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/CoproductDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/CoproductDecoderTest.scala
@@ -23,6 +23,15 @@ class CoproductDecoderTest extends FunSuite with Matchers {
     record.put("u", gimble)
     Decoder[CPWrapper].decode(record, schema) shouldBe CPWrapper(Coproduct[CPWrapper.ISBG](Gimble("foo")))
   }
+
+  test("coproducts with options") {
+    val schema = AvroSchema[CPWithOption]
+    val gimble = new GenericData.Record(AvroSchema[Gimble])
+    gimble.put("x", new Utf8("foo"))
+    val record = new GenericData.Record(schema)
+    record.put("u", gimble)
+    Decoder[CPWithOption].decode(record, schema) shouldBe CPWithOption(Some(Coproduct[CPWrapper.ISBG](Gimble("foo"))))
+  }
 }
 
 case class CPWithArray(u: CPWrapper.SSI)

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/EnumDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/EnumDecoderTest.scala
@@ -24,9 +24,10 @@ class EnumDecoderTest extends WordSpec with Matchers {
     }
     "support optional java enums" in {
       val schema = AvroSchema[JavaOptionEnumClass]
+      val wineSchema = AvroSchema[Wine]
 
       val record1 = new GenericData.Record(schema)
-      record1.put("wine", new EnumSymbol(schema.getField("wine").schema(), "Merlot"))
+      record1.put("wine", new EnumSymbol(wineSchema, "Merlot"))
       Decoder[JavaOptionEnumClass].decode(record1, schema) shouldBe JavaOptionEnumClass(Some(Wine.Merlot))
 
       val record2 = new GenericData.Record(schema)
@@ -41,9 +42,10 @@ class EnumDecoderTest extends WordSpec with Matchers {
     }
     "support optional scala enums" in {
       val schema = AvroSchema[ScalaOptionEnumClass]
+      val colourSchema = AvroSchema[Colours.Value]
 
       val record1 = new GenericData.Record(schema)
-      record1.put("colour", new EnumSymbol(schema.getField("colour").schema(), "Amber"))
+      record1.put("colour", new EnumSymbol(colourSchema, "Amber"))
       Decoder[ScalaOptionEnumClass].decode(record1, schema) shouldBe ScalaOptionEnumClass(Some(Colours.Amber))
 
       val record2 = new GenericData.Record(schema)

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/FixedDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/FixedDecoderTest.scala
@@ -20,7 +20,7 @@ class FixedDecoderTest extends FunSuite with Matchers {
   test("support options of fixed") {
     val schema = AvroSchema[OptionalFixedValueType]
     val record = new GenericData.Record(schema)
-    record.put("z", Array[Byte](115, 97, 109))
+    record.put("z", new GenericData.Fixed(AvroSchema[FixedValueType], Array[Byte](115, 97, 109)))
     Decoder[OptionalFixedValueType].decode(record, schema) shouldBe OptionalFixedValueType(Some(FixedValueType("sam")))
   }
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/StructDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/StructDecoderTest.scala
@@ -5,6 +5,7 @@ import com.sksamuel.avro4s.Decoder
 import org.apache.avro.generic.GenericData
 import org.scalatest.{Matchers, WordSpec}
 
+case class OptionCounty(county: Option[County])
 case class County(name: String, towns: Seq[Town], ceremonial: Boolean, lat: Double, long: Double)
 case class Town(name: String, population: Int)
 
@@ -36,6 +37,39 @@ class StructDecoderTest extends WordSpec with Matchers {
       bucks.put("long", 0.123)
 
       Decoder[County].decode(bucks, countySchema) shouldBe obj
+    }
+
+    "decode optional structs" in {
+      val countySchema = AvroSchema[County]
+      val townSchema = AvroSchema[Town]
+      val optionCountySchema = AvroSchema[OptionCounty]
+
+      val obj = OptionCounty(Some(County("Bucks", Seq(Town("Hardwick", 123), Town("Weedon", 225)), true, 12.34, 0.123)))
+
+      val hardwick = new GenericData.Record(townSchema)
+      hardwick.put("name", "Hardwick")
+      hardwick.put("population", 123)
+
+      val weedon = new GenericData.Record(townSchema)
+      weedon.put("name", "Weedon")
+      weedon.put("population", 225)
+
+      val bucks = new GenericData.Record(countySchema)
+      bucks.put("name", "Bucks")
+      bucks.put("towns", List(hardwick, weedon).asJava)
+      bucks.put("ceremonial", true)
+      bucks.put("lat", 12.34)
+      bucks.put("long", 0.123)
+
+      val record = new GenericData.Record(optionCountySchema)
+      record.put("county", bucks)
+
+      Decoder[OptionCounty].decode(record, optionCountySchema) shouldBe obj
+
+      val emptyRecord = new GenericData.Record(optionCountySchema)
+      emptyRecord.put("county", null)
+
+      Decoder[OptionCounty].decode(emptyRecord, optionCountySchema) shouldBe OptionCounty(None)
     }
   }
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/BigDecimalSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/BigDecimalSchemaTest.scala
@@ -1,8 +1,10 @@
 package com.sksamuel.avro4s.schema
 
-import com.sksamuel.avro4s.{AvroSchema, SchemaFor}
+import com.sksamuel.avro4s.{AvroSchema, ScalePrecisionRoundingMode, SchemaFor}
 import org.apache.avro.{Schema, SchemaBuilder}
 import org.scalatest.{Matchers, WordSpec}
+
+import scala.math.BigDecimal.RoundingMode
 
 case class BigDecimalSeqOption(biggies: Seq[Option[BigDecimal]])
 case class BigDecimalSeq(biggies: Seq[BigDecimal])
@@ -15,6 +17,13 @@ class BigDecimalSchemaTest extends WordSpec with Matchers {
       case class Test(decimal: BigDecimal)
       val schema = AvroSchema[Test]
       val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/bigdecimal.json"))
+      schema shouldBe expected
+    }
+    "accept big decimal as logical type on bytes with custom scale and precision" in {
+      implicit val sp = ScalePrecisionRoundingMode(8, 20 , RoundingMode.HALF_UP)
+      case class Test(decimal: BigDecimal)
+      val schema = AvroSchema[Test]
+      val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/bigdecimal-scale-and-precision.json"))
       schema shouldBe expected
     }
     "support big decimal with default" in {

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/Encoder.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/Encoder.scala
@@ -15,7 +15,6 @@ import shapeless.ops.hlist.ToList
 import shapeless.{Coproduct, Generic, HList, Lazy}
 
 import scala.language.experimental.macros
-import scala.math.BigDecimal.RoundingMode
 import scala.reflect.ClassTag
 
 /**
@@ -206,13 +205,11 @@ object Encoder extends CoproductEncoders with TupleEncoders {
     import scala.collection.JavaConverters._
 
     override def encode(t: Option[T], schema: Schema): AnyRef = {
-      val nonNullSchema = schema.getTypes.size match {
-        // if the option is none we just return null, otherwise we encode the value
-        // by finding the non null schema
-        case 2 => schema.getTypes.asScala.find(_.getType != Schema.Type.NULL).get
-        case _ =>
-          val remainingSchemas = schema.getTypes.asScala.filter(_.getType != Schema.Type.NULL)
-          Schema.createUnion(remainingSchemas.toList.asJava)
+      // if the option is none we just return null, otherwise we encode the value
+      // by finding the non null schema
+      val nonNullSchema = schema.getTypes.asScala.filter(_.getType != Schema.Type.NULL).toList match {
+        case s :: Nil => s
+        case multipleSchemas => Schema.createUnion(multipleSchemas.asJava)
       }
       t.map(encoder.encode(_, nonNullSchema)).orNull
     }
@@ -225,30 +222,23 @@ object Encoder extends CoproductEncoders with TupleEncoders {
     }
   }
 
-  implicit object BigDecimalEncoder extends Encoder[BigDecimal] {
+  private val decimalConversion = new Conversions.DecimalConversion
 
-    override def encode(t: BigDecimal, schema: Schema): AnyRef = {
+  implicit def bigDecimalEncoder(implicit sp: ScalePrecisionRoundingMode = ScalePrecisionRoundingMode.default): Encoder[BigDecimal] =
+    (t: BigDecimal, schema: Schema) => {
 
       // we support encoding big decimals in three ways - fixed, bytes or as a String
       schema.getType match {
         case Schema.Type.STRING => StringEncoder.encode(t.toString, schema)
-        case Schema.Type.BYTES => ByteBufferEncoder.comap[BigDecimal] { _ =>
-
+        case Schema.Type.BYTES => ByteBufferEncoder.comap[BigDecimal] { value =>
           val decimal = schema.getLogicalType.asInstanceOf[Decimal]
-          require(decimal != null)
-
-          val decimalConversion = new Conversions.DecimalConversion
-          val decimalType = LogicalTypes.decimal(decimal.getPrecision, decimal.getScale)
-
-          val scaledValue = t.setScale(decimal.getScale, RoundingMode.HALF_UP)
-          decimalConversion.toBytes(scaledValue.bigDecimal, null, decimalType)
-
+          val scaledValue = value.setScale(decimal.getScale, sp.roundingMode)
+          decimalConversion.toBytes(scaledValue.bigDecimal, schema, decimal)
         }.encode(t, schema)
-        case Schema.Type.FIXED => sys.error("Unsupported. PR Please!")
+        case Schema.Type.FIXED => sys.error("Unsupported. PR Please!") // TODO decimalConversion.toFixed
         case _ => sys.error(s"Cannot serialize BigDecimal as ${schema.getType}")
       }
     }
-  }
 
   implicit def javaEnumEncoder[E <: Enum[_]]: Encoder[E] = new Encoder[E] {
     override def encode(t: E, schema: Schema): EnumSymbol = new EnumSymbol(schema, t.name)


### PR DESCRIPTION
Work in progress, happy to take feedback. In the process of fixing the bigdecimal en/decoders I uncovered a couple of issues in the decoders for `String`, `Option` and most collections. I hope the fixes are acceptable.

I am also looking at allowing `BigDecimal` -> `FIXED` in the decoder & encoder unless you feel this should be a separate PR.
