### PR TITLE
Fix SchemaFor when either have nested union types

### DIFF
--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/EitherSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/EitherSchemaTest.scala
@@ -30,5 +30,8 @@ class EitherSchemaTest extends WordSpec with Matchers {
       val schema = AvroSchema[Test]
       schema.toString(true) shouldBe expected.toString(true)
     }
+    "flatten nested unions and move null to first position" in {
+      AvroSchema[Either[String, Option[Int]]].toString shouldBe """["null","string","int"]"""
+    }
   }
 }

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
@@ -89,7 +89,7 @@ object SchemaFor extends TupleSchemaFor with CoproductSchemaFor {
 
   implicit def eitherSchemaFor[A, B](implicit leftFor: SchemaFor[A], rightFor: SchemaFor[B]): SchemaFor[Either[A, B]] = {
     new SchemaFor[Either[A, B]] {
-      override def schema: Schema = Schema.createUnion(leftFor.schema, rightFor.schema)
+      override def schema: Schema = SchemaHelper.createSafeUnion(leftFor.schema, rightFor.schema)
     }
   }
 


### PR DESCRIPTION
```
AvroSchema[Either[String, Option[Int]]]
org.apache.avro.AvroRuntimeException: Nested union: ["string",["null","int"]]
  at org.apache.avro.Schema$UnionSchema.<init>(Schema.java:849)
  at org.apache.avro.Schema.createUnion(Schema.java:189)
  at org.apache.avro.Schema.createUnion(Schema.java:194)
  at com.sksamuel.avro4s.SchemaFor$$anon$5.schema(SchemaFor.scala:92)
  at com.sksamuel.avro4s.AvroSchema$.apply(AvroSchema.scala:21)
```