### PR TITLE
Issue 303 - Fix AvroMergeSchema

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroSchemaMerge.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroSchemaMerge.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.avro4s
 
-import org.apache.avro.Schema
+import org.apache.avro.{JsonProperties, Schema}
 import org.apache.avro.Schema.Field
 
 object AvroSchemaMerge {
@@ -14,16 +14,34 @@ object AvroSchemaMerge {
 
     val fields = schemas.flatMap(_.getFields.asScala).groupBy(_.name).map { case (name, fields) =>
 
-        val doc = fields.flatMap(x => Option(x.doc)).mkString("; ")
-        val default = fields.find(_.defaultVal != null).map(_.defaultVal).orNull
+      val doc = fields.flatMap(x => Option(x.doc)).mkString("; ")
+      val default = fields.find(_.defaultVal != null).map(_.defaultVal).orNull
 
-        // if we have two schemas with the same type, then just keep the first one
-        val union = {
-          val schemas = fields.map(_.schema).groupBy(_.getType).map(_._2.head).toList.sortBy(_.getName) :+ Schema.create(Schema.Type.NULL)
-          Schema.createUnion(schemas.asJava)
-        }
+      // if we have two schemas with the same type, then just keep the first one
+      val union = {
+        val schemas = fields
+          .map(_.schema)
+          .flatMap(schema => schema.getType match {
+            case Schema.Type.UNION => schema.getTypes.asScala
+            case _ => Seq(schema)
+          })
+          .filter(_.getType != Schema.Type.NULL)
+          .groupBy(_.getType)
+          .map(_._2.head)
+          .toList
+          .sortBy(_.getName)
 
-        new Field(name, union, if (doc.isEmpty) null else doc, default)
+        // if default value was not specified or equal to JsonProperties.NULL_VALUE then null schema should be the first in union
+        Schema.createUnion({
+          if (default == null || default == JsonProperties.NULL_VALUE) {
+            (Schema.create(Schema.Type.NULL) :: schemas).asJava
+          } else {
+            (schemas :+ Schema.create(Schema.Type.NULL)).asJava
+          }
+        })
+      }
+
+      new Field(name, union, if (doc.isEmpty) null else doc, default)
     }
 
     val schema = Schema.createRecord(name, if (doc.isEmpty) null else doc, namespace, false)

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/AvroSchemaMergeTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/AvroSchemaMergeTest.scala
@@ -1,0 +1,37 @@
+package com.sksamuel.avro4s.schema
+
+import com.sksamuel.avro4s.AvroSchemaMerge
+import org.apache.avro.SchemaBuilder
+import org.scalatest.{Matchers, WordSpec}
+
+class AvroSchemaMergeTest extends WordSpec with Matchers {
+  "AvroSchemaMerge" should {
+    "merge schemas with union type" in {
+      val schemaOne = SchemaBuilder
+        .builder("test")
+        .record("s1")
+        .fields()
+        .requiredString("f1")
+        .nullableLong("f2", 0)
+        .endRecord()
+
+      val schemaTwo = SchemaBuilder
+        .builder("test")
+        .record("s2")
+        .fields()
+        .optionalString("f1")
+        .requiredLong("f2")
+        .endRecord()
+
+      val expected = SchemaBuilder
+        .builder("test")
+        .record("s3")
+        .fields()
+        .optionalString("f1")
+        .nullableLong("f2", 0)
+        .endRecord()
+
+      AvroSchemaMerge.apply("s3", "test", List(schemaOne, schemaTwo)).toString shouldBe expected.toString
+    }
+  }
+}


### PR DESCRIPTION
This PR should fix this issue: https://github.com/sksamuel/avro4s/issues/303
Also, i tried to fix this: in some cases if there is no default value, null schema was last in union, but as avro specification says it is better to put null schema as first schema in union (https://avro.apache.org/docs/1.8.2/spec.html#Unions).
