### PR TITLE
Fixed various instance deriving problems relating to recursive types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ credentials.sbt
 *.iml
 
 universe.avro
+
+# metals specific
+.metals
+.bloop

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/Github273.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/Github273.scala
@@ -1,0 +1,36 @@
+package com.sksamuel.avro4s.github
+
+import com.sksamuel.avro4s.{Decoder, Encoder, RecordFormat, SchemaFor}
+import org.apache.avro.generic.GenericRecord
+import org.scalatest.{FunSuite}
+import shapeless.{:+:, CNil}
+
+object Github273 extends FunSuite {
+
+  case class Coproducts(cp: Int :+: String :+: Boolean :+: CNil)
+  case class CoproductOfCoproductsField(cp: Coproducts :+: Boolean :+: CNil)
+
+  sealed trait SealedTraitOfSealedTrait
+
+  object SealedTraitOfSealedTrait {
+    final case class X(x: SealedTrait)
+      extends SealedTraitOfSealedTrait
+
+    sealed trait SealedTrait
+
+    object SealedTrait {
+      final case class Y(x: Int)
+        extends SealedTrait
+    }
+  }
+
+  implicitly[SchemaFor[Coproducts]]
+  implicitly[SchemaFor[CoproductOfCoproductsField]]
+  implicitly[SchemaFor[SealedTraitOfSealedTrait]]
+  implicitly[Encoder[Coproducts]]
+  implicitly[Encoder[CoproductOfCoproductsField]]
+  implicitly[Encoder[SealedTraitOfSealedTrait]]
+  implicitly[Decoder[Coproducts]]
+  implicitly[Decoder[CoproductOfCoproductsField]]
+  implicitly[Decoder[SealedTraitOfSealedTrait]]
+}

--- a/project/GlobalPlugin.scala
+++ b/project/GlobalPlugin.scala
@@ -1,7 +1,7 @@
-import com.typesafe.sbt.SbtPgp
 import com.typesafe.sbt.pgp.PgpKeys
-import sbt.Keys._
+import com.typesafe.sbt.SbtPgp
 import sbt._
+import sbt.Keys._
 import sbtrelease.ReleasePlugin
 
 /** Adds common settings automatically to all subprojects */
@@ -12,7 +12,7 @@ object GlobalPlugin extends AutoPlugin {
     val AvroVersion = "1.8.2"
     val Log4jVersion = "1.2.17"
     val ScalatestVersion = "3.0.7"
-    val ScalaVersion = "2.12.7"
+    val ScalaVersion = "2.12.8"
     val Slf4jVersion = "1.7.26"
     val Json4sVersion = "3.6.5"
     val CatsVersion = "1.6.0"
@@ -26,7 +26,7 @@ object GlobalPlugin extends AutoPlugin {
   override def projectSettings = publishingSettings ++ Seq(
     organization := org,
     scalaVersion := ScalaVersion,
-    crossScalaVersions := Seq("2.12.7", "2.11.12", "2.13.0-M5"),
+    crossScalaVersions := Seq(ScalaVersion, "2.11.12", "2.13.0-M5"),
     resolvers += Resolver.mavenLocal,
     parallelExecution in Test := false,
     scalacOptions := Seq(


### PR DESCRIPTION
This should fix at least #273. I guess the motivation for deciding for or against `shapeless.Lazy` was implicit resolution performance improvements. I did not benchmark it seriously, but I think it's still fast enough with `shapeless.Lazy` as default. 

@sksamuel can you guess how long it takes to build a bugfix release from this?