### PR TITLE
Use optional decoder to read non optional fields

### DIFF
--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/OptionDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/OptionDecoderTest.scala
@@ -7,12 +7,24 @@ import org.scalatest.{Matchers, WordSpec}
 
 case class OptionBoolean(b: Option[Boolean])
 case class OptionString(s: Option[String])
+case class RequiredString(s: String)
 
 class OptionDecoderTest extends WordSpec with Matchers {
 
   "Decoder" should {
     "support String options" in {
       val schema = AvroSchema[OptionString]
+
+      val record1 = new GenericData.Record(schema)
+      record1.put("s", "hello")
+      Decoder[OptionString].decode(record1, schema) shouldBe OptionString(Some("hello"))
+
+      val record2 = new GenericData.Record(schema)
+      record2.put("s", null)
+      Decoder[OptionString].decode(record2, schema) shouldBe OptionString(None)
+    }
+    "support decoding required fields as Option" in {
+      val schema = AvroSchema[RequiredString]
 
       val record1 = new GenericData.Record(schema)
       record1.put("s", "hello")

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/OptionDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/OptionDecoderTest.scala
@@ -24,15 +24,11 @@ class OptionDecoderTest extends WordSpec with Matchers {
       Decoder[OptionString].decode(record2, schema) shouldBe OptionString(None)
     }
     "support decoding required fields as Option" in {
-      val schema = AvroSchema[RequiredString]
+      val requiredStringSchema = AvroSchema[RequiredString]
 
-      val record1 = new GenericData.Record(schema)
-      record1.put("s", "hello")
-      Decoder[OptionString].decode(record1, schema) shouldBe OptionString(Some("hello"))
-
-      val record2 = new GenericData.Record(schema)
-      record2.put("s", null)
-      Decoder[OptionString].decode(record2, schema) shouldBe OptionString(None)
+      val requiredStringRecord = new GenericData.Record(requiredStringSchema)
+      requiredStringRecord.put("s", "hello")
+      Decoder[OptionString].decode(requiredStringRecord, requiredStringSchema) shouldBe OptionString(Some("hello"))
     }
     "support boolean options" in {
       val schema = AvroSchema[OptionBoolean]

--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/Decoder.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/Decoder.scala
@@ -188,7 +188,12 @@ object Decoder extends CoproductDecoders with TupleDecoders {
   implicit def optionDecoder[T](implicit decoder: Decoder[T]) = new Decoder[Option[T]] {
     override def decode(value: Any, schema: Schema): Option[T] = if (value == null) None else {
       // Options are Union schemas of ["null", other], the decoder may require the other schema
-      val nonNullSchema = schema.getTypes.asScala.filter(_.getType != Schema.Type.NULL).toList match {
+      val schemas = if (schema.getType == Schema.Type.UNION) {
+        schema.getTypes.asScala.toList
+      } else {
+        List(schema)
+      }
+      val nonNullSchema = schemas.filter(_.getType != Schema.Type.NULL) match {
         case s :: Nil => s
         case multipleSchemas => Schema.createUnion(multipleSchemas.asJava)
       }


### PR DESCRIPTION
I want to be able read fields that declared as non-optional in Avro schema utilizing `optionDecoder`.
This is common case in my project when I migrate older model to the new one where certain fields become optional.
With this change I could read "legacy" records into the new schema where certain fields are now optional.
The problem with existing implementation is that in such case it throws AvroRuntimeException with "Not a union: " message.