### PR TITLE
Add default values for seqs and maps

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/DefaultResolver.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/DefaultResolver.scala
@@ -1,5 +1,6 @@
 package com.sksamuel.avro4s
 
+import scala.collection.JavaConverters._
 import java.nio.ByteBuffer
 import java.util.UUID
 
@@ -35,6 +36,9 @@ object DefaultResolver {
     case x: scala.Int => java.lang.Integer.valueOf(x)
     case x: scala.Double => java.lang.Double.valueOf(x)
     case x: scala.Float => java.lang.Float.valueOf(x)
+    case x: Map[_,_] => new java.util.LinkedHashMap[Any,Any](x.asJava)
+    case x: Seq[_] => new java.util.ArrayList[Any](x.asJava)
     case _ => value.asInstanceOf[AnyRef]
   }
+
 }

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/SchemaHelper.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/SchemaHelper.scala
@@ -3,6 +3,7 @@ package com.sksamuel.avro4s
 import org.apache.avro.{JsonProperties, Schema}
 import org.apache.avro.generic.GenericData
 import org.apache.avro.util.Utf8
+import scala.util.matching.Regex
 
 object SchemaHelper {
 
@@ -28,10 +29,10 @@ object SchemaHelper {
 
     // if we are looking for an array type then find "array" first
     // this is totally not FP but what the heck it's late and it's perfectly valid
-    fullName match {
-      case "scala.collection.immutable.::" =>
-        return types.asScala.find(_.getType == Schema.Type.ARRAY).getOrElse(sys.error(s"Could not find array type to match $fullName"))
-      case _ =>
+    val arrayTypeNamePattern: Regex = "scala.collection.immutable.::(__B)?".r
+    arrayTypeNamePattern.findFirstMatchIn(fullName) match {
+      case Some(_) => return types.asScala.find(_.getType == Schema.Type.ARRAY).getOrElse(sys.error(s"Could not find array type to match $fullName")) 
+      case None => 
     }
 
     // Finds the matching schema and keeps track a null type if any.

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/CoproductEncoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/CoproductEncoderTest.scala
@@ -29,6 +29,7 @@ class CoproductEncoderTest extends FunSuite with Matchers {
 
   test("coproducts with arrays") {
     val schema = AvroSchema[CPWithArray]
+    println(s"$schema")
     Encoder[CPWithArray].encode(CPWithArray(Coproduct[CPWrapper.SSI](Seq("foo", "bar"))), schema) shouldBe ImmutableRecord(schema, Vector(java.util.Arrays.asList(new Utf8("foo"), new Utf8("bar"))))
     Encoder[CPWithArray].encode(CPWithArray(Coproduct[CPWrapper.SSI](4)), schema) shouldBe ImmutableRecord(schema, Vector(java.lang.Integer.valueOf(4)))
   }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/CoproductEncoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/CoproductEncoderTest.scala
@@ -29,7 +29,6 @@ class CoproductEncoderTest extends FunSuite with Matchers {
 
   test("coproducts with arrays") {
     val schema = AvroSchema[CPWithArray]
-    println(s"$schema")
     Encoder[CPWithArray].encode(CPWithArray(Coproduct[CPWrapper.SSI](Seq("foo", "bar"))), schema) shouldBe ImmutableRecord(schema, Vector(java.util.Arrays.asList(new Utf8("foo"), new Utf8("bar"))))
     Encoder[CPWithArray].encode(CPWithArray(Coproduct[CPWrapper.SSI](4)), schema) shouldBe ImmutableRecord(schema, Vector(java.lang.Integer.valueOf(4)))
   }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/DefaultValueSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/DefaultValueSchemaTest.scala
@@ -38,6 +38,11 @@ class DefaultValueSchemaTest extends WordSpec with Matchers {
       val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/default_values_float.json"))
       schema.toString(true) shouldBe expected.toString(true)
     }
+    "support default values for maps and seqs" in {
+      val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/defaultvalues.json"))
+      val schema = AvroSchema[DefaultValues]
+      schema.toString(true) shouldBe expected.toString(true)
+    }
   }
 }
 


### PR DESCRIPTION
I noticed that for some reason the test for default arrays and maps had been omitted. I was running into issues generating schemas with these kind of default values so I've had  a stab at implementing the feature here.

For some reason this broke the `CoproductEncoderTest`. I couldn't figure out exactly what the problem was but making the type name  check slightly more flexible in `SchemaHelper` fixed the test. 