### PR TITLE
Optional unions with default values set to None

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
@@ -218,7 +218,7 @@ object SchemaFor {
     }
 
     // if our default value is null, then we should change the type to be nullable even if we didn't use option
-    val schemaWithPossibleNull = if (default == Some(null)) {
+    val schemaWithPossibleNull = if (default == Some(null) && schema.getType != Schema.Type.UNION) {
       SchemaBuilder.unionOf().`type`(schema).and().`type`(Schema.create(Schema.Type.NULL)).endUnion()
     } else schema
 

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
@@ -206,6 +206,7 @@ object SchemaFor {
     // and set to null, or something else, in which case it's a non null value
     val encodedDefault: AnyRef = default match {
       case None => null
+      case Some(None) => JsonProperties.NULL_VALUE
       case Some(null) => JsonProperties.NULL_VALUE
       case Some(other) => DefaultResolver(other, fieldSchema)
     }
@@ -217,7 +218,7 @@ object SchemaFor {
     }
 
     // if our default value is null, then we should change the type to be nullable even if we didn't use option
-    val schemaWithPossibleNull = if (encodedDefault == JsonProperties.NULL_VALUE) {
+    val schemaWithPossibleNull = if (default == Some(null)) {
       SchemaBuilder.unionOf().`type`(schema).and().`type`(Schema.create(Schema.Type.NULL)).endUnion()
     } else schema
 

--- a/avro4s-core/src/test/resources/default_values_optional_union.json
+++ b/avro4s-core/src/test/resources/default_values_optional_union.json
@@ -1,0 +1,24 @@
+{
+  "type": "record",
+  "name": "DogProspect",
+  "namespace": "com.sksamuel.avro4s.schema",
+  "fields": [
+    {
+      "name": "dog",
+      "type": [
+          "null",
+          {
+              "type": "record",
+              "name": "UpperDog",
+              "fields": [{"name": "how_fortunate", "type": "double"}]
+          },
+          {
+              "type": "record",
+              "name": "UnderDog",
+              "fields": [{"name": "how_unfortunate", "type": "double"}]
+          }
+      ],
+      "default": null
+    }
+  ]
+}

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/DefaultValueSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/DefaultValueSchemaTest.scala
@@ -38,8 +38,20 @@ class DefaultValueSchemaTest extends WordSpec with Matchers {
       val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/default_values_float.json"))
       schema.toString(true) shouldBe expected.toString(true)
     }
+    "support default values for optional sealed trait hierarchies" in {
+      val schema = AvroSchema[DogProspect]
+      val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/default_values_optional_union.json"))
+      schema.toString(true) shouldBe expected.toString(true)
+    }
   }
 }
+
+sealed trait Dog
+case class UpperDog(how_fortunate: Double) extends Dog
+case class UnderDog(how_unfortunate: Double) extends Dog
+
+case class DogProspect(dog: Option[Dog] = None)
+
 
 case class ClassWithDefaultString(s: String = "foo")
 case class ClassWithDefaultInt(i: Int = 123)


### PR DESCRIPTION
I ran into a problem where setting the default value of an `Option` field caused an error. This was because of the way the current behaviour which allows a default value of `null` to generate a union schema was implemented.

I've fixed the behaviour so that setting a default value of `None` renders a `null` in the schema. However, this might not be a complete implementation because I can see an argument that if the default value is set to `None` then reading an older record (i.e one written before the field existed and hence requiring the default value) should return `None`, and I _think_ that at the moment it would read `null`. 