### PR TITLE
Optional unions

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/DefaultResolver.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/DefaultResolver.scala
@@ -36,8 +36,8 @@ object DefaultResolver {
     case x: scala.Int => java.lang.Integer.valueOf(x)
     case x: scala.Double => java.lang.Double.valueOf(x)
     case x: scala.Float => java.lang.Float.valueOf(x)
-    case x: Map[_,_] => new java.util.LinkedHashMap[Any,Any](x.asJava)
-    case x: Seq[_] => new java.util.ArrayList[Any](x.asJava)
+    case x: Map[_,_] => x.asJava
+    case x: Seq[_] => x.asJava
     case _ => value.asInstanceOf[AnyRef]
   }
 

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/SchemaHelper.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/SchemaHelper.scala
@@ -95,6 +95,8 @@ object SchemaHelper {
       case _: Double => Schema.Type.DOUBLE
       case _: Array[Byte] => Schema.Type.BYTES
       case _: GenericData.EnumSymbol => Schema.Type.ENUM
+      case _: java.util.ArrayList[_] => Schema.Type.ARRAY
+      case _: java.util.LinkedHashMap[_,_] => Schema.Type.MAP
       case JsonProperties.NULL_VALUE => Schema.Type.NULL
       case other => other
     }

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/SchemaHelper.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/SchemaHelper.scala
@@ -95,8 +95,8 @@ object SchemaHelper {
       case _: Double => Schema.Type.DOUBLE
       case _: Array[Byte] => Schema.Type.BYTES
       case _: GenericData.EnumSymbol => Schema.Type.ENUM
-      case _: java.util.ArrayList[_] => Schema.Type.ARRAY
-      case _: java.util.LinkedHashMap[_,_] => Schema.Type.MAP
+      case _: java.util.Collection[_] => Schema.Type.ARRAY
+      case _: java.util.Map[_,_] => Schema.Type.MAP
       case JsonProperties.NULL_VALUE => Schema.Type.NULL
       case other => other
     }

--- a/avro4s-core/src/test/resources/optional_default_values.json
+++ b/avro4s-core/src/test/resources/optional_default_values.json
@@ -1,0 +1,60 @@
+{
+  "type": "record",
+  "name": "OptionalDefaultValues",
+  "namespace": "com.sksamuel.avro4s.schema",
+  "fields": [
+    {
+      "name": "name",
+      "type": ["string", "null"],
+      "default" : "sammy"
+    },
+    {
+      "name": "age",
+      "type": ["int", "null"],
+      "default": 21
+    },
+    {
+      "name": "isFemale",
+      "type": ["boolean", "null"],
+      "default": false
+    },
+    {
+      "name": "length",
+      "type": ["double", "null"],
+      "default": 6.2
+    },
+    {
+      "name": "timestamp",
+      "type": ["long", "null"],
+      "default": 1468920998000
+    },
+    {
+      "name": "address",
+      "type": [{
+        "type": "map",
+        "values": "string"
+      }, "null"],
+      "default": {
+        "home": "sammy's home address",
+        "work": "sammy's work address"
+      }
+    },
+    {
+      "name": "traits",
+      "type": [{
+        "type": "array",
+        "items": "string"
+      }, "null"],
+      "default": ["Adventurous", "Helpful"]
+    },
+    {
+      "name": "favoriteWine",
+      "type": [{
+        "type": "enum",
+        "name": "Wine",
+        "symbols": ["Malbec", "Shiraz", "CabSav", "Merlot"]
+      }, "null"],
+      "default": "CabSav"
+    }
+  ]
+}

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/DefaultValueSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/DefaultValueSchemaTest.scala
@@ -49,6 +49,13 @@ class DefaultValueSchemaTest extends WordSpec with Matchers {
       schema.toString(true) shouldBe expected.toString(true)
     }
 
+    "support default values of optional Seq and Map" in {
+      val schema = AvroSchema[OptionalDefaultValues]
+      val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/optional_default_values.json"))
+      schema.toString(true) shouldBe expected.toString(true)
+
+    }
+
   }
 }
 
@@ -57,6 +64,18 @@ case class UpperDog(how_fortunate: Double) extends Dog
 case class UnderDog(how_unfortunate: Double) extends Dog
 
 case class DogProspect(dog: Option[Dog] = None)
+
+case class OptionalDefaultValues(name: Option[String] = Some("sammy"),
+                         age: Option[Int] = Some(21),
+                         isFemale: Option[Boolean] = Some(false),
+                         length: Option[Double] = Some(6.2),
+                         timestamp: Option[Long] = Some(1468920998000l),
+                         address: Option[Map[String, String]] = Some(Map(
+                           "home" -> "sammy's home address",
+                           "work" -> "sammy's work address"
+                         )),
+                         traits: Option[Seq[String]] = Some(Seq("Adventurous", "Helpful")),
+                         favoriteWine: Option[Wine] = Some(Wine.CabSav))
 
 
 case class ClassWithDefaultString(s: String = "foo")


### PR DESCRIPTION
This is another part of defaults for `map` and `array` types that I missed. Specifically, in cases where the default is a map or array it wasn't moving the default value to the head of the type list in the union.