### PR TITLE
Fix incorrect name lookup with enums

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/Decoder.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/Decoder.scala
@@ -400,19 +400,19 @@ object Decoder {
           }
         // case objects are encoded as enums
         // we need to take the string and create the object
-        case Schema.Type.ENUM =>
-          container match {
-            case enum: GenericEnumSymbol[_] =>
-              ctx.subtypes.find { subtype => Namer(subtype).name == enum.getSchema.getFullName }
-                .getOrElse(sys.error(s"Could not find subtype for enum $enum"))
-                .typeclass.decode(enum, enum.getSchema, naming)
-            case str: String =>
-              val subtype = ctx.subtypes.find { subtype => Namer(subtype).name == str }
-                .getOrElse(sys.error(s"Could not find subtype for enum $str"))
-              val runtimeMirror = universe.runtimeMirror(getClass.getClassLoader)
-              val module = runtimeMirror.staticModule(subtype.typeName.full)
-              val companion = runtimeMirror.reflectModule(module.asModule)
-              companion.instance.asInstanceOf[T]
+        case Schema.Type.ENUM => {
+            val subtype = container match {
+              case enum: GenericEnumSymbol[_] =>
+                ctx.subtypes.find { subtype => Namer(subtype).name == enum.toString }
+                  .getOrElse(sys.error(s"Could not find subtype for enum $enum"))
+              case str: String =>
+                ctx.subtypes.find { subtype => Namer(subtype).name == str }
+                  .getOrElse(sys.error(s"Could not find subtype for enum $str"))
+            }
+            val runtimeMirror = universe.runtimeMirror(getClass.getClassLoader)
+            val module = runtimeMirror.staticModule(subtype.typeName.full)
+            val companion = runtimeMirror.reflectModule(module.asModule)
+            companion.instance.asInstanceOf[T]
           }
         case other => sys.error(s"Unsupported sealed trait schema type $other")
       }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/SealedTraitDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/SealedTraitDecoderTest.scala
@@ -1,8 +1,8 @@
 package com.sksamuel.avro4s.record.decoder
 
-import com.sksamuel.avro4s.{AvroName, AvroNamespace, AvroSchema, Decoder, DefaultNamingStrategy, ImmutableRecord}
+import com.sksamuel.avro4s.{AvroName, AvroNamespace, AvroSchema, Decoder, DefaultNamingStrategy, ImmutableRecord, Encoder}
 import org.apache.avro.SchemaBuilder
-import org.apache.avro.generic.GenericData
+import org.apache.avro.generic.{GenericData, GenericRecord}
 import org.apache.avro.util.Utf8
 import org.scalatest.{FunSuite, Matchers}
 
@@ -75,6 +75,17 @@ class SealedTraitDecoderTest extends FunSuite with Matchers {
     Decoder[ThingHolder].decode(record1, schema, DefaultNamingStrategy) shouldBe ThingHolder(WhimWham)
     Decoder[ThingHolder].decode(record2, schema, DefaultNamingStrategy) shouldBe ThingHolder(Widget)
   }
+
+  test("use @AvroNamespace and @AvroName with sealed traits of case objects in a round trip") {
+    val thingySchema = SchemaBuilder.enumeration("thingy").symbols("whim_wham", "widget")
+    val schema = SchemaBuilder.record("ThingHolder").fields().name("thing").`type`(thingySchema).noDefault().endRecord()
+
+    val value = ThingHolder(WhimWham)
+    val encodedRecord: GenericRecord = Encoder[ThingHolder].encode(value, schema, DefaultNamingStrategy).asInstanceOf[GenericRecord]
+    val decoded = Decoder[ThingHolder].decode(encodedRecord, schema, DefaultNamingStrategy)
+    decoded shouldBe value
+  }
+
 }
 
 sealed trait Wibble


### PR DESCRIPTION
Ran into an issue where enums with the `@AvroName` annotation were failing to decode. For some reason it seems to only be replicated by a round trip through the encoder and decoder. I've attached a test which reproduces the issue but it may be in the wrong place. (given that it's in the `decoder` test folder).