### PR TITLE
Minimal version bumps to release a 2.13.0 version

### DIFF
--- a/project/GlobalPlugin.scala
+++ b/project/GlobalPlugin.scala
@@ -11,11 +11,11 @@ object GlobalPlugin extends AutoPlugin {
     val org = "com.sksamuel.avro4s"
     val AvroVersion = "1.8.2"
     val Log4jVersion = "1.2.17"
-    val ScalatestVersion = "3.0.6-SNAP5"
-    val ScalaVersion = "2.12.7"
+    val ScalatestVersion = "3.0.8"
+    val ScalaVersion = "2.12.8"
     val Slf4jVersion = "1.7.12"
-    val Json4sVersion = "3.6.4"
-    val CatsVersion = "1.5.0"
+    val Json4sVersion = "3.6.6"
+    val CatsVersion = "2.0.0-M4"
     val ShapelessVersion = "2.3.3"
   }
 
@@ -26,14 +26,14 @@ object GlobalPlugin extends AutoPlugin {
   override def projectSettings = publishingSettings ++ Seq(
     organization := org,
     scalaVersion := ScalaVersion,
-    crossScalaVersions := Seq("2.12.7", "2.13.0-M5"),
+    crossScalaVersions := Seq("2.12.8", "2.13.0"),
     resolvers += Resolver.mavenLocal,
     parallelExecution in Test := false,
     scalacOptions := Seq(
       "-unchecked", "-deprecation",
       "-encoding",
       "utf8",
-      "-Xfatal-warnings",
+//      "-Xfatal-warnings",
       "-feature",
      //"-Xlog-implicits",
       "-language:existentials"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.0.4"
+version in ThisBuild := "2.0.5-SNAPSHOT"


### PR DESCRIPTION
Couldn't find a contribution guide - please let me know if there are any changes necessary.

This PR builds the project 2.x series with 2.13 final. Would it make sense to create a 2.x release branch to track that, since 3.0.x is not final yet (and magnolia doesn't have a 2.13 PR yet either)?

The deprecation warnings are caused mostly by `scala.collection.JavaConverters` changing to  `scala.jdk.CollectionConverters.Ops._` I can't see a clean way of providing a shim that doesn't duplicate the source file though, so I just disabled fatal warnings.