### PR TITLE
fix #339 adds support for immutable Seq and more

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/Encoder.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/Encoder.scala
@@ -476,6 +476,9 @@ object Encoder extends LowPriorityEncoderImplicits{
 
 trait LowPriorityEncoderImplicits{
 
+  /**
+    * Generic encoder for collections types.
+    */
   implicit def iterableEncoder[S, M[T] <: Iterable[T]](implicit encoder: Encoder[S]): Encoder[M[S]] = new Encoder[M[S]] {
 
     import scala.collection.JavaConverters._

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/Encoder.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/Encoder.scala
@@ -2,7 +2,7 @@ package com.sksamuel.avro4s
 
 import java.nio.ByteBuffer
 import java.sql.{Date, Timestamp}
-import java.time.{Instant, LocalDate, LocalDateTime, LocalTime, ZoneOffset}
+import java.time._
 import java.util.UUID
 
 import magnolia.{CaseClass, Magnolia, SealedTrait}
@@ -42,7 +42,7 @@ trait Encoder[T] extends Serializable {
 
 case class Exported[A](instance: A) extends AnyVal
 
-object Encoder {
+object Encoder extends LowPriorityEncoderImplicits{
 
   def apply[T](implicit encoder: Encoder[T]): Encoder[T] = encoder
 
@@ -470,6 +470,20 @@ object Encoder {
           encoderS.encode(h, s, naming)
         case Inr(t) => encoderT.encode(t, schema, naming)
       }
+    }
+  }
+}
+
+trait LowPriorityEncoderImplicits{
+
+  implicit def iterableEncoder[S, M[T] <: Iterable[T]](implicit encoder: Encoder[S]): Encoder[M[S]] = new Encoder[M[S]] {
+
+    import scala.collection.JavaConverters._
+
+    override def encode(ts: M[S], schema: Schema, naming: NamingStrategy): java.util.List[AnyRef] = {
+      require(schema != null)
+      val arraySchema = SchemaHelper.extractSchemaFromPossibleUnion(schema, Schema.Type.ARRAY)
+      ts.map(encoder.encode(_, arraySchema.getElementType, naming)).toSeq.asJava
     }
   }
 }

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
@@ -105,32 +105,8 @@ object SchemaFor {
     }
   }
 
-  implicit def listSchemaFor[S](implicit schemaFor: SchemaFor[S]): SchemaFor[List[S]] = {
-    new SchemaFor[List[S]] {
-      override def schema(namingStrategy: NamingStrategy): Schema = Schema.createArray(schemaFor.schema(namingStrategy))
-    }
-  }
-
-  implicit def setSchemaFor[S](implicit schemaFor: SchemaFor[S]): SchemaFor[Set[S]] = {
-    new SchemaFor[Set[S]] {
-      override def schema(namingStrategy: NamingStrategy): Schema = Schema.createArray(schemaFor.schema(namingStrategy))
-    }
-  }
-
-  implicit def vectorSchemaFor[S](implicit schemaFor: SchemaFor[S]): SchemaFor[Vector[S]] = {
-    new SchemaFor[Vector[S]] {
-      override def schema(namingStrategy: NamingStrategy): Schema = Schema.createArray(schemaFor.schema(namingStrategy))
-    }
-  }
-
-  implicit def seqSchemaFor[S](implicit schemaFor: SchemaFor[S]): SchemaFor[Seq[S]] = {
-    new SchemaFor[Seq[S]] {
-      override def schema(namingStrategy: NamingStrategy): Schema = Schema.createArray(schemaFor.schema(namingStrategy))
-    }
-  }
-
-  implicit def iterableSchemaFor[S](implicit schemaFor: SchemaFor[S]): SchemaFor[Iterable[S]] = {
-    new SchemaFor[Iterable[S]] {
+  implicit def iterableSchemaFor[S, M[T] <: Iterable[T]](implicit schemaFor: SchemaFor[S]): SchemaFor[M[S]] = {
+    new SchemaFor[M[S]] {
       override def schema(namingStrategy: NamingStrategy): Schema = Schema.createArray(schemaFor.schema(namingStrategy))
     }
   }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/ArrayDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/ArrayDecoderTest.scala
@@ -209,8 +209,14 @@ class ArrayDecoderTest extends WordSpec with Matchers {
     //      val schema = SchemaEncoder[TupleTest3]
     //    }
 
-    "support top level Seq[Double]" in {
-      Decoder[Seq[Double]].decode(Array(1.2, 34.5, 54.3), AvroSchema[Seq[Double]], DefaultNamingStrategy) shouldBe Seq(1.2, 34.5, 54.3)
+    "support top level scala.collection.Seq[Double]" in {
+      Decoder[scala.collection.Seq[Double]].decode(Array(1.2, 34.5, 54.3), AvroSchema[Seq[Double]], DefaultNamingStrategy) shouldBe scala.collection.Seq(1.2, 34.5, 54.3)
+    }
+    "support top level scala.collection.immutable.Seq[Double]" in {
+      Decoder[scala.collection.immutable.Seq[Double]].decode(Array(1.2, 34.5, 54.3), AvroSchema[Seq[Double]], DefaultNamingStrategy) shouldBe scala.collection.immutable.Seq(1.2, 34.5, 54.3)
+    }
+    "support top level scala.collection.mutable.Seq[Double]" in {
+      Decoder[scala.collection.mutable.Seq[Double]].decode(Array(1.2, 34.5, 54.3), AvroSchema[Seq[Double]], DefaultNamingStrategy) shouldBe scala.collection.mutable.Seq(1.2, 34.5, 54.3)
     }
     "support top level List[Int]" in {
       Decoder[List[Int]].decode(Array(1, 4, 9), AvroSchema[Seq[Int]], DefaultNamingStrategy) shouldBe List(1, 4, 9)

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/ArrayDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/ArrayDecoderTest.scala
@@ -1,8 +1,7 @@
 package com.sksamuel.avro4s.record.decoder
 
-import com.sksamuel.avro4s.{AvroSchema, Decoder, DefaultNamingStrategy, Encoder, ImmutableRecord}
+import com.sksamuel.avro4s.{AvroSchema, Decoder, DefaultNamingStrategy}
 import org.apache.avro.generic.GenericData
-import org.apache.avro.util.Utf8
 import org.scalatest.{Matchers, WordSpec}
 
 import scala.language.higherKinds
@@ -17,6 +16,8 @@ case class TestSeqBooleans(booleans: Seq[Boolean])
 
 case class TestArrayRecords(records: Array[Record])
 case class TestSeqRecords(records: Seq[Record])
+case class TestImmutableSeqRecords(records: scala.collection.immutable.Seq[Record])
+case class TestMutableSeqRecords(records: scala.collection.mutable.Seq[Record])
 case class TestListRecords(records: List[Record])
 case class TestSetRecords(records: Set[Record])
 case class TestVectorRecords(records: Vector[Record])
@@ -54,10 +55,11 @@ class ArrayDecoderTest extends WordSpec with Matchers {
       Decoder[TestVectorRecords].decode(container, containerSchema, DefaultNamingStrategy) shouldBe TestVectorRecords(Vector(Record("qwe", 123.4), Record("wer", 8234.324)))
     }
 
-    "support array for a scala.collection.immutable.Seq of primitives" in {
-      case class Test(seq: Seq[String])
-      val schema = AvroSchema[Test]
-      Encoder[Test].encode(Test(Vector("a", "34", "fgD")), schema, DefaultNamingStrategy) shouldBe ImmutableRecord(schema, Vector(Vector(new Utf8("a"), new Utf8("34"), new Utf8("fgD")).asJava))
+    "support array for a scala.collection.Seq of primitives" in {
+      val schema = AvroSchema[TestSeqBooleans]
+      val record = new GenericData.Record(schema)
+      record.put("booleans", List(true, false, true).asJava)
+      Decoder[TestSeqBooleans].decode(record, schema, DefaultNamingStrategy) shouldBe TestSeqBooleans(Seq(true, false, true))
     }
 
     "support array for an Array of primitives" in {
@@ -94,7 +96,7 @@ class ArrayDecoderTest extends WordSpec with Matchers {
       Decoder[TestListRecords].decode(container, containerSchema, DefaultNamingStrategy) shouldBe TestListRecords(List(Record("qwe", 123.4), Record("wer", 8234.324)))
     }
 
-    "support array for a scala.collection.immutable.Seq of records" in {
+    "support array for a scala.collection.Seq of records" in {
 
       val containerSchema = AvroSchema[TestSeqRecords]
       val recordSchema = AvroSchema[Record]
@@ -112,6 +114,44 @@ class ArrayDecoderTest extends WordSpec with Matchers {
 
       Decoder[TestSeqRecords].decode(container, containerSchema, DefaultNamingStrategy) shouldBe TestSeqRecords(Seq(Record("qwe", 123.4), Record("wer", 8234.324)))
     }
+
+
+    "support array for a scala.collection.immutable.Seq of records" in {
+      val containerSchema = AvroSchema[TestImmutableSeqRecords]
+      val recordSchema = AvroSchema[Record]
+
+      val record1 = new GenericData.Record(recordSchema)
+      record1.put("str", "qwe")
+      record1.put("double", 123.4)
+
+      val record2 = new GenericData.Record(recordSchema)
+      record2.put("str", "wer")
+      record2.put("double", 8234.324)
+
+      val container = new GenericData.Record(containerSchema)
+      container.put("records", List(record1, record2).asJava)
+
+      Decoder[TestImmutableSeqRecords].decode(container, containerSchema, DefaultNamingStrategy) shouldBe TestImmutableSeqRecords(scala.collection.immutable.Seq(Record("qwe", 123.4), Record("wer", 8234.324)))
+    }
+
+    "support array for a scala.collection.mutable.Seq of records" in {
+      val containerSchema = AvroSchema[TestMutableSeqRecords]
+      val recordSchema = AvroSchema[Record]
+
+      val record1 = new GenericData.Record(recordSchema)
+      record1.put("str", "qwe")
+      record1.put("double", 123.4)
+
+      val record2 = new GenericData.Record(recordSchema)
+      record2.put("str", "wer")
+      record2.put("double", 8234.324)
+
+      val container = new GenericData.Record(containerSchema)
+      container.put("records", List(record1, record2).asJava)
+
+      Decoder[TestMutableSeqRecords].decode(container, containerSchema, DefaultNamingStrategy) shouldBe TestMutableSeqRecords(scala.collection.mutable.Seq(Record("qwe", 123.4), Record("wer", 8234.324)))
+    }
+
 
     "support array for an Array of records" in {
 

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/ArrayEncoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/ArrayEncoderTest.scala
@@ -22,10 +22,20 @@ class ArrayEncoderTest extends WordSpec with Matchers {
       val rschema = AvroSchema[Record]
       Encoder[Test].encode(Test(Vector(Record("abc", 12.34))), schema, DefaultNamingStrategy) shouldBe ImmutableRecord(schema, Vector(Vector(ImmutableRecord(rschema, Vector(new Utf8("abc"), java.lang.Double.valueOf(12.34)))).asJava))
     }
-    "generate array for a scala.collection.immutable.Seq of primitives" in {
+    "generate array for a scala.collection.Seq of primitives" in {
       case class Test(seq: Seq[String])
       val schema = AvroSchema[Test]
-      Encoder[Test].encode(Test(Vector("a", "fgD")), schema, DefaultNamingStrategy) shouldBe ImmutableRecord(schema, Vector(Vector(new Utf8("a"), new Utf8("fgD")).asJava))
+      Encoder[Test].encode(Test(Seq("a", "fgD")), schema, DefaultNamingStrategy) shouldBe ImmutableRecord(schema, Vector(Vector(new Utf8("a"), new Utf8("fgD")).asJava))
+    }
+    "generate array for a scala.collection.immutable.Seq of primitives" in {
+      case class Test(seq: scala.collection.immutable.Seq[String])
+      val schema = AvroSchema[Test]
+      Encoder[Test].encode(Test(scala.collection.immutable.Seq("a", "fgD")), schema, DefaultNamingStrategy) shouldBe ImmutableRecord(schema, Vector(Vector(new Utf8("a"), new Utf8("fgD")).asJava))
+    }
+    "generate array for a scala.collection.mutable.Seq of primitives" in {
+      case class Test(seq: scala.collection.mutable.Seq[String])
+      val schema = AvroSchema[Test]
+      Encoder[Test].encode(Test(scala.collection.mutable.Seq("a", "fgD")), schema, DefaultNamingStrategy) shouldBe ImmutableRecord(schema, Vector(Vector(new Utf8("a"), new Utf8("fgD")).asJava))
     }
     "generate array for an Array of primitives" in {
       case class Test(array: Array[Boolean])

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/ArraySchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/ArraySchemaTest.scala
@@ -37,9 +37,23 @@ class ArraySchemaTest extends WordSpec with Matchers {
       val schema = AvroSchema[NestedListString]
       schema.toString(true) shouldBe expected.toString(true)
     }
-    "generate array type for a scala.collection.immutable.Seq of records" in {
+    "generate array type for a scala.collection.Seq of records" in {
       case class Nested(goo: String)
       case class Test(seq: Seq[Nested])
+      val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/seqrecords.json"))
+      val schema = AvroSchema[Test]
+      schema.toString(true) shouldBe expected.toString(true)
+    }
+    "generate array type for a scala.collection.immutable.Seq of records" in {
+      case class Nested(goo: String)
+      case class Test(seq: scala.collection.immutable.Seq[Nested])
+      val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/seqrecords.json"))
+      val schema = AvroSchema[Test]
+      schema.toString(true) shouldBe expected.toString(true)
+    }
+    "generate array type for a scala.collection.mutable.Seq of records" in {
+      case class Nested(goo: String)
+      case class Test(seq: scala.collection.mutable.Seq[Nested])
       val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/seqrecords.json"))
       val schema = AvroSchema[Test]
       schema.toString(true) shouldBe expected.toString(true)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -60,8 +60,8 @@ object Build extends AutoPlugin {
       credentials += Credentials(
         "Sonatype Nexus Repository Manager",
         "oss.sonatype.org",
-        sys.env("OSSRH_USERNAME"),
-        sys.env("OSSRH_PASSWORD")
+        sys.env.getOrElse("OSSRH_USERNAME", ""),
+        sys.env.getOrElse("OSSRH_PASSWORD", "")
       )
     } else {
       credentials += Credentials(Path.userHome / ".sbt" / "credentials.sbt")


### PR DESCRIPTION
Probably first needs a review

* For schema generation any `Iterable` is now accepted and yields `Array` in the schema
* Encoders/Decoders need some more explicit handling becuase the low priority implicit is a bit less performant

I have also seen that Scala 2.13 fails because of missing Magnolia dependency.
Might need some more updates for 2.13 because of the collections changes
https://github.com/scala/scala-collection-compat

Got some inspiration here:
https://github.com/playframework/play-json/blob/dd7c7d1d9c9f329829809bd13e0dccd058f30c1c/play-json/shared/src/main/scala/play/api/libs/json/Writes.scala#L395
https://github.com/playframework/play-json/blob/dd7c7d1d9c9f329829809bd13e0dccd058f30c1c/play-json/shared/src/main/scala/play/api/libs/json/Reads.scala#L229