### PR TITLE
Issue #352 - User defined classes can't be used as defaults in a Union

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/Decoder.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/Decoder.scala
@@ -365,7 +365,14 @@ object Decoder {
                 } else {
                   val k = record.getSchema.getFields.indexOf(field)
                   val value = record.get(k)
-                  p.typeclass.decode(value, schema.getFields.get(p.index).schema, naming)
+                  val tryDecode = util.Try {
+                    p.typeclass.decode(value, schema.getFields.get(p.index).schema, naming)
+                  }.toEither
+                  (tryDecode, p.default) match {
+                    case (Right(v), _) => v
+                    case (Left(_), Some(default)) => default
+                    case (Left(ex), _) => throw ex
+                  }
                 }
               }
 

--- a/avro4s-core/src/test/resources/case_class_default_values.json
+++ b/avro4s-core/src/test/resources/case_class_default_values.json
@@ -1,0 +1,30 @@
+{
+  "type": "record",
+  "name": "Cuppers",
+  "namespace": "com.sksamuel.avro4s.schema",
+  "fields": [
+    {
+      "name": "cupcat",
+      "type": [
+        {
+          "type": "record",
+          "name": "Snoutley",
+          "fields": [
+            {
+              "name": "snoutley",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "type": "record",
+          "name": "Rendal",
+          "fields": []
+        }
+      ],
+      "default": {
+        "snoutley" : "hates varg"
+      }
+    }
+  ]
+}

--- a/avro4s-core/src/test/resources/case_object_default_values.json
+++ b/avro4s-core/src/test/resources/case_object_default_values.json
@@ -1,0 +1,28 @@
+{
+  "type": "record",
+  "name": "NoVarg",
+  "namespace": "com.sksamuel.avro4s.schema",
+  "fields": [
+    {
+      "name": "cupcat",
+      "type": [
+        {
+          "type": "record",
+          "name": "Rendal",
+          "fields": []
+        },
+        {
+          "type": "record",
+          "name": "Snoutley",
+          "fields": [
+            {
+              "name": "snoutley",
+              "type": "string"
+            }
+          ]
+        }
+      ],
+      "default": {}
+    }
+  ]
+}

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/Blah.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/Blah.scala
@@ -1,0 +1,47 @@
+package com.sksamuel.avro4s.schema
+
+
+import com.sksamuel.avro4s.{AvroName, AvroSchema, FromRecord, ToRecord}
+import org.scalatest.{Matchers, WordSpec}
+
+class DefaultValueRecordTest extends WordSpec with Matchers {
+
+  "Converting to and from Avro GenericRecord" should {
+
+    "respect default case class values" in {
+
+      FromRecord[Jude].from(ToRecord[Jude].to(Jude(Bobby("blah")))) shouldBe Jude(CKola)
+    }
+
+    "respect default case object values" in {
+      FromRecord[Catcup].from(ToRecord[Catcup].to(Catcup())) shouldBe Catcup(Bobby("hates varg"))
+    }
+
+    "gtfo" in {
+      println(ToRecord[Jude].to(Jude(CKola)))
+      FromRecord[Jude2].from(ToRecord[Jude].to(Jude())) shouldBe Jude2()
+    }
+
+  }
+
+}
+sealed trait X
+case object BX extends X
+
+
+sealed trait Cup
+case object CKola extends Cup
+case class Bobby(hatesVarg: String) extends Cup
+
+case class Catcup(cupcat: Cup = Bobby("hates varg"))
+case class Jude(hatesVarg: Cup = CKola)
+
+@AvroName("Cup")
+sealed trait Cup2
+
+object Cup2 {
+
+  case class Bobby(hatesVarg: String) extends Cup2
+}
+
+case class Jude2(hatesVarg: Cup2 = Cup2.Bobby("hates varg"))

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/DefaultValueRecordTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/DefaultValueRecordTest.scala
@@ -8,26 +8,13 @@ class DefaultValueRecordTest extends WordSpec with Matchers {
 
   "Converting to and from Avro GenericRecord" should {
 
-    "respect default case class values" in {
-
-      FromRecord[Jude].from(ToRecord[Jude].to(Jude(Bobby("blah")))) shouldBe Jude(CKola)
-    }
-
-    "respect default case object values" in {
-      FromRecord[Catcup].from(ToRecord[Catcup].to(Catcup())) shouldBe Catcup(Bobby("hates varg"))
-    }
-
-    "gtfo" in {
-      println(ToRecord[Jude].to(Jude(CKola)))
+    "use the default where appropriate" in {
       FromRecord[Jude2].from(ToRecord[Jude].to(Jude())) shouldBe Jude2()
     }
 
   }
 
 }
-sealed trait X
-case object BX extends X
-
 
 sealed trait Cup
 case object CKola extends Cup
@@ -40,7 +27,6 @@ case class Jude(hatesVarg: Cup = CKola)
 sealed trait Cup2
 
 object Cup2 {
-
   case class Bobby(hatesVarg: String) extends Cup2
 }
 

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/DefaultValueSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/DefaultValueSchemaTest.scala
@@ -53,16 +53,27 @@ class DefaultValueSchemaTest extends WordSpec with Matchers {
       val schema = AvroSchema[OptionalDefaultValues]
       val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/optional_default_values.json"))
       schema.toString(true) shouldBe expected.toString(true)
-
     }
 
+    "support default values that are case classes" in {
+      val schema = AvroSchema[Cuppers]
+
+      val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/case_class_default_values.json"))
+      schema.toString(true) shouldBe expected.toString(true)
+    }
+
+    "support default values that are case objects" in {
+      implicit val schema = AvroSchema[NoVarg]
+
+      val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/case_object_default_values.json"))
+      schema.toString(true) shouldBe expected.toString(true)
+    }
   }
 }
 
 sealed trait Dog
 case class UnderDog(how_unfortunate: Double) extends Dog
 case class UpperDog(how_fortunate: Double) extends Dog
-
 case class DogProspect(dog: Option[Dog] = None)
 
 case class OptionalDefaultValues(name: Option[String] = Some("sammy"),
@@ -96,3 +107,10 @@ case class DefaultValues(name: String = "sammy",
                          ),
                          traits: Seq[String] = Seq("Adventurous", "Helpful"),
                          favoriteWine: Wine = Wine.CabSav)
+
+sealed trait Cupcat
+case object Rendal extends Cupcat
+case class Snoutley(snoutley: String) extends Cupcat
+
+case class Cuppers(cupcat: Cupcat = Snoutley("hates varg"))
+case class NoVarg(cupcat: Cupcat = Rendal)

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,8 @@ val `avro4s-core` = project.in(file("avro4s-core"))
   .settings(
     libraryDependencies ++= Seq(
       "com.propensive" %% "magnolia" % MagnoliaVersion,
-      "com.chuusai" %% "shapeless" % ShapelessVersion
+      "com.chuusai" %% "shapeless" % ShapelessVersion,
+      "org.json4s" %% "json4s-native" % Json4sVersion
     )
   )
 


### PR DESCRIPTION
- allows union defaults to be user defined case classes / case objects
- handles correctly reordering the schema as per the spec
- case class defaults are json objects
- case object defaults are empty json object