### PR TITLE
Correctly decode tuples that contain a Seq

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/Decoder.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/Decoder.scala
@@ -428,8 +428,8 @@ object Decoder {
     override def decode(t: Any, schema: Schema, naming: NamingStrategy): (A, B) = {
       val record = t.asInstanceOf[GenericRecord]
       (
-        decoderA.decode(record.get("_1"), schema, naming),
-        decoderB.decode(record.get("_2"), schema, naming)
+        decoderA.decode(record.get("_1"), schema.getField("_1").schema(), naming),
+        decoderB.decode(record.get("_2"), schema.getField("_2").schema(), naming)
       )
     }
   }
@@ -442,9 +442,9 @@ object Decoder {
     override def decode(t: Any, schema: Schema, naming: NamingStrategy): (A, B, C) = {
       val record = t.asInstanceOf[GenericRecord]
       (
-        decoderA.decode(record.get("_1"), schema, naming),
-        decoderB.decode(record.get("_2"), schema, naming),
-        decoderC.decode(record.get("_3"), schema, naming)
+        decoderA.decode(record.get("_1"), schema.getField("_1").schema(), naming),
+        decoderB.decode(record.get("_2"), schema.getField("_2").schema(), naming),
+        decoderC.decode(record.get("_3"), schema.getField("_3").schema(), naming)
       )
     }
   }
@@ -458,10 +458,10 @@ object Decoder {
     override def decode(t: Any, schema: Schema, naming: NamingStrategy): (A, B, C, D) = {
       val record = t.asInstanceOf[GenericRecord]
       (
-        decoderA.decode(record.get("_1"), schema, naming),
-        decoderB.decode(record.get("_2"), schema, naming),
-        decoderC.decode(record.get("_3"), schema, naming),
-        decoderD.decode(record.get("_4"), schema, naming)
+        decoderA.decode(record.get("_1"), schema.getField("_1").schema(), naming),
+        decoderB.decode(record.get("_2"), schema.getField("_2").schema(), naming),
+        decoderC.decode(record.get("_3"), schema.getField("_3").schema(), naming),
+        decoderD.decode(record.get("_4"), schema.getField("_4").schema(), naming)
       )
     }
   }
@@ -476,11 +476,11 @@ object Decoder {
     override def decode(t: Any, schema: Schema, naming: NamingStrategy): (A, B, C, D, E) = {
       val record = t.asInstanceOf[GenericRecord]
       (
-        decoderA.decode(record.get("_1"), schema, naming),
-        decoderB.decode(record.get("_2"), schema, naming),
-        decoderC.decode(record.get("_3"), schema, naming),
-        decoderD.decode(record.get("_4"), schema, naming),
-        decoderE.decode(record.get("_5"), schema, naming)
+        decoderA.decode(record.get("_1"), schema.getField("_1").schema(), naming),
+        decoderB.decode(record.get("_2"), schema.getField("_2").schema(), naming),
+        decoderC.decode(record.get("_3"), schema.getField("_3").schema(), naming),
+        decoderD.decode(record.get("_4"), schema.getField("_4").schema(), naming),
+        decoderE.decode(record.get("_5"), schema.getField("_5").schema(), naming)
       )
     }
   }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/TupleDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/TupleDecoderTest.scala
@@ -4,13 +4,18 @@ import com.sksamuel.avro4s.{AvroSchema, Decoder, DefaultNamingStrategy}
 import org.apache.avro.generic.GenericData
 import org.apache.avro.util.Utf8
 import org.scalatest.{FunSuite, Matchers}
+import scala.collection.JavaConverters._
 
 class TupleDecoderTest extends FunSuite with Matchers {
 
   case class Test2(z: (String, Int))
+  case class Test2Seq(z: (Seq[String], Int))
   case class Test3(z: (String, Int, Boolean))
+  case class Test3Seq(z: (String, Seq[Int], Boolean))
   case class Test4(z: (String, Int, Boolean, Double))
+  case class Test4Seq(z: (String, Int, Boolean, Seq[Double]))
   case class Test5(z: (String, Int, Boolean, Double, Long))
+  case class Test5Seq(z: (String, Int, Boolean, Double, Seq[Long]))
 
   test("decode tuple2") {
     val schema = AvroSchema[Test2]
@@ -22,6 +27,16 @@ class TupleDecoderTest extends FunSuite with Matchers {
     Decoder[Test2].decode(record, schema, DefaultNamingStrategy) shouldBe Test2(("hello", 214))
   }
 
+  test("decode tuple2 with seq") {
+    val schema = AvroSchema[Test2Seq]
+    val z = new GenericData.Record(AvroSchema[(Seq[String], Int)])
+    z.put("_1", List(new Utf8("hello")).asJava)
+    z.put("_2", java.lang.Integer.valueOf(214))
+    val record = new GenericData.Record(schema)
+    record.put("z", z)
+    Decoder[Test2Seq].decode(record, schema, DefaultNamingStrategy) shouldBe Test2Seq((Seq("hello"), 214))
+  }
+
   test("decode tuple3") {
     val schema = AvroSchema[Test3]
     val z = new GenericData.Record(AvroSchema[(String, Int, Boolean)])
@@ -31,6 +46,17 @@ class TupleDecoderTest extends FunSuite with Matchers {
     val record = new GenericData.Record(schema)
     record.put("z", z)
     Decoder[Test3].decode(record, schema, DefaultNamingStrategy) shouldBe Test3(("hello", 214, true))
+  }
+
+  test("decode tuple3 with seq") {
+    val schema = AvroSchema[Test3Seq]
+    val z = new GenericData.Record(AvroSchema[(String, Seq[Int], Boolean)])
+    z.put("_1", new Utf8("hello"))
+    z.put("_2", List(java.lang.Integer.valueOf(214)).asJava)
+    z.put("_3", java.lang.Boolean.valueOf(true))
+    val record = new GenericData.Record(schema)
+    record.put("z", z)
+    Decoder[Test3Seq].decode(record, schema, DefaultNamingStrategy) shouldBe Test3Seq(("hello", Seq(214), true))
   }
 
   test("decode tuple4") {
@@ -45,6 +71,18 @@ class TupleDecoderTest extends FunSuite with Matchers {
     Decoder[Test4].decode(record, schema, DefaultNamingStrategy) shouldBe Test4(("hello", 214, true, 56.45))
   }
 
+  test("decode tuple4 with seq") {
+    val schema = AvroSchema[Test4Seq]
+    val z = new GenericData.Record(AvroSchema[(String, Int, Boolean, Seq[Double])])
+    z.put("_1", new Utf8("hello"))
+    z.put("_2", java.lang.Integer.valueOf(214))
+    z.put("_3", java.lang.Boolean.valueOf(true))
+    z.put("_4", List(java.lang.Double.valueOf(56.45)).asJava)
+    val record = new GenericData.Record(schema)
+    record.put("z", z)
+    Decoder[Test4Seq].decode(record, schema, DefaultNamingStrategy) shouldBe Test4Seq(("hello", 214, true, Seq(56.45)))
+  }
+
   test("decode tuple5") {
     val schema = AvroSchema[Test5]
     val z = new GenericData.Record(AvroSchema[(String, Int, Boolean, Double, Long)])
@@ -56,6 +94,19 @@ class TupleDecoderTest extends FunSuite with Matchers {
     val record = new GenericData.Record(schema)
     record.put("z", z)
     Decoder[Test5].decode(record, schema, DefaultNamingStrategy) shouldBe Test5(("hello", 214, true, 56.45, 9999999999L))
+  }
+
+  test("decode tuple5 with seq") {
+    val schema = AvroSchema[Test5Seq]
+    val z = new GenericData.Record(AvroSchema[(String, Int, Boolean, Double, Seq[Long])])
+    z.put("_1", new Utf8("hello"))
+    z.put("_2", java.lang.Integer.valueOf(214))
+    z.put("_3", java.lang.Boolean.valueOf(true))
+    z.put("_4", java.lang.Double.valueOf(56.45))
+    z.put("_5", List(java.lang.Long.valueOf(9999999999L)).asJava)
+    val record = new GenericData.Record(schema)
+    record.put("z", z)
+    Decoder[Test5Seq].decode(record, schema, DefaultNamingStrategy) shouldBe Test5Seq(("hello", 214, true, 56.45, Seq(9999999999L)))
   }
 }
 


### PR DESCRIPTION
Otherwise decoding fails with `org.apache.avro.AvroRuntimeException: Not an array`. I guess this would also fix decoding of tuples that contain other complex types.