### PR TITLE
Small PR to add a test around sort priority and defaults

### DIFF
--- a/avro4s-core/src/test/resources/avro_sort_priority_union_with_default.json
+++ b/avro4s-core/src/test/resources/avro_sort_priority_union_with_default.json
@@ -1,21 +1,11 @@
 {
   "type": "record",
-  "name": "FightingStyleWrapper",
+  "name": "FightingStyleWrapperWithDefault",
   "namespace": "com.sksamuel.avro4s.schema",
   "fields": [
     {
       "name": "fightingstyle",
       "type": [
-        {
-          "type": "record",
-          "name": "DefensiveFightingStyle",
-          "fields": [
-            {
-              "name": "has_armor",
-              "type": "boolean"
-            }
-          ]
-        },
         {
           "type": "record",
           "name": "AggressiveFightingStyle",
@@ -25,8 +15,21 @@
               "type": "float"
             }
           ]
+        },
+        {
+          "type": "record",
+          "name": "DefensiveFightingStyle",
+          "fields": [
+            {
+              "name": "has_armor",
+              "type": "boolean"
+            }
+          ]
         }
-      ]
+      ],
+      "default": {
+        "agressiveness": 10.0
+      }
     }
   ]
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/AvroSortPrioritySchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/AvroSortPrioritySchemaTest.scala
@@ -18,6 +18,13 @@ class AvroSortPrioritySchemaTest extends FunSuite with Matchers {
 
     schema.toString(true) shouldBe expected.toString(true)
   }
+
+  test("avrosortpriority should respect union default ordering") {
+    val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/avro_sort_priority_union_with_default.json"))
+    val schema = AvroSchema[FightingStyleWrapperWithDefault]
+
+    schema.toString(true) shouldBe expected.toString(true)
+  }
 }
 
 
@@ -31,9 +38,11 @@ case object NaturalNumber extends Numeric
 
 
 case class FightingStyleWrapper(fightingstyle: FightingStyle)
+case class FightingStyleWrapperWithDefault(fightingstyle: FightingStyle = AggressiveFightingStyle(10))
 
 sealed trait FightingStyle
 @AvroSortPriority(2)
 case class AggressiveFightingStyle(agressiveness: Float) extends FightingStyle
 @AvroSortPriority(10)
-case class DefensiveFightingStlye(has_armor: Boolean) extends FightingStyle
+case class DefensiveFightingStyle(has_armor: Boolean) extends FightingStyle
+


### PR DESCRIPTION
Tests that the @AvroSortPriority annotation, does not break the reordering of the schema fields that happens when we add a default union value

Also fixes a small typo in test class naming