### PR TITLE
bump Scala versions, modernize Travis-CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
-sudo: false
-
 language: scala
 
 scala:
-- 2.12.8
+- 2.12.10
+- 2.13.1
 
 script:
-- sbt +test
+- sbt ++$TRAVIS_SCALA_VERSION test
 
 jdk:
-- openjdk10
-- oraclejdk11
+- openjdk8
+- openjdk11
 
 after_success: "./snapshot_deploy.sh"

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/annotations.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/annotations.scala
@@ -119,4 +119,4 @@ sealed trait AvroFieldReflection extends StaticAnnotation {
 
 case class AvroSortPriority(priority: Float) extends AvroFieldReflection
 
-case class AvroEnumDefault(default: Any)
+case class AvroEnumDefault(default: Any) extends StaticAnnotation

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -26,8 +26,8 @@ object Build extends AutoPlugin {
   override def trigger = allRequirements
   override def projectSettings = publishingSettings ++ Seq(
     organization := org,
-    scalaVersion := "2.12.8",
-    crossScalaVersions := Seq("2.12.8", "2.13.0"),
+    scalaVersion := "2.12.10",
+    crossScalaVersions := Seq("2.12.10", "2.13.1"),
     resolvers += Resolver.mavenLocal,
     parallelExecution in Test := false,
     scalacOptions := Seq(

--- a/snapshot_deploy.sh
+++ b/snapshot_deploy.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 if [ "$TRAVIS_BRANCH" == 'master' ]; then
-  sbt +publish
+  sbt publish
 fi


### PR DESCRIPTION
I think it's a bit more standard (and more parallel) to put the matrix of Scala versions in `.travis.yml`, rather than using `+test` and `+publish`. it's nice to see at a glance in the Travis-CI results which versions are failing

btw it seems a bit suspicious to me that you have two JDKs in the Travis-CI matrix but you run `snapshot_deploy.sh` from both, aren't you double-publishing snapshots? I didn't check or change this

was it intentional that you weren't building/testing on JDK 8, only 10 and 11? I changed it to 8 and 11, but perhaps that's wrong