### PR TITLE
Fixed encoding GenericRecord using AvroDataOutputStream

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroDataOutputStream.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroDataOutputStream.scala
@@ -36,7 +36,7 @@ case class AvroDataOutputStream[T](os: OutputStream,
       dataFileWriter.setCodec(codec)
       dataFileWriter.create(schema, os)
       (dataFileWriter, (t: T) => {
-        val record = encoder.encode(t, schema, fieldMapper).asInstanceOf[ImmutableRecord]
+        val record = encoder.encode(t, schema, fieldMapper).asInstanceOf[GenericRecord]
         dataFileWriter.append(record)
       })
   }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/streams/output/AvroDataOutputStreamCodecTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/streams/output/AvroDataOutputStreamCodecTest.scala
@@ -1,9 +1,10 @@
 package com.sksamuel.avro4s.streams.output
 
-import java.io.ByteArrayOutputStream
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 
-import com.sksamuel.avro4s.{AvroOutputStream, AvroSchema}
-import org.apache.avro.file.CodecFactory
+import com.sksamuel.avro4s.{AvroOutputStream, AvroSchema, Encoder}
+import org.apache.avro.file.{CodecFactory, DataFileStream}
+import org.apache.avro.generic.{GenericDatumReader, GenericRecord, GenericRecordBuilder}
 import org.scalatest.{Matchers, WordSpec}
 
 class AvroDataOutputStreamCodecTest extends WordSpec with Matchers {
@@ -44,6 +45,28 @@ class AvroDataOutputStreamCodecTest extends WordSpec with Matchers {
       output.write(ennio)
       output.close()
       new String(baos.toByteArray) should include("bzip2")
+    }
+
+    "serialize generic record" in {
+      import scala.collection.JavaConverters._
+      val record = new GenericRecordBuilder(schema)
+        .set("name", "ennio morricone")
+        .set("birthplace", "rome")
+        .set("compositions", List("legend of 1900", "ecstasy of gold").asJava)
+        .build()
+
+      implicit val encoder: Encoder[GenericRecord] = (r, _, _) => r
+
+      val baos = new ByteArrayOutputStream()
+      val output = AvroOutputStream.data[GenericRecord].to(baos).build(schema)
+      output.write(record)
+      output.close()
+
+      val bais = new ByteArrayInputStream(baos.toByteArray)
+      val reader = new DataFileStream[GenericRecord](bais, new GenericDatumReader[GenericRecord](schema))
+      val result = reader.iterator().asScala.toList
+      result should have size 1
+      result.head shouldBe record
     }
   }
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/streams/output/AvroDataOutputStreamCodecTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/streams/output/AvroDataOutputStreamCodecTest.scala
@@ -1,10 +1,9 @@
 package com.sksamuel.avro4s.streams.output
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import java.io.ByteArrayOutputStream
 
-import com.sksamuel.avro4s.{AvroOutputStream, AvroSchema, Encoder}
-import org.apache.avro.file.{CodecFactory, DataFileStream}
-import org.apache.avro.generic.{GenericDatumReader, GenericRecord, GenericRecordBuilder}
+import com.sksamuel.avro4s.{AvroOutputStream, AvroSchema}
+import org.apache.avro.file.CodecFactory
 import org.scalatest.{Matchers, WordSpec}
 
 class AvroDataOutputStreamCodecTest extends WordSpec with Matchers {
@@ -45,28 +44,6 @@ class AvroDataOutputStreamCodecTest extends WordSpec with Matchers {
       output.write(ennio)
       output.close()
       new String(baos.toByteArray) should include("bzip2")
-    }
-
-    "serialize generic record" in {
-      import scala.collection.JavaConverters._
-      val record = new GenericRecordBuilder(schema)
-        .set("name", "ennio morricone")
-        .set("birthplace", "rome")
-        .set("compositions", List("legend of 1900", "ecstasy of gold").asJava)
-        .build()
-
-      implicit val encoder: Encoder[GenericRecord] = (r, _, _) => r
-
-      val baos = new ByteArrayOutputStream()
-      val output = AvroOutputStream.data[GenericRecord].to(baos).build(schema)
-      output.write(record)
-      output.close()
-
-      val bais = new ByteArrayInputStream(baos.toByteArray)
-      val reader = new DataFileStream[GenericRecord](bais, new GenericDatumReader[GenericRecord](schema))
-      val result = reader.iterator().asScala.toList
-      result should have size 1
-      result.head shouldBe record
     }
   }
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/streams/output/BasicOutputStreamTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/streams/output/BasicOutputStreamTest.scala
@@ -1,5 +1,8 @@
 package com.sksamuel.avro4s.streams.output
 
+import com.sksamuel.avro4s.{Encoder, SchemaFor}
+import org.apache.avro.Schema.Parser
+import org.apache.avro.generic.{GenericRecord, GenericRecordBuilder}
 import org.apache.avro.util.Utf8
 
 class BasicOutputStreamTest extends OutputStreamTest {
@@ -43,6 +46,22 @@ class BasicOutputStreamTest extends OutputStreamTest {
     case class Test(z: Float)
     writeRead(Test(3.4F)) { record =>
       record.get("z") shouldBe 3.4F
+    }
+  }
+
+  test("write out generic record") {
+    val schema = new Parser().parse(
+      """{"type":"record","name":"Test","fields":[{"name":"field","type":"string"}]}"""
+    )
+
+    implicit val encoder: Encoder[GenericRecord] = (r, _, _) => r
+    implicit val schemaFor: SchemaFor[GenericRecord] = _ => schema
+
+    val record: GenericRecord =
+      new GenericRecordBuilder(schema).set("field", "value").build()
+
+    writeRead(record) { rec =>
+      rec.get("field") shouldBe new Utf8("value")
     }
   }
 }


### PR DESCRIPTION
There's an issue with writing raw `GenericRecord` using `AvroDataOutputStream` caused by cast to `ImmutableRecord`.
The proposed solution just narrows the type of encoded entity to `GenericRecord`, since that's the most generic type required by `GenericDatumWriter[GenericRecord]`.