### PR TITLE
FromRecord should decode using reader schema

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
@@ -13,6 +13,6 @@ trait FromRecord[T] extends Serializable {
 object FromRecord {
   def apply[T: Decoder : SchemaFor]: FromRecord[T] = apply(AvroSchema[T])
   def apply[T: Decoder](schema: Schema)(implicit fieldMapper: FieldMapper = DefaultFieldMapper): FromRecord[T] = new FromRecord[T] {
-    override def from(record: IndexedRecord): T = implicitly[Decoder[T]].decode(record, record.getSchema, fieldMapper)
+    override def from(record: IndexedRecord): T = implicitly[Decoder[T]].decode(record, schema, fieldMapper)
   }
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/FromRecordTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/FromRecordTest.scala
@@ -1,0 +1,31 @@
+package com.sksamuel.avro4s.record.decoder
+
+import com.sksamuel.avro4s.{AvroSchema, FromRecord, ToRecord}
+import org.apache.avro.generic.GenericData
+import org.scalatest.{Matchers, WordSpec}
+
+case class HasSomeFields(str: String, int: Int, boolean: Boolean, nested: Nested)
+case class Nested(foo: String)
+case class HasLessFields(str: String, boolean: Boolean, nested: Nested)
+
+class FromRecordTest extends WordSpec with Matchers {
+
+  "FromRecord" should {
+    "decode to class with a subset of fields used to encode" in {
+      val schema = AvroSchema[HasSomeFields]
+      val nestedSchema = AvroSchema[Nested]
+
+      val record = new GenericData.Record(schema)
+      val nestedRecord = new GenericData.Record(nestedSchema)
+      record.put("str", "hello")
+      record.put("int", 42)
+      record.put("boolean", false)
+      nestedRecord.put("foo", "there")
+      record.put("nested", nestedRecord)
+
+      FromRecord[HasLessFields].from(record) shouldBe HasLessFields("hello", false, Nested("there"))
+    }
+  }
+}
+
+


### PR DESCRIPTION
I think `FromRecord` should be decoding using the reader schema (for the class being decoded to) rather than the schema of the record being decoded. Currently with more than basic classes, `T` needs the same fields as the writer.

Sorry, if this is wrong but I think it makes sense unless I've misunderstood what `FromRecord` is supposed to be used for?

The test seemed to fit in with the decoding tests but let me know if there is a better place for it.