### PR TITLE
ISSUE-387 | Fixed LocalTime Encoder to properly convert to milliseconds

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/Encoder.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/Encoder.scala
@@ -99,7 +99,7 @@ object Encoder {
   }
 
   implicit val UUIDEncoder: Encoder[UUID] = StringEncoder.comap[UUID](_.toString)
-  implicit val LocalTimeEncoder: Encoder[LocalTime] = IntEncoder.comap[LocalTime](lt => lt.toSecondOfDay * 1000 + lt.getNano / 1000)
+  implicit val LocalTimeEncoder: Encoder[LocalTime] = IntEncoder.comap[LocalTime](lt => (lt.toNanoOfDay / 1000000).toInt)
   implicit val LocalDateEncoder: Encoder[LocalDate] = IntEncoder.comap[LocalDate](_.toEpochDay.toInt)
   implicit val InstantEncoder: Encoder[Instant] = LongEncoder.comap[Instant](_.toEpochMilli)
   implicit val LocalDateTimeEncoder: Encoder[LocalDateTime] = InstantEncoder.comap[LocalDateTime](_.toInstant(ZoneOffset.UTC))

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/Encoder.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/Encoder.scala
@@ -99,7 +99,7 @@ object Encoder {
   }
 
   implicit val UUIDEncoder: Encoder[UUID] = StringEncoder.comap[UUID](_.toString)
-  implicit val LocalTimeEncoder: Encoder[LocalTime] = IntEncoder.comap[LocalTime](lt => (lt.toNanoOfDay / 1000000).toInt)
+  implicit val LocalTimeEncoder: Encoder[LocalTime] = LongEncoder.comap[LocalTime](lt => lt.toNanoOfDay / 1000)
   implicit val LocalDateEncoder: Encoder[LocalDate] = IntEncoder.comap[LocalDate](_.toEpochDay.toInt)
   implicit val InstantEncoder: Encoder[Instant] = LongEncoder.comap[Instant](_.toEpochMilli)
   implicit val LocalDateTimeEncoder: Encoder[LocalDateTime] = InstantEncoder.comap[LocalDateTime](_.toInstant(ZoneOffset.UTC))

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
@@ -142,7 +142,7 @@ object SchemaFor {
   }
 
   implicit object LocalTimeSchemaFor extends SchemaFor[LocalTime] {
-    override def schema(fieldMapper: FieldMapper): Schema = LogicalTypes.timeMillis().addToSchema(SchemaBuilder.builder.intType)
+    override def schema(fieldMapper: FieldMapper): Schema = LogicalTypes.timeMillis().addToSchema(SchemaBuilder.builder.intType())
   }
 
   implicit object LocalDateSchemaFor extends SchemaFor[LocalDate] {

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
@@ -142,7 +142,7 @@ object SchemaFor {
   }
 
   implicit object LocalTimeSchemaFor extends SchemaFor[LocalTime] {
-    override def schema(fieldMapper: FieldMapper): Schema = LogicalTypes.timeMillis().addToSchema(SchemaBuilder.builder.intType())
+    override def schema(fieldMapper: FieldMapper): Schema = LogicalTypes.timeMicros().addToSchema(SchemaBuilder.builder.longType())
   }
 
   implicit object LocalDateSchemaFor extends SchemaFor[LocalDate] {

--- a/avro4s-core/src/test/resources/localdatetime.json
+++ b/avro4s-core/src/test/resources/localdatetime.json
@@ -1,13 +1,13 @@
 {
   "type": "record",
-  "name": "LocalTimeTest",
+  "name": "LocalDateTimeTest",
   "namespace": "com.sksamuel.avro4s.schema.DateSchemaTest",
   "fields": [
     {
       "name": "time",
       "type": {
-        "type": "int",
-        "logicalType": "time-millis"
+        "type": "long",
+        "logicalType": "timestamp-millis"
       }
     }
   ]

--- a/avro4s-core/src/test/resources/localtime.json
+++ b/avro4s-core/src/test/resources/localtime.json
@@ -6,8 +6,8 @@
     {
       "name": "time",
       "type": {
-        "type": "int",
-        "logicalType": "time-millis"
+        "type": "long",
+        "logicalType": "time-micros"
       }
     }
   ]

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/GithubIssue387.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/GithubIssue387.scala
@@ -8,7 +8,7 @@ import org.scalatest.{Matchers, WordSpec}
 
 class GithubIssue387 extends WordSpec with Matchers {
 
-  val NANOSECONDS_IN_A_MILLISECOND = 1000000
+  val NANOSECONDS_IN_A_MICROSECOND = 1000
 
   "LocalTime" must {
 
@@ -19,7 +19,7 @@ class GithubIssue387 extends WordSpec with Matchers {
         AvroSchema[LocalTime],
         DefaultFieldMapper
       )
-      encoded shouldBe localTime.toNanoOfDay / NANOSECONDS_IN_A_MILLISECOND
+      encoded shouldBe localTime.toNanoOfDay / NANOSECONDS_IN_A_MICROSECOND
     }
 
     "encode the value and truncate any precision beyond milliseconds" in {
@@ -28,10 +28,10 @@ class GithubIssue387 extends WordSpec with Matchers {
         AvroSchema[LocalTime],
         DefaultFieldMapper
       )
-      encoded shouldBe LocalTime.MAX.toNanoOfDay / NANOSECONDS_IN_A_MILLISECOND
+      encoded shouldBe LocalTime.MAX.toNanoOfDay / NANOSECONDS_IN_A_MICROSECOND
     }
 
-    "encode and decode back to an equivalent LocalTime object when Local has millisecond precision" in {
+    "encode and decode back to an equivalent LocalTime object when Local has microsecond precision" in {
       val localTime = LocalTime.now()
       val encoded = Encoder[LocalTime].encode(
         localTime,
@@ -47,7 +47,7 @@ class GithubIssue387 extends WordSpec with Matchers {
       decoded.toNanoOfDay shouldBe localTime.toNanoOfDay
     }
 
-    "encode and decode back to a LocalTime object with an equivalent time to  millisecond precision" in {
+    "encode and decode back to a LocalTime object with an equivalent time to  microsecond precision" in {
       val encoded = Encoder[LocalTime].encode(
         LocalTime.MAX,
         AvroSchema[LocalTime],
@@ -60,7 +60,7 @@ class GithubIssue387 extends WordSpec with Matchers {
       )
       decoded should not be LocalTime.MAX
       // compare to a LocalTime.MAX that has had the time precision truncated to milliseconds
-      decoded shouldBe LocalTime.ofNanoOfDay((LocalTime.MAX.toNanoOfDay / NANOSECONDS_IN_A_MILLISECOND) * NANOSECONDS_IN_A_MILLISECOND)
+      decoded shouldBe LocalTime.ofNanoOfDay((LocalTime.MAX.toNanoOfDay / NANOSECONDS_IN_A_MICROSECOND) * NANOSECONDS_IN_A_MICROSECOND)
     }
 
   }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/GithubIssue387.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/GithubIssue387.scala
@@ -1,0 +1,68 @@
+package com.sksamuel.avro4s.github
+
+import java.time.LocalTime
+
+import com.sksamuel.avro4s
+import com.sksamuel.avro4s.{AvroSchema, Decoder, DefaultFieldMapper, Encoder}
+import org.scalatest.{Matchers, WordSpec}
+
+class GithubIssue387 extends WordSpec with Matchers {
+
+  val NANOSECONDS_IN_A_MILLISECOND = 1000000
+
+  "LocalTime" must {
+
+    "encode the value to a int represented as milliseconds since midnight" in {
+      val localTime = LocalTime.now()
+      val encoded = Encoder[LocalTime].encode(
+        localTime,
+        AvroSchema[LocalTime],
+        DefaultFieldMapper
+      )
+      encoded shouldBe localTime.toNanoOfDay / NANOSECONDS_IN_A_MILLISECOND
+    }
+
+    "encode the value and truncate any precision beyond milliseconds" in {
+      val encoded = Encoder[LocalTime].encode(
+        LocalTime.MAX,
+        AvroSchema[LocalTime],
+        DefaultFieldMapper
+      )
+      encoded shouldBe LocalTime.MAX.toNanoOfDay / NANOSECONDS_IN_A_MILLISECOND
+    }
+
+    "encode and decode back to an equivalent LocalTime object when Local has millisecond precision" in {
+      val localTime = LocalTime.now()
+      val encoded = Encoder[LocalTime].encode(
+        localTime,
+        AvroSchema[LocalTime],
+        DefaultFieldMapper
+      )
+      val decoded = Decoder[LocalTime].decode(
+        encoded,
+        AvroSchema[LocalTime],
+        avro4s.DefaultFieldMapper
+      )
+      decoded shouldBe localTime
+      decoded.toNanoOfDay shouldBe localTime.toNanoOfDay
+    }
+
+    "encode and decode back to a LocalTime object with an equivalent time to  millisecond precision" in {
+      val encoded = Encoder[LocalTime].encode(
+        LocalTime.MAX,
+        AvroSchema[LocalTime],
+        DefaultFieldMapper
+      )
+      val decoded = Decoder[LocalTime].decode(
+        encoded,
+        AvroSchema[LocalTime],
+        avro4s.DefaultFieldMapper
+      )
+      decoded should not be LocalTime.MAX
+      // compare to a LocalTime.MAX that has had the time precision truncated to milliseconds
+      decoded shouldBe LocalTime.ofNanoOfDay((LocalTime.MAX.toNanoOfDay / NANOSECONDS_IN_A_MILLISECOND) * NANOSECONDS_IN_A_MILLISECOND)
+    }
+
+  }
+
+}

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/DateDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/DateDecoderTest.scala
@@ -20,7 +20,7 @@ class DateDecoderTest extends FunSuite with Matchers {
   test("decode int to LocalTime") {
     val schema = AvroSchema[WithLocalTime]
     val record = new GenericData.Record(schema)
-    record.put("z", 46245000)
+    record.put("z", 46245000000L)
     Decoder[WithLocalTime].decode(record, schema, DefaultFieldMapper) shouldBe WithLocalTime(LocalTime.of(12, 50, 45))
   }
 

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/DateEncoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/DateEncoderTest.scala
@@ -12,7 +12,7 @@ class DateEncoderTest extends FunSuite with Matchers {
   test("encode LocalTime as TIME-MILLIS") {
     case class Foo(s: LocalTime)
     val schema = AvroSchema[Foo]
-    Encoder[Foo].encode(Foo(LocalTime.of(12, 50, 45)), schema, DefaultFieldMapper) shouldBe ImmutableRecord(schema, Vector(java.lang.Integer.valueOf(46245000)))
+    Encoder[Foo].encode(Foo(LocalTime.of(12, 50, 45)), schema, DefaultFieldMapper) shouldBe ImmutableRecord(schema, Vector(java.lang.Long.valueOf(46245000000L)))
   }
 
   test("encode LocalDate as DATE") {

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/DateSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/DateSchemaTest.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.avro4s.schema
 
 import java.sql.{Date, Timestamp}
-import java.time.{Instant, LocalDate, LocalTime}
+import java.time.{Instant, LocalDate, LocalDateTime, LocalTime}
 
 import com.sksamuel.avro4s.AvroSchema
 import org.scalatest.{FunSuite, Matchers}
@@ -30,9 +30,9 @@ class DateSchemaTest extends FunSuite with Matchers {
   }
 
   test("generate time logical type for LocalDateTime") {
-    case class LocalTimeTest(time: LocalTime)
+    case class LocalDateTimeTest(time: LocalDateTime)
     val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/localdatetime.json"))
-    val schema = AvroSchema[LocalTimeTest]
+    val schema = AvroSchema[LocalDateTimeTest]
     schema.toString(true) shouldBe expected.toString(true)
   }
 


### PR DESCRIPTION
~~Fixed the Encoder for LocalTime objects to properly convert from nanoseconds to millisseconds. Nano second values are truncated to the millisecond precision. LocalTime.now() produces millisecond precision values by default so the schema and encoder/decoder are inline with default functionality of the LocalTime object even though LocalTime does allow for a higher level of precision.~~

In Java8 the default functionality of LocalTime.now() produces millisecond precision, however, in Java11 it produces microsecond precision.  I change the logical type of LocalTime to be `time-micros` and updated the encoder and tests accordingly.