### PR TITLE
ISSUE-389 | Add support for OffsetDateTime

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/Decoder.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/Decoder.scala
@@ -3,7 +3,8 @@ package com.sksamuel.avro4s
 import DecoderHelper.tryDecode
 import java.nio.ByteBuffer
 import java.sql.{Date, Timestamp}
-import java.time.{Instant, LocalDate, LocalDateTime, LocalTime, ZoneOffset}
+import java.time.format.DateTimeFormatter
+import java.time.{Instant, LocalDate, LocalDateTime, LocalTime, OffsetDateTime, ZoneOffset}
 import java.util.UUID
 
 import magnolia.{CaseClass, Magnolia, SealedTrait}
@@ -159,6 +160,11 @@ object Decoder {
           }
       }
     }
+  }
+
+  implicit object OffsetDateTimeDecoder extends Decoder[OffsetDateTime] {
+    override def decode(value: Any, schema: Schema, fieldMapper: FieldMapper) =
+      OffsetDateTime.parse(value.toString, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
   }
 
   implicit val LocalDateTimeDecoder: Decoder[LocalDateTime] = LongDecoder.map(millis => LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneOffset.UTC))

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/Encoder.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/Encoder.scala
@@ -2,7 +2,8 @@ package com.sksamuel.avro4s
 
 import java.nio.ByteBuffer
 import java.sql.{Date, Timestamp}
-import java.time.{Instant, LocalDate, LocalDateTime, LocalTime, ZoneOffset}
+import java.time.format.DateTimeFormatter
+import java.time.{Instant, LocalDate, LocalDateTime, LocalTime, OffsetDateTime, ZoneOffset}
 import java.util
 import java.util.UUID
 
@@ -96,6 +97,11 @@ object Encoder {
 
   implicit object NoneEncoder extends Encoder[None.type] {
     override def encode(t: None.type, schema: Schema, fieldMapper: FieldMapper): AnyRef = null
+  }
+
+  implicit object OffsetDateTimeEncoder extends Encoder[OffsetDateTime] {
+    override def encode(value: OffsetDateTime, schema: Schema, fieldMapper: FieldMapper) =
+      value.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
   }
 
   implicit val UUIDEncoder: Encoder[UUID] = StringEncoder.comap[UUID](_.toString)

--- a/avro4s-core/src/test/resources/github/github_389.json
+++ b/avro4s-core/src/test/resources/github/github_389.json
@@ -1,0 +1,1 @@
+{"type":"string","logicalType":"datetime-with-offset"}

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/GithubIssue389.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/GithubIssue389.scala
@@ -1,0 +1,72 @@
+package com.sksamuel.avro4s.github
+
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+
+import com.sksamuel.avro4s.{AvroSchema, Decoder, DefaultFieldMapper, Encoder}
+import org.scalatest.{Matchers, WordSpec}
+
+class GithubIssue389 extends WordSpec with Matchers {
+
+  "OffsetDateTime" must {
+
+    val NOW = OffsetDateTime.now()
+    val MAX = OffsetDateTime.MAX
+    val MIN = OffsetDateTime.MIN
+
+    "generate a schema with a logical type backed by a string" in {
+      val schema = AvroSchema[OffsetDateTime]
+      val expected = new org.apache.avro.Schema.Parser().parse(this.getClass.getResourceAsStream("/github/github_389.json"))
+      schema shouldBe expected
+    }
+
+    "encode to an iso formatted String" in {
+      def testEncode(datetime: OffsetDateTime): Unit = {
+        val encoded = Encoder[OffsetDateTime].encode(
+          datetime,
+          AvroSchema[OffsetDateTime],
+          DefaultFieldMapper
+        )
+        encoded shouldBe datetime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+      }
+      testEncode(NOW)
+      testEncode(MAX)
+      testEncode(MIN)
+    }
+
+    "decode an iso formatted String to an equivalent OffsetDatetime object" in {
+      def testDecode(datetime: OffsetDateTime): Unit = {
+        val dateTimeString = datetime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+        val decoder = Decoder[OffsetDateTime].decode(
+          dateTimeString,
+          AvroSchema[OffsetDateTime],
+          DefaultFieldMapper
+        )
+        decoder shouldBe datetime
+      }
+      testDecode(NOW)
+      testDecode(MAX)
+      testDecode(MIN)
+    }
+
+    "round trip encode and decode into an equivalent object" in {
+      def testRoundTrip(datetime: OffsetDateTime): Unit = {
+        val encoded = Encoder[OffsetDateTime].encode(
+          datetime,
+          AvroSchema[OffsetDateTime],
+          DefaultFieldMapper
+        )
+        val decoded = Decoder[OffsetDateTime].decode(
+          encoded,
+          AvroSchema[OffsetDateTime],
+          DefaultFieldMapper
+        )
+        decoded shouldBe datetime
+      }
+      testRoundTrip(NOW)
+      testRoundTrip(MAX)
+      testRoundTrip(MIN)
+    }
+
+  }
+}


### PR DESCRIPTION
Added support for OffsetDateTime objects. Created a custom logical type 'datetime-with-offset' that is backed by string. OffsetDateTimes are encoded by converting them to a String using the DateTimeFormatter.ISO_OFFSET_DATE_TIME . Example Avro schema can be found in test/resources/github/github_389.json.