### PR TITLE
add the possibility to define custom default values

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/AnnotationExtractors.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/AnnotationExtractors.scala
@@ -21,6 +21,7 @@ class AnnotationExtractors(annos: Seq[Any]) {
   def fixed: Option[Int] = findFirst[AvroFixable].map(_.size)
   def name: Option[String] = findFirst[AvroNameable].map(_.name).filterNot(_.trim.isEmpty)
   def sortPriority: Option[Float] = findFirst[AvroSortPriority].map(_.priority)
+  def defaultValue: Option[String] = findFirst[AvroDefault].map(_.value)
 
   def enumDefault: Option[Any] = findFirst[AvroEnumDefault].map(_.default)
 

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/DefaultResolver.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/DefaultResolver.scala
@@ -8,6 +8,7 @@ import org.apache.avro.generic.{GenericEnumSymbol, GenericFixed}
 import org.apache.avro.util.Utf8
 import org.apache.avro.{Conversions, Schema}
 import CustomDefaults._
+import org.apache.avro.Schema.Type._
 import scala.collection.JavaConverters._
 
 /**
@@ -20,6 +21,25 @@ import scala.collection.JavaConverters._
   * suitable for Avro and the provided schema.
   */
 object DefaultResolver {
+
+  /**
+    * Tries to transform the value into something compatible with the schema
+    *
+    * If the cleverness doesn't work, return the value as-is
+    *
+    * @param value the value to transform, as a String
+    * @param schema the target schema, determining what type we want for the value
+    * @return the value in the most compatible form possible for the schema
+    */
+  def resolve(value: String, schema: Schema): Any = schema.getType match {
+    case INT => value.toInt
+    case LONG => value.toLong
+    case FLOAT => value.toFloat
+    case DOUBLE => value.toDouble
+    case BOOLEAN => value.toBoolean
+    case STRING => value
+    case _ => value
+  }
 
   def apply(value: Any, schema: Schema): AnyRef = value match {
     case Some(x) => apply(x, schema)
@@ -38,7 +58,7 @@ object DefaultResolver {
     case x: scala.Int => java.lang.Integer.valueOf(x)
     case x: scala.Double => java.lang.Double.valueOf(x)
     case x: scala.Float => java.lang.Float.valueOf(x)
-    case x: Map[_,_] => x.asJava
+    case x: Map[_, _] => x.asJava
     case x: Seq[_] => x.asJava
     case p: Product => customDefault(p, schema)
     case v if isScalaEnumeration(v) => customScalaEnumDefault(value)

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/annotations.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/annotations.scala
@@ -86,7 +86,6 @@ trait AvroProperty extends AvroFieldReflection {
   val value: String
 }
 
-
 /**
   * This annotation is used to disable generics in the encoding
   * of a record's name.
@@ -120,3 +119,5 @@ sealed trait AvroFieldReflection extends StaticAnnotation {
 case class AvroSortPriority(priority: Float) extends AvroFieldReflection
 
 case class AvroEnumDefault(default: Any) extends StaticAnnotation
+
+case class AvroDefault(value: String) extends StaticAnnotation

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/Github378.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/Github378.scala
@@ -1,0 +1,76 @@
+package com.sksamuel.avro4s.github
+
+import java.time.ZonedDateTime
+
+import com.sksamuel.avro4s.{AvroDefault, AvroName, AvroSchema, Decoder, Encoder, FieldMapper, SchemaFor}
+import org.apache.avro.{Schema, SchemaBuilder}
+import org.scalatest.{FunSuite, Matchers}
+
+class Github378 extends FunSuite with Matchers {
+
+  implicit object ZonedDateTimeSchemaFor extends SchemaFor[ZonedDateTime] {
+    override def schema(fieldMapper: FieldMapper): Schema =
+      SchemaBuilder.builder.stringType
+  }
+
+  implicit object ZonedDateTimeEncoder extends Encoder[ZonedDateTime] {
+    override def encode(t: ZonedDateTime, schema: Schema, fieldMapper: FieldMapper): AnyRef =
+      t.toString
+  }
+
+  implicit object ZonedDateTimeDecoder extends Decoder[ZonedDateTime] {
+    override def decode(value: Any, schema: Schema, fieldMapper: FieldMapper): ZonedDateTime =
+      ZonedDateTime.parse(value.toString)
+  }
+
+  test("Error building schemas with custom types serialized as Strings") {
+    AvroSchema[Github378Model] should be (AvroSchema[Github378ModelAsString])
+  }
+
+  test("default values with int type") {
+    AvroSchema[Github378IntModel] should be(AvroSchema[Github378IntWithAnnotationModel])
+  }
+
+  test("default values with long type") {
+    AvroSchema[Github378LongModel] should be(AvroSchema[Github378LongWithAnnotationModel])
+  }
+
+  test("default values with float type") {
+    AvroSchema[Github378FloatModel] should be(AvroSchema[Github378FloatWithAnnotationModel])
+  }
+
+  test("default values with double type") {
+    AvroSchema[Github378DoubleModel] should be(AvroSchema[Github378DoubleWithAnnotationModel])
+  }
+
+  test("default values with boolean type") {
+    AvroSchema[Github378BooleanModel] should be(AvroSchema[Github378BooleanWithAnnotationModel])
+  }
+}
+
+final case class Github378Model(@AvroDefault("2019-11-26T18:22:36.519Z") date: ZonedDateTime)
+@AvroName("Github378Model")
+final case class Github378ModelAsString(date: String = "2019-11-26T18:22:36.519Z")
+
+final case class Github378IntModel(value: Int = 42)
+@AvroName("Github378IntModel")
+final case class Github378IntWithAnnotationModel(@AvroDefault("42") value: Int)
+
+final case class Github378LongModel(value: Long = 42L)
+@AvroName("Github378LongModel")
+final case class Github378LongWithAnnotationModel(@AvroDefault("42") value: Long)
+
+final case class Github378FloatModel(value: Float = 42.0F)
+@AvroName("Github378FloatModel")
+final case class Github378FloatWithAnnotationModel(@AvroDefault("42") value: Float)
+
+final case class Github378DoubleModel(value: Double = 42.0D)
+@AvroName("Github378DoubleModel")
+final case class Github378DoubleWithAnnotationModel(@AvroDefault("42") value: Double)
+
+final case class Github378BooleanModel(value: Boolean = true)
+@AvroName("Github378BooleanModel")
+final case class Github378BooleanWithAnnotationModel(@AvroDefault("true") value: Boolean)
+
+
+


### PR DESCRIPTION
Use @AvroDefault to define default values that cannot be resolved
correctly with default value resolution, ie. if the type is not one well
known by avro or handled by abro4s natively, like uuids

closes #378 