### PR TITLE
recursively resolve default values

### DIFF
--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/Github411.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/Github411.scala
@@ -1,0 +1,16 @@
+package com.sksamuel.avro4s.github
+
+import com.sksamuel.avro4s.{DefaultFieldMapper, SchemaFor}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class Github411  extends AnyFunSuite with Matchers {
+
+  case class DefaultOfDefault(value: String)
+  case class DefaultValue(property: DefaultOfDefault = DefaultOfDefault("some-default"))
+  case class Github411Class(property: DefaultValue = DefaultValue())
+
+  test("schema generation with defaults in defaults") {
+    SchemaFor[Github411Class].schema(DefaultFieldMapper).toString(true)
+  }
+}


### PR DESCRIPTION
if a default value is a case class with default values, they were not
correctly handled.

Use the default resolver back to resolve the default value in the
default value recursively

Known issue: at some point, we need the type name if the schema is a
union. The name used here does't resolve the correct name if an
@AvroName annotation is used on the class. Same applies on the field
name, no FieldMapper is applied.

Also, in `CustomUnionDefault` some code left me a bit puzzled, so I changed it to what seemed the right thing

```scala
        CustomUnionDefault(trimmedClassName(p), parse(write(p)).extract[Map[String, Any]].mapValues {
          case (name, b: BigInt) if b.isValidInt => b.intValue: Any
          case (name, b: BigInt) if b.isValidLong => b.longValue: Any
        }
```
changed to:

```scala
        CustomUnionDefault(trimmedClassName(p), parse(write(p)).extract[Map[String, Any]].map {
          case (name, b: BigInt) if b.isValidInt => name -> b.intValue
          case (name, b: BigInt) if b.isValidLong => name -> b.longValue
        }
```
The unit test only checks that no exception is thrown when generating the schema