### PR TITLE
extends Serializable

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/SafeFrom.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/SafeFrom.scala
@@ -4,7 +4,7 @@ import org.apache.avro.Schema
 import org.apache.avro.generic.{GenericContainer, GenericData}
 import org.apache.avro.util.Utf8
 
-protected abstract class SafeFrom[T: Decoder] {
+protected abstract class SafeFrom[T: Decoder] extends Serializable {
   val decoder: Decoder[T] = implicitly[Decoder[T]]
   def safeFrom(value: Any, schema: Schema, fieldMapper: FieldMapper): Option[T]
 }


### PR DESCRIPTION
fix the exception when use avro4s in Spark:(#419)
`Caused by: java.io.NotSerializableException: com.sksamuel.avro4s.SafeFrom$$anon$9
Serialization stack:
	- object not serializable (class: com.sksamuel.avro4s.SafeFrom$$anon$9, value: com.sksamuel.avro4s.SafeFrom$$anon$9@59e320ea)
	- field (class: com.sksamuel.avro4s.Decoder$$anon$18, name: safeFromS, type: class com.sksamuel.avro4s.SafeFrom)
	- object (class com.sksamuel.avro4s.Decoder$$anon$18, com.sksamuel.avro4s.Decoder$$anon$18@2dfd2c1b)
	- field (class: com.sksamuel.avro4s.Decoder$$anon$18, name: decoder$3, type: interface com.sksamuel.avro4s.Decoder)
	- object (class com.sksamuel.avro4s.Decoder$$anon$18, com.sksamuel.avro4s.Decoder$$anon$18@55cad944)`