### PR TITLE
Improve encoding / decoding performance by caching

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/SchemaHelper.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/SchemaHelper.scala
@@ -19,6 +19,8 @@ object SchemaHelper {
     case _ => None
   }
 
+  private val arrayTypeNamePattern: Regex = "scala.collection.immutable.::(__B)?".r
+
   def extractTraitSubschema(fullName: String, schema: Schema): Schema = matchPrimitiveName(fullName) getOrElse {
     require(schema.getType == Schema.Type.UNION, s"Can only extract subschemas from a UNION but was given $schema")
 
@@ -29,7 +31,6 @@ object SchemaHelper {
 
     // if we are looking for an array type then find "array" first
     // this is totally not FP but what the heck it's late and it's perfectly valid
-    val arrayTypeNamePattern: Regex = "scala.collection.immutable.::(__B)?".r
     arrayTypeNamePattern.findFirstMatchIn(fullName) match {
       case Some(_) => return types.asScala.find(_.getType == Schema.Type.ARRAY).getOrElse(sys.error(s"Could not find array type to match $fullName"))
       case None =>


### PR DESCRIPTION
NameExtractors are expensive to build; this caches the instances.
Also, SchemaHelper.extractTraitSubschema compiles the same regex on each
call, this is now extracted.

Relates to issue #422 