### PR TITLE
Improve encoding / decoding performance

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/Decoder.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/Decoder.scala
@@ -437,8 +437,8 @@ object Decoder {
 
   def dispatch[T](ctx: SealedTrait[Typeclass, T]): Decoder[T] = {
     val nameExtractors = ctx.subtypes.map(s => s -> NameExtractor(s.typeName, s.annotations ++ ctx.annotations)).toMap
-    val nameOf = nameExtractors.mapValues(_.name)
-    val fullNameOf = nameExtractors.mapValues(_.fullName)
+    val nameOf = nameExtractors.map(kv => kv._1 -> kv._2.name)
+    val fullNameOf = nameExtractors.map(kv => kv._1 -> kv._2.fullName)
 
     new Decoder[T] {
       override def decode(container: Any, schema: Schema, fieldMapper: FieldMapper): T = {

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/Encoder.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/Encoder.scala
@@ -301,8 +301,8 @@ object Encoder {
     // note: that the schema may have a custom name and a custom namespace!
     // note2: the field for the ADT itself may be annotated!
     val nameExtractors = ctx.subtypes.map(s => s -> NameExtractor(s.typeName, s.annotations ++ ctx.annotations)).toMap
-    val nameOf = nameExtractors.mapValues(_.name)
-    val fullNameOf = nameExtractors.mapValues(_.fullName)
+    val nameOf = nameExtractors.map(kv => kv._1 -> kv._2.name)
+    val fullNameOf = nameExtractors.map(kv => kv._1 -> kv._2.fullName)
 
     new Encoder[T] {
       override def encode(t: T, schema: Schema, fieldMapper: FieldMapper): AnyRef = {

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/SchemaHelper.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/SchemaHelper.scala
@@ -19,6 +19,8 @@ object SchemaHelper {
     case _ => None
   }
 
+  private val arrayTypeNamePattern: Regex = "scala.collection.immutable.::(__B)?".r
+
   def extractTraitSubschema(fullName: String, schema: Schema): Schema = matchPrimitiveName(fullName) getOrElse {
     require(schema.getType == Schema.Type.UNION, s"Can only extract subschemas from a UNION but was given $schema")
 
@@ -29,7 +31,6 @@ object SchemaHelper {
 
     // if we are looking for an array type then find "array" first
     // this is totally not FP but what the heck it's late and it's perfectly valid
-    val arrayTypeNamePattern: Regex = "scala.collection.immutable.::(__B)?".r
     arrayTypeNamePattern.findFirstMatchIn(fullName) match {
       case Some(_) => return types.asScala.find(_.getType == Schema.Type.ARRAY).getOrElse(sys.error(s"Could not find array type to match $fullName"))
       case None =>


### PR DESCRIPTION
NameExtractors are expensive to build; this pre-computes the
names and fullnames needed outside of encoding / decoding.
Also, SchemaHelper.extractTraitSubschema compiles the same regex on each
call, this is now extracted.
Also, removed unused code.

Benchmark results:
```
::Benchmark avro4s union type with type param encoding:: 0.005265 ms
::Benchmark avro4s union type with type param decoding:: 0.00267 ms
```

Encoding speedup is x 2.6, decoding speedup is x 4.8.

Flame graphs.

Encoding before:
<img width="1566" alt="Encode before refactoring" src="https://user-images.githubusercontent.com/6724788/71765226-253dec80-2ef2-11ea-814b-3120cb663338.png">

Encoding after:
<img width="1568" alt="Encode after refactoring" src="https://user-images.githubusercontent.com/6724788/71765227-2bcc6400-2ef2-11ea-9cab-239d50c08fcd.png">

Decoding before:
<img width="1565" alt="Decode before refactoring" src="https://user-images.githubusercontent.com/6724788/71765228-338c0880-2ef2-11ea-950f-e24229684606.png">

Decoding after:
<img width="1262" alt="Decode after refactoring" src="https://user-images.githubusercontent.com/6724788/71765230-3c7cda00-2ef2-11ea-9579-5d79cc36c1e5.png">
