### PR TITLE
Improve AvroBinaryInputStream by using GenericData singleton

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroBinaryInputStream.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroBinaryInputStream.scala
@@ -3,7 +3,7 @@ package com.sksamuel.avro4s
 import java.io.InputStream
 
 import org.apache.avro.Schema
-import org.apache.avro.generic.{GenericData, GenericDatumReader, GenericRecord}
+import org.apache.avro.generic.{GenericDatumReader, GenericRecord}
 import org.apache.avro.io.DecoderFactory
 
 import scala.util.Try
@@ -22,7 +22,7 @@ class AvroBinaryInputStream[T](in: InputStream,
                                fieldMapper: FieldMapper = DefaultFieldMapper)
                               (implicit decoder: Decoder[T]) extends AvroInputStream[T] {
 
-  private val datumReader = new GenericDatumReader[GenericRecord](writerSchema, readerSchema, new GenericData)
+  private val datumReader = new GenericDatumReader[GenericRecord](writerSchema, readerSchema)
   private val avroDecoder = DecoderFactory.get().binaryDecoder(in, null)
 
   private val _iter = new Iterator[GenericRecord] {


### PR DESCRIPTION
Improve AvroBinaryInputStream by using GenericDatumReader constructor with GenericData singleton instead of creating new instances of GenericData.

https://github.com/apache/avro/blob/4cd778a7e0de048eacf2a06abe3d0e310bbcc343/lang/java/avro/src/main/java/org/apache/avro/generic/GenericDatumReader.java#L61