### PR TITLE
Support shapeless coproduct fields with default values

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/DefaultResolver.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/DefaultResolver.scala
@@ -40,6 +40,7 @@ object DefaultResolver {
     case x: scala.Float => java.lang.Float.valueOf(x)
     case x: Map[_,_] => x.asJava
     case x: Seq[_] => x.asJava
+    case shapeless.Inl(x) => apply(x, schema)
     case p: Product => customDefault(p, schema)
     case v if isScalaEnumeration(v) => customScalaEnumDefault(value)
     case _ =>

--- a/avro4s-core/src/test/resources/coproduct_with_default.json
+++ b/avro4s-core/src/test/resources/coproduct_with_default.json
@@ -1,0 +1,26 @@
+{
+  "type": "record",
+  "name": "CPWithDefault",
+  "namespace": "com.sksamuel.avro4s.schema",
+  "fields": [
+    {
+      "name": "u",
+      "type": [
+        "int",
+        "string",
+        "boolean",
+        {
+          "type": "record",
+          "name": "Gimble",
+          "fields": [
+            {
+              "name": "x",
+              "type": "string"
+            }
+          ]
+        }
+      ],
+      "default": 123
+    }
+  ]
+}

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/CoproductSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/CoproductSchemaTest.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.avro4s.schema
 
 import com.sksamuel.avro4s.AvroSchema
-import shapeless.{:+:, CNil}
+import shapeless.{:+:, Coproduct, CNil}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
@@ -24,11 +24,18 @@ class CoproductSchemaTest extends AnyFunSuite with Matchers {
     val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/coproduct_of_coproducts.json"))
     coproductOfCoproducts.toString(true) shouldBe expected.toString(true)
   }
+
+  test("coproducts with default arguments") {
+    val schema = AvroSchema[CPWithDefault]
+    val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/coproduct_with_default.json"))
+    schema.toString(true) shouldBe expected.toString(true)
+  }
 }
 
 case class Gimble(x: String)
 case class CPWrapper(u: CPWrapper.ISBG)
 case class CPWithOption(u: Option[CPWrapper.ISBG])
+case class CPWithDefault(u: CPWrapper.ISBG = Coproduct[CPWrapper.ISBG](123))
 object CPWrapper {
   type ISBG = Int :+: String :+: Boolean :+: Gimble :+: CNil
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/CoproductSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/CoproductSchemaTest.scala
@@ -9,27 +9,31 @@ class CoproductSchemaTest extends AnyFunSuite with Matchers {
 
   test("coproducts") {
     val schema = AvroSchema[CPWrapper]
-    val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/coproduct.json"))
+    val expected = parseSchema("/coproduct.json")
     schema.toString(true) shouldBe expected.toString(true)
   }
 
   test("options of coproducts") {
     val schema = AvroSchema[CPWithOption]
-    val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/coproduct_option.json"))
+    val expected = parseSchema("/coproduct_option.json")
     schema.toString(true) shouldBe expected.toString(true)
   }
 
   test("support coproducts of coproducts") {
     val coproductOfCoproducts = AvroSchema[CoproductOfCoproducts]
-    val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/coproduct_of_coproducts.json"))
+    val expected = parseSchema("/coproduct_of_coproducts.json")
     coproductOfCoproducts.toString(true) shouldBe expected.toString(true)
   }
 
   test("coproducts with default arguments") {
     val schema = AvroSchema[CPWithDefault]
-    val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/coproduct_with_default.json"))
+    val expected = parseSchema("/coproduct_with_default.json")
     schema.toString(true) shouldBe expected.toString(true)
   }
+
+  def parseSchema(resourcePath: String) =
+    new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream(resourcePath))
+
 }
 
 case class Gimble(x: String)


### PR DESCRIPTION
Support for schema generation for fields with shapeless Coproduct type and default value.

Note that we only support `Inl(...)`, not `Inr(...(Inl(...)))`, because "the type of the default value must match the first element of the union" (quoted from the [Avro spec](https://avro.apache.org/docs/current/spec.html#Unions)).

Without the `Inl(x)` case added to `DefaultResolver`, the pattern match falls into the `Product` case and the test fails with:

```
org.apache.avro.AvroTypeException: Invalid default for field u: {"head":123} not a ["int","string","boolean",{"type":"record","name":"Gimble","namespace":"com.sksamuel.avro4s.schema","fields":[{"name":"x","type":"string"}]}]
```