### PR TITLE
#441 Changed the implementation of the TypeInfo.fromTypeName method t…

### DIFF
--- a/avro4s-core/src/test/resources/deeply_nested_generic_with_value_type.json
+++ b/avro4s-core/src/test/resources/deeply_nested_generic_with_value_type.json
@@ -1,0 +1,12 @@
+{
+  "type" : "record",
+  "name" : "Generic__Option__Seq__Thing1Id",
+  "namespace" : "com.sksamuel.avro4s.schema.GenericSchemaTest",
+  "fields" : [ {
+    "name" : "t",
+    "type" : [ "null", {
+      "type" : "array",
+      "items" : "int"
+    } ]
+  } ]
+}

--- a/avro4s-core/src/test/resources/deeply_nested_generics.json
+++ b/avro4s-core/src/test/resources/deeply_nested_generics.json
@@ -1,0 +1,45 @@
+{
+  "type" : "record",
+  "name" : "Outer__Thing1Id_Option__Seq__Thing2",
+  "namespace" : "com.sksamuel.avro4s.schema",
+  "fields" : [ {
+    "name" : "id",
+    "type" : {
+      "type" : "string",
+      "logicalType" : "uuid"
+    }
+  }, {
+    "name" : "innerThing",
+    "type" : {
+      "type" : "record",
+      "name" : "Inner__Thing1Id_Option__Seq__Thing2",
+      "fields" : [ {
+        "name" : "id",
+        "type" : "string"
+      }, {
+        "name" : "left",
+        "type" : "int"
+      }, {
+        "name" : "right",
+        "type" : [ "null", {
+          "type" : "array",
+          "items" : {
+            "type" : "record",
+            "name" : "Thing2",
+            "fields" : [ {
+              "name" : "id",
+              "type" : {
+                "type" : "string",
+                "logicalType" : "uuid"
+              }
+            }, {
+              "name" : "name",
+              "type" : "string"
+            } ]
+          }
+        } ],
+        "default" : null
+      } ]
+    }
+  } ]
+}


### PR DESCRIPTION
I changed the implementation of the `TypeInfo.fromTypeName` method to property generate `TypeInfo` hierarchies for nested generic types. Doing so fixes issue #441 where avro4s was truncating the schema names of deeply nested generic types, resulting in schema names that are not unique.

For example, before the fix, the type `A[B[C]]]` would result in a truncated schema name of `A__B`. With the fix, the name is now `A__B__C`, which correctly reflects the nested type. Likewise, if the type was `A[B[D]]]`, the resulting schema's name is now `A__B__D` and does not conflict with `A[B[C]]]`'s schema name of `A__B__C`.

Added two new schema tests to GenericSchemaTest to test deeply nested generic types. In addition to the new tests passing, all of the existing tests pass as well.