### PR TITLE
fix classloader for decoding in combination with play dev

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/Decoder.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/Decoder.scala
@@ -473,7 +473,7 @@ object Decoder {
                 ctx.subtypes.find { subtype => nameOf(subtype) == str }
                   .getOrElse(sys.error(s"Could not find subtype for enum $str"))
             }
-            val runtimeMirror = universe.runtimeMirror(getClass.getClassLoader)
+            val runtimeMirror = universe.runtimeMirror(Thread.currentThread().getContextClassLoader)
             val module = runtimeMirror.staticModule(subtype.typeName.full)
             val companion = runtimeMirror.reflectModule(module.asModule)
             companion.instance.asInstanceOf[T]

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/Decoder.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/Decoder.scala
@@ -340,7 +340,7 @@ object Decoder {
 
   implicit def scalaEnumDecoder[E <: Enumeration#Value](implicit tag: WeakTypeTag[E]) = new Decoder[E] {
 
-    val mirror: Mirror = runtimeMirror(getClass.getClassLoader)
+    val mirror: Mirror = runtimeMirror(Thread.currentThread().getContextClassLoader)
 
     val enum = tag.tpe match {
       case TypeRef(enumType, _, _) =>

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/TypeInfo.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/TypeInfo.scala
@@ -31,7 +31,7 @@ object TypeInfo {
     // try to populate from the class name, but this may fail if the class is not top level
     // if it does fail then we default back to using what magnolia provides
     val maybeType: Option[universe.Type] = Try {
-      val mirror = universe.runtimeMirror(this.getClass.getClassLoader)
+      val mirror = universe.runtimeMirror(Thread.currentThread().getContextClassLoader)
       val classsym = mirror.staticClass(typeName.full)
       classsym.toType
     }.toOption
@@ -48,7 +48,7 @@ object TypeInfo {
 
   def fromClass[A](klass: Class[A]): TypeInfo = {
     import scala.reflect.runtime.universe
-    val mirror = universe.runtimeMirror(getClass.getClassLoader)
+    val mirror = universe.runtimeMirror(Thread.currentThread().getContextClassLoader)
     val sym = mirror.classSymbol(klass)
     val tpe = sym.toType
     TypeInfo.fromType(tpe)


### PR DESCRIPTION
Thanks for the great library! As before, I discovered another bug related to decoding sealed traits/enums in combination with the Play classloader. I changed every reference to getClass.getClassLoader I could find to Thread.currentThread().getContextClassLoader.