### PR TITLE
Generic serdes

### DIFF
--- a/README.md
+++ b/README.md
@@ -916,6 +916,27 @@ val format = RecordFormat[Composer]
 val ennio = format.from(record)
 ```
 
+## Usage as a Kafka Serde
+
+The [com.sksamuel.avro4s.kafka.GenericSerde](src/main/scala/com/sksamuel/avro4s/kafka/GenericSerde.scala) class can be used as a Kafka Serdes to serialize/deserialize case classes into Avro records with Avro4s.
+Note that this class is not integrated with the schema registry.
+
+```scala
+
+  import java.util.Properties
+  import org.apache.kafka.clients.CommonClientConfigs
+  import org.apache.kafka.clients.producer.ProducerConfig
+
+  case class TheKafkaKey(id: String)
+  case class TheKafkaValue(name: String, location: String)
+
+  val producerProps = new Properties();
+  producerProps.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "...")
+  producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, new GenericSerde[TheKafkaKey]())
+  producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, new GenericSerde[TheKafkaValue]())
+  new ProducerConfig(producerProps)
+```
+
 ## Type Mappings
 
 Avro4s defines two typeclasses, `Encoder` and `Decoder` which do the work

--- a/README.md
+++ b/README.md
@@ -926,14 +926,15 @@ Note that this class is not integrated with the schema registry.
   import java.util.Properties
   import org.apache.kafka.clients.CommonClientConfigs
   import org.apache.kafka.clients.producer.ProducerConfig
+  import com.sksamuel.avro4s.BinaryFormat
 
   case class TheKafkaKey(id: String)
   case class TheKafkaValue(name: String, location: String)
 
   val producerProps = new Properties();
   producerProps.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "...")
-  producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, new GenericSerde[TheKafkaKey]())
-  producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, new GenericSerde[TheKafkaValue]())
+  producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, new GenericSerde[TheKafkaKey](BinaryFormat))
+  producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, new GenericSerde[TheKafkaValue](BinaryFormat))
   new ProducerConfig(producerProps)
 ```
 

--- a/avro4s-kafka/src/test/scala/com/sksamuel/avro4s/kafka/GenericSerdeTest.scala
+++ b/avro4s-kafka/src/test/scala/com/sksamuel/avro4s/kafka/GenericSerdeTest.scala
@@ -1,0 +1,56 @@
+package com.sksamuel.avro4s.kafka
+
+import com.sksamuel.avro4s.{BinaryFormat, DataFormat, JsonFormat}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+case class TheKafkaValue(name: String, location: String)
+
+class GenericSerdeTest extends AnyFlatSpec with Matchers {
+
+  val someValue = TheKafkaValue("the name", "the location")
+
+  "serialization with default binary avro format" should " be identical to binary format" in  {
+    val defaultSerde = new GenericSerde[TheKafkaValue]()
+    val binarySerde = new GenericSerde[TheKafkaValue](BinaryFormat)
+
+    defaultSerde.serialize("any-topic", someValue) shouldBe binarySerde.serialize("any-topic", someValue)
+  }
+
+  "round trip with default (binary) avro format" should "yield back original data" in  {
+    val defaultSerde = new GenericSerde[TheKafkaValue]()
+
+    defaultSerde.deserialize(
+      "any-topic",
+      defaultSerde.serialize("any-topic", someValue)
+    ) shouldBe someValue
+  }
+
+  "round trip with binary avro format" should "yield back original data" in  {
+    val binarySerde = new GenericSerde[TheKafkaValue](BinaryFormat)
+
+    binarySerde.deserialize(
+      "any-topic",
+      binarySerde.serialize("any-topic", someValue)
+    ) shouldBe someValue
+  }
+
+  "round trip with json avro format" should "yield back original data" in  {
+    val jsonSerde = new GenericSerde[TheKafkaValue](JsonFormat)
+
+    jsonSerde.deserialize(
+      "any-topic",
+      jsonSerde.serialize("any-topic", someValue)
+    ) shouldBe someValue
+  }
+
+  "round trip with data avro format" should "yield back original data" in  {
+    val dataSerde = new GenericSerde[TheKafkaValue](DataFormat)
+
+    dataSerde.deserialize(
+      "any-topic",
+      dataSerde.serialize("any-topic", someValue)
+    ) shouldBe someValue
+  }
+
+}


### PR DESCRIPTION
As discussed in https://github.com/sksamuel/avro4s/issues/447

This MR adds support for Json and Data Avro format in the Kafka `GenericSerde` class and documents its usage `readme.md`. By default, the behaviour is the same as before, i.e usage of `BinaryFormat`.

Behaviour is validated with a few supplementary UT, and I did a quick manual validation with Akka Streams (https://github.com/sv3ndk/kafka-to-rdbms-export-akka-demo/blob/master/src/main/scala/com/svend/demo/DataGenerator.scala#L27).


