### PR TITLE
Fix decoder for coproducts with arrays/maps

### DIFF
--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/CoproductDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/CoproductDecoderTest.scala
@@ -6,6 +6,7 @@ import org.apache.avro.util.Utf8
 import shapeless.{:+:, CNil, Coproduct}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import scala.collection.JavaConverters._
 
 class CoproductDecoderTest extends AnyFunSuite with Matchers {
 
@@ -32,6 +33,14 @@ class CoproductDecoderTest extends AnyFunSuite with Matchers {
     val record = new GenericData.Record(schema)
     record.put("u", gimble)
     Decoder[CPWithOption].decode(record, schema, DefaultFieldMapper) shouldBe CPWithOption(Some(Coproduct[CPWrapper.ISBG](Gimble("foo"))))
+  }
+
+  test("coproduct with array") {
+    val schema = AvroSchema[CPWithArray]
+    val array = new GenericData.Array(AvroSchema[Seq[String]], List(new Utf8("a"), new Utf8("b")).asJava)
+    val record = new GenericData.Record(schema)
+    record.put("u", array)
+    Decoder[CPWithArray].decode(record, schema, DefaultFieldMapper) shouldBe CPWithArray(Coproduct[CPWrapper.SSI](Seq("a", "b")))
   }
 }
 

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/CoproductDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/CoproductDecoderTest.scala
@@ -41,6 +41,7 @@ class CoproductDecoderTest extends AnyFunSuite with Matchers {
     val record = new GenericData.Record(schema)
     record.put("u", array)
     Decoder[CPWithArray].decode(record, schema, DefaultFieldMapper) shouldBe CPWithArray(Coproduct[CPWrapper.SSI](Seq("a", "b")))
+  }
 
   test("coproducts") {
     val schema = AvroSchema[Coproducts]


### PR DESCRIPTION
After upgrading to the latest `mu-scala` release, we also are using avro4s 3.x.
I had some problems with decoding some union types where one of the elements is an array.

It seems we currently are attempting to decode the elements of the union with specific decoders but still with the schema of the complete union.

Here I unfold the schemas for union types and filter to the schemas that make sense for the `SafeFrom` instance that we are building. Then we try them one by one until one of them succeeds, otherwise we throw an error which includes the error messages of all the schemas we have tried.

Today was the first time looking under the cover of `avro4s` so I am not sure if these changes are within the right spirit? I can probably try to clean this up a bit if we think the solution looks OK.