### PR TITLE
Fix nested coproducts

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/SafeFrom.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/SafeFrom.scala
@@ -96,6 +96,16 @@ object SafeFrom {
           }
         }
       }
+    } else if (tpe <:< typeOf[shapeless.Coproduct]) {
+      // this is only sort of safe because we will call SafeFrom again in the decoder
+      new SafeFrom[T] {
+        override def safeFrom(value: Any, schema: Schema, fieldMapper: FieldMapper): Option[T] = {
+          util.Try(decoder.decode(value, schema, fieldMapper)) match {
+            case util.Success(cp) => Some(cp)
+            case _ => None
+          }
+        }
+      }
     } else {
       new SafeFrom[T] {
 

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/CoproductDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/CoproductDecoderTest.scala
@@ -33,6 +33,22 @@ class CoproductDecoderTest extends AnyFunSuite with Matchers {
     record.put("u", gimble)
     Decoder[CPWithOption].decode(record, schema, DefaultFieldMapper) shouldBe CPWithOption(Some(Coproduct[CPWrapper.ISBG](Gimble("foo"))))
   }
+
+  test("coproducts") {
+    val schema = AvroSchema[Coproducts]
+    val record = new GenericData.Record(schema)
+    record.put("union", new Utf8("foo"))
+    val coproduct = Coproduct[Int :+: String :+: Boolean :+: CNil]("foo")
+    Decoder[Coproducts].decode(record, schema, DefaultFieldMapper) shouldBe Coproducts(coproduct)
+  }
+
+  test("coproducts of coproducts") {
+    val schema = AvroSchema[CoproductsOfCoproducts]
+    val record = new GenericData.Record(schema)
+    record.put("union", new Utf8("foo"))
+    val coproduct = Coproduct[(Int :+: String :+: CNil) :+: Boolean :+: CNil](Coproduct[Int :+: String :+: CNil]("foo"))
+    Decoder[CoproductsOfCoproducts].decode(record, schema, DefaultFieldMapper) shouldBe CoproductsOfCoproducts(coproduct)
+  }
 }
 
 case class CPWithArray(u: CPWrapper.SSI)


### PR DESCRIPTION
This feels dirty, but adding a special case for `Coproduct` in `SafeFrom` fixes decoders for nested coproducts.

Maybe we should put this in the `:+:` decoder?