### PR TITLE
Bug/coproduct with enums

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/SchemaHelper.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/SchemaHelper.scala
@@ -46,6 +46,8 @@ object SchemaHelper {
       val s = types.get(i)
       if (s.getFullName == fullName) {
         result = s
+      } else if(s.getType == Schema.Type.ENUM && fullName == "scala.Enumeration.Val") {
+        result = s
       } else if (s.getType == Schema.Type.NULL) {
         nullIndex = i
       }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/CoproductEncoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/CoproductEncoderTest.scala
@@ -1,6 +1,8 @@
 package com.sksamuel.avro4s.record.encoder
 
+import com.sksamuel.avro4s.schema.Colours
 import com.sksamuel.avro4s.{AvroSchema, DefaultFieldMapper, Encoder, ImmutableRecord}
+import org.apache.avro.generic.GenericData.EnumSymbol
 import org.apache.avro.util.Utf8
 import shapeless.{:+:, CNil, Coproduct}
 import org.scalatest.funsuite.AnyFunSuite
@@ -32,6 +34,19 @@ class CoproductEncoderTest extends AnyFunSuite with Matchers {
     Encoder[CPWithArray].encode(CPWithArray(Coproduct[CPWrapper.SSI](Seq("foo", "bar"))), schema, DefaultFieldMapper) shouldBe ImmutableRecord(schema, Vector(java.util.Arrays.asList(new Utf8("foo"), new Utf8("bar"))))
     Encoder[CPWithArray].encode(CPWithArray(Coproduct[CPWrapper.SSI](4)), schema, DefaultFieldMapper) shouldBe ImmutableRecord(schema, Vector(java.lang.Integer.valueOf(4)))
   }
+
+  test("coproducts with enums") {
+    type ColorOrNil = Colours.Value :+: CNil
+    val schema = AvroSchema[CoproductOfEnum]
+    Encoder[CoproductOfEnum].encode(CoproductOfEnum(Coproduct[ColorOrNil](Colours.Red)), schema, DefaultFieldMapper) shouldBe ImmutableRecord(schema, Vector(new EnumSymbol(schema.getField("union").schema(), "Red")))
+  }
+  
+  test("coproducts with enum and Int") {
+    type ColorOrInt = Colours.Value :+: Int :+: CNil
+    val schema = AvroSchema[CoproductOfEnumOrInt]
+    Encoder[CoproductOfEnumOrInt].encode(CoproductOfEnumOrInt(Coproduct[ColorOrInt](4)), schema, DefaultFieldMapper) shouldBe ImmutableRecord(schema, Vector(java.lang.Integer.valueOf(4)))
+    Encoder[CoproductOfEnumOrInt].encode(CoproductOfEnumOrInt(Coproduct[ColorOrInt](Colours.Red)), schema, DefaultFieldMapper) shouldBe ImmutableRecord(schema, Vector(new EnumSymbol(schema.getField("union").schema(), "Red")))
+  }
 }
 
 case class CPWithArray(u: CPWrapper.SSI)
@@ -47,3 +62,6 @@ object CPWrapper {
 
 case class Coproducts(union: Int :+: String :+: Boolean :+: CNil)
 case class CoproductsOfCoproducts(union: (Int :+: String :+: CNil) :+: Boolean :+: CNil)
+
+case class CoproductOfEnum(union: Colours.Value :+: CNil)
+case class CoproductOfEnumOrInt(union: Colours.Value :+: Int :+: CNil)


### PR DESCRIPTION
I found that encoding/decoding a coproduct with Scala enumerations fails. 

It only happens if a coproduct value contains an enumeration. With other element of coproduct it works fine. 

In this PR, I added tests to reproduce the problem, and my solution for encoding. I didn't find one for decoding unfortunately (it's the first time I had a look at avro4s code :slightly_smiling_face: ).

One caveat: I'm not sure if the added tests for decoding are correct, but they looks ok to me... They pass for an element other than enumeration.