### PR TITLE
ISSUE-432 | Fix serializable Encoder[BigDecimal] (#432)

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/Encoder.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/Encoder.scala
@@ -243,7 +243,7 @@ object Encoder {
 
     import org.apache.avro.Conversions
 
-    private val converter = new Conversions.DecimalConversion
+    @transient private lazy val converter = new Conversions.DecimalConversion
     private val rm = java.math.RoundingMode.valueOf(roundingMode.id)
 
     override def encode(decimal: BigDecimal, schema: Schema, fieldMapper: FieldMapper): AnyRef = {

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/GithubIssue432.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/GithubIssue432.scala
@@ -1,0 +1,14 @@
+package com.sksamuel.avro4s.github
+
+import java.io.{ByteArrayOutputStream, ObjectOutputStream}
+import com.sksamuel.avro4s.Encoder
+import org.scalatest.{FunSuite, Matchers}
+
+class GithubIssue432 extends FunSuite with Matchers {
+
+  test("Serializable Encoder[BigDecimal] #432") {
+    val oos = new ObjectOutputStream(new ByteArrayOutputStream())
+    oos.writeObject(Encoder.bigDecimalEncoder)
+    oos.close
+  }
+}


### PR DESCRIPTION
Encoders should be serializable, denote the value Avro: DecimalConversion with transient lazy to allow it.