### PR TITLE
don't pull in scala-compiler as run-time dependency

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -15,7 +15,7 @@ object Build extends AutoPlugin {
     val CatsVersion = "2.0.0-RC2"
     val ShapelessVersion = "2.3.3"
     val RefinedVersion = "0.9.13"
-    val MagnoliaVersion = "0.14.5"
+    val MagnoliaVersion = "0.16.0"
     val ScalaMeterVersion = "0.19"
   }
 


### PR DESCRIPTION
Hi,

I recently noticed that when you use avro4s, you end up with scala-compiler on the run-time classpath. But it's needed only at compile-time, and including it in the run-time classpath adds unnecessary bloat for the users.