### PR TITLE
small performance optimization

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroBinaryInputStream.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroBinaryInputStream.scala
@@ -24,8 +24,12 @@ class AvroBinaryInputStream[T](in: InputStream,
   private val avroDecoder = DecoderFactory.get().binaryDecoder(in, null)
 
   private val _iter = new Iterator[GenericRecord] {
+    var record: GenericRecord = null
     override def hasNext: Boolean = !avroDecoder.isEnd
-    override def next(): GenericRecord = datumReader.read(null, avroDecoder)
+    override def next(): GenericRecord = {
+      record = datumReader.read(record, avroDecoder)
+      record
+    }
   }
 
   /**

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroJsonInputStream.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroJsonInputStream.scala
@@ -15,8 +15,10 @@ final case class AvroJsonInputStream[T](in: InputStream,
   private val datumReader = new DefaultAwareDatumReader[GenericRecord](writerSchema, decoder.schema)
   private val jsonDecoder = DecoderFactory.get.jsonDecoder(writerSchema, in)
 
+  private var record: GenericRecord = null
   private def next = Try {
-    datumReader.read(null, jsonDecoder)
+    record = datumReader.read(record, jsonDecoder)
+    record
   }
 
   def iterator: Iterator[T] = Iterator.continually(next)

--- a/benchmarks/src/main/scala/benchmarks/Decoding.scala
+++ b/benchmarks/src/main/scala/benchmarks/Decoding.scala
@@ -84,7 +84,7 @@ class Decoding extends CommonParams with BenchmarkHelpers {
 
 
   @Benchmark
-  def avroSpecificRecord(setup: Setup, blackhole: Blackhole) = {
+  def avroSpecificRecord(setup: AvroBytesSetup, blackhole: Blackhole) = {
     import benchmarks.record.generated._
     blackhole.consume(RecordWithUnionAndTypeField.fromByteBuffer(setup.avroBytes.duplicate))
   }


### PR DESCRIPTION
Hey,

I've noticed that the code in Avro4s doesn't conform to the recommendations in the avro4s manual.
https://avro.apache.org/docs/1.9.2/gettingstartedjava.html
They recommend reusing the same `GenericRecord` over and over to avoid allocations.  Here is the relevant quote:
> Note how we perform the iteration: we create a single GenericRecord object which we store the current deserialized user in, and pass this record object to every call of dataFileReader.next. This is a performance optimization that allows the DataFileReader to reuse the same record object rather than allocating a new GenericRecord for every iteration, which can be very expensive in terms of object allocation and garbage collection if we deserialize a large data file.

I'm not sure how much of a difference that makes, but it can't hurt.

I also removed an `asInstanceOf` and an unnecessary field from the `AvroDataInputStream` class along the way. 

