### PR TITLE
Check whether class is value class

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/Records.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/Records.scala
@@ -142,9 +142,6 @@ object Records {
       if (annotations.transient) None
       else {
         val doc = valueTypeDoc(ctx, param)
-        if(doc.isDefined) {
-          println("context with doc: " + ctx.typeName.full)
-        }
         val schema = param.typeclass.resolveSchemaFor(nextEnv, NoUpdate).schema
         Some(buildSchemaField(param, schema, annotations, record.getNamespace, fieldMapper, doc))
       }

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/Records.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/Records.scala
@@ -142,6 +142,9 @@ object Records {
       if (annotations.transient) None
       else {
         val doc = valueTypeDoc(ctx, param)
+        if(doc.isDefined) {
+          println("context with doc: " + ctx.typeName.full)
+        }
         val schema = param.typeclass.resolveSchemaFor(nextEnv, NoUpdate).schema
         Some(buildSchemaField(param, schema, annotations, record.getNamespace, fieldMapper, doc))
       }
@@ -253,11 +256,19 @@ object Records {
       import scala.reflect.runtime.universe
       val mirror = universe.runtimeMirror(Thread.currentThread().getContextClassLoader)
       val sym = mirror.staticClass(ctx.typeName.full).primaryConstructor.asMethod.paramLists.head(param.index)
-      sym.typeSignature.typeSymbol.annotations.collectFirst {
-        case a if a.tree.tpe =:= typeOf[AvroDoc] =>
-          val annoValue = a.tree.children.tail.head.asInstanceOf[Literal].value.value
-          annoValue.toString
+
+      val anyValSym = typeOf[AnyVal].typeSymbol
+      val typeSym = sym.typeSignature.typeSymbol
+      if(typeSym.isClass && typeSym.asClass.baseClasses.contains(anyValSym)) {
+        typeSym.annotations.collectFirst {
+          case a if a.tree.tpe =:= typeOf[AvroDoc] =>
+            val annoValue = a.tree.children.tail.head.asInstanceOf[Literal].value.value
+            annoValue.toString
+        }
+      } else {
+        None
       }
+
     } catch {
       case NonFatal(_) => None
     }

--- a/avro4s-core/src/test/resources/doc_field_regular_case_class.json
+++ b/avro4s-core/src/test/resources/doc_field_regular_case_class.json
@@ -1,0 +1,17 @@
+{
+  "type" : "record",
+  "name" : "Message",
+  "namespace" : "com.sksamuel.avro4s.schema",
+  "fields" : [ {
+    "name" : "record1",
+    "type" : {
+      "type" : "record",
+      "name" : "Record1",
+      "doc" : "This is a record",
+      "fields" : [ {
+        "name" : "field",
+        "type" : "string"
+      } ]
+    }
+  } ]
+}

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/AvroDocSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/AvroDocSchemaTest.scala
@@ -31,9 +31,20 @@ class AvroDocSchemaTest extends AnyWordSpec with Matchers {
       val schema = AvroSchema[Annotated123]
       schema.toString(true) shouldBe expected.toString(true)
     }
+
+    "produce doc only on the field record when field is not a value class" in {
+      val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/doc_field_regular_case_class.json"))
+      val schema = AvroSchema[Message]
+
+      schema.toString(true) shouldBe expected.toString(true)
+    }
   }
 }
 
 case class Annotated123(a: ValueTypeForDocAnnoTest)
 @AvroDoc("wibble")
 case class ValueTypeForDocAnnoTest(s: String) extends AnyVal
+
+case class Message(record1: Record1)
+@AvroDoc("This is a record")
+case class Record1(field: String)


### PR DESCRIPTION
In order to avoid duplicating the doc field, check whether the current class is a value class before extracting the annotation from it.

Fixes #509