### PR TITLE
Use ad-hoc instances so that expensive resolving isn't performed on stream creation time

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroBinaryInputStream.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroBinaryInputStream.scala
@@ -20,9 +20,7 @@ class AvroBinaryInputStream[T](in: InputStream,
                                writerSchema: Schema)
                               (implicit decoder: Decoder[T]) extends AvroInputStream[T] {
 
-  val resolved = decoder.resolveDecoder()
-
-  private val datumReader = new GenericDatumReader[GenericRecord](writerSchema,  resolved.schema)
+  private val datumReader = new GenericDatumReader[GenericRecord](writerSchema,  decoder.schema)
   private val avroDecoder = DecoderFactory.get().binaryDecoder(in, null)
 
   private val _iter = new Iterator[GenericRecord] {
@@ -35,7 +33,7 @@ class AvroBinaryInputStream[T](in: InputStream,
     */
   override def iterator: Iterator[T] = new Iterator[T] {
     override def hasNext: Boolean = _iter.hasNext
-    override def next(): T = resolved.decode(_iter.next())
+    override def next(): T = decoder.decode(_iter.next())
   }
 
   /**
@@ -44,7 +42,7 @@ class AvroBinaryInputStream[T](in: InputStream,
     */
   override def tryIterator: Iterator[Try[T]] = new Iterator[Try[T]] {
     override def hasNext: Boolean = _iter.hasNext
-    override def next(): Try[T] = Try(resolved.decode(_iter.next()))
+    override def next(): Try[T] = Try(decoder.decode(_iter.next()))
   }
 
   override def close(): Unit = in.close()

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroDataInputStream.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroDataInputStream.scala
@@ -13,12 +13,11 @@ class AvroDataInputStream[T](in: InputStream,
                              writerSchema: Option[Schema])
                             (implicit decoder: Decoder[T]) extends AvroInputStream[T] {
 
-  val resolved = decoder.resolveDecoder()
 
   // if no reader or writer schema is specified, then we create a reader that uses what's present in the files
   private val datumReader = writerSchema match {
-    case Some(writer) => GenericData.get.createDatumReader(writer, resolved.schema)
-    case None => GenericData.get.createDatumReader(null, resolved.schema)
+    case Some(writer) => GenericData.get.createDatumReader(writer, decoder.schema)
+    case None => GenericData.get.createDatumReader(null, decoder.schema)
   }
 
   private val dataFileReader = new DataFileStream[GenericRecord](in, datumReader.asInstanceOf[DatumReader[GenericRecord]])
@@ -27,7 +26,7 @@ class AvroDataInputStream[T](in: InputStream,
     override def hasNext: Boolean = dataFileReader.hasNext
     override def next(): T = {
       val record = dataFileReader.next
-      resolved.decode(record)
+      decoder.decode(record)
     }
   }
 
@@ -35,7 +34,7 @@ class AvroDataInputStream[T](in: InputStream,
     override def hasNext: Boolean = dataFileReader.hasNext
     override def next(): Try[T] = Try {
       val record = dataFileReader.next
-      resolved.decode(record)
+      decoder.decode(record)
     }
   }
 

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/DefaultAvroOutputStream.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/DefaultAvroOutputStream.scala
@@ -8,9 +8,7 @@ class DefaultAvroOutputStream[T](os: OutputStream,
                                  serializer: org.apache.avro.io.Encoder)
                                 (implicit encoder: Encoder[T]) extends AvroOutputStream[T] {
 
-  val resolved = encoder.resolveEncoder()
-
-  private val datumWriter = new GenericDatumWriter[AnyRef](resolved.schema)
+  private val datumWriter = new GenericDatumWriter[AnyRef](encoder.schema)
 
   override def close(): Unit = {
     flush()
@@ -18,7 +16,7 @@ class DefaultAvroOutputStream[T](os: OutputStream,
   }
 
   override def write(t: T): Unit = {
-    val datum = resolved.encode(t)
+    val datum = encoder.encode(t)
     datumWriter.write(datum, serializer)
   }
 

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
@@ -1,6 +1,5 @@
 package com.sksamuel.avro4s
 
-import org.apache.avro.Schema
 import org.apache.avro.generic.IndexedRecord
 
 /**
@@ -13,8 +12,6 @@ trait FromRecord[T] extends Serializable {
 object FromRecord {
   def apply[T](implicit decoder: Decoder[T]): FromRecord[T] = new FromRecord[T] {
 
-    val resolved = decoder.resolveDecoder()
-
-    override def from(record: IndexedRecord): T = resolved.decode(record)
+    override def from(record: IndexedRecord): T = decoder.decode(record)
   }
 }

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/ToRecord.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/ToRecord.scala
@@ -19,9 +19,7 @@ trait ToRecord[T] extends Serializable {
 object ToRecord {
   def apply[T](implicit encoder: Encoder[T]): ToRecord[T] = new ToRecord[T] {
 
-    val resolved = encoder.resolveEncoder()
-
-    def to(t: T): Record = resolved.encode(t) match {
+    def to(t: T): Record = encoder.encode(t) match {
       case record: Record => record
       case output =>
         throw new Avro4sEncodingException(s"Cannot marshall an instance of $t to a Record (was $output)",


### PR DESCRIPTION
This is the easiest way to avoid the performance hit discussed [here](https://github.com/sksamuel/avro4s/issues/495#issuecomment-659492364) 
we can fall back to use the ad-hoc instance of the resolvable encoder / decoder, which is a lazy val and has some slight performance hit, but by this it becomes impossible to accidentally perform resolution multiple times.

I haven't had time to create benchmarks yet to check how much of a win it would be to explicitly resolve at the right place, I will investigate in the next couple days. I expect the win to be very small, if noticeable at all, to be honest.