### PR TITLE
Add getClass String for ToRecord failure

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/ToRecord.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/ToRecord.scala
@@ -21,10 +21,12 @@ object ToRecord {
 
     def to(t: T): Record = encoder.encode(t) match {
       case record: Record => record
-      case output =>
-        throw new Avro4sEncodingException(s"Cannot marshall an instance of $t to a Record (was $output)",
-                                          output,
-                                          encoder)
+      case output => {
+        val clazz = output.getClass
+        throw new Avro4sEncodingException(s"Cannot marshall an instance of $t to a Record (had class $clazz, output was $output)",
+          output,
+          encoder)
+      }
     }
   }
 }


### PR DESCRIPTION
This PR just adds a `getClass` for the `output` seen in the exception message.

I had a confusing instance where my type `T` was not being marshalled, and it wasn't clear to me that it was being seen as a `String`. Eventually we figured out that it was because our case classes extended `AnyVal`.