### PR TITLE
Added support for scala named enums in schemas #502

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/BaseTypes.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/BaseTypes.scala
@@ -85,19 +85,23 @@ trait BaseSchemaFors {
       case t @ TypeRef(_, _, _) => t
     }
 
-    val valueType = typeOf[E]
-    val pre = typeRef.pre.typeSymbol.typeSignature.members.sorted
-    val syms = pre
-      .filter { sym =>
-        !sym.isMethod &&
-        !sym.isType &&
-        sym.typeSignature.baseType(valueType.typeSymbol) =:= valueType
-      }
-      .map { sym =>
-        sym.name.decodedName.toString.trim
-      }
+//    val valueType = typeOf[E]
+//    val pre = typeRef.pre.typeSymbol.typeSignature.members.sorted
+//    val syms = pre
+//      .filter { sym =>
+//        !sym.isMethod &&
+//        !sym.isType &&
+//        sym.typeSignature.baseType(valueType.typeSymbol) =:= valueType
+//      }
+//      .map { sym =>
+//        sym.name.decodedName.toString.trim
+//      }
 
     val annotations: Seq[Annotation] = typeRef.pre.typeSymbol.annotations
+
+    val enumObject = tag.mirror.classLoader.loadClass(typeRef.pre.typeSymbol.fullName + "$").getField("MODULE$").get(null)
+    val valuesMethod = enumObject.getClass.getMethod("values")
+    val syms = valuesMethod.invoke(enumObject).asInstanceOf[Iterable[E]].map(_.toString).toList
 
     val maybeName = getAnnotationValue(classOf[AvroName], annotations)
     val maybeNamespace = getAnnotationValue(classOf[AvroNamespace], annotations)

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/EnumSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/EnumSchemaTest.scala
@@ -207,7 +207,7 @@ class EnumSchemaTest extends AnyWordSpec with Matchers {
 
     "support optional java enums with default values" in {
 
-      case class OptionalJavaEnumWithDefaultValue(wine: Option[Wine] = Some(Wine.CabSav))
+      case class OptionalJavaEnumWithDefaultValue(wine: Option[Wine] = Option(Wine.CabSav))
 
       val schema = AvroSchema[OptionalJavaEnumWithDefaultValue]
       val expected = new org.apache.avro.Schema.Parser().parse(
@@ -776,6 +776,28 @@ class EnumSchemaTest extends AnyWordSpec with Matchers {
 
       schema.toString(true) shouldBe expected.toString(true)
     }
+
+    "named scala enum" in {
+      val schema = AvroSchema[NamedEnumFoo]
+      val expected = new org.apache.avro.Schema.Parser().parse(
+        """
+          {
+            "type" : "record",
+            "name" : "NamedEnumFoo",
+            "namespace" : "com.sksamuel.avro4s.schema",
+            "fields" : [{
+              "name" : "z",
+              "type" : {
+                "type" : "enum",
+                "name" : "NamedEnum",
+                "symbols" : [ "Temperature" ]
+              }
+            }]
+          }
+          """
+      )
+      schema.toString(true) shouldBe expected.toString(true)
+    }
   }
 }
 
@@ -800,3 +822,8 @@ sealed trait CupcatAnnotatedEnum
 @AvroSortPriority(0) case object SnoutleyAnnotatedEnum extends CupcatAnnotatedEnum
 @AvroSortPriority(1) case object CuppersAnnotatedEnum extends CupcatAnnotatedEnum
 
+object NamedEnum extends Enumeration {
+  val T: NamedEnum.Value = Value("Temperature")
+}
+
+case class NamedEnumFoo(z: NamedEnum.Value)


### PR DESCRIPTION
This could be tidied up further. Mostly I would prefer to use the mirror on the type tag to obtain the module instance but I couldn't figure that out.