### PR TITLE
Introduced AvroValue ADT and updated Decoder interface

### DIFF
--- a/avro4s-cats/src/main/scala/com/sksamuel/avro4s/cats/package.scala
+++ b/avro4s-cats/src/main/scala/com/sksamuel/avro4s/cats/package.scala
@@ -1,6 +1,7 @@
 package com.sksamuel.avro4s
 
 import _root_.cats.data.{NonEmptyList, NonEmptyVector}
+import com.sksamuel.avro4s.AvroValue.AvroList
 import org.apache.avro.Schema
 
 import scala.language.implicitConversions
@@ -15,7 +16,7 @@ package object cats {
   implicit def nonEmptyVectorSchemaFor[T](implicit schemaFor: SchemaFor[T]): SchemaFor[NonEmptyVector[T]] =
     SchemaFor(Schema.createArray(schemaFor.schema))
 
-  implicit def nonEmptyListEncoder[T](implicit encoder: Encoder[T]) = new Encoder[NonEmptyList[T]] {
+  implicit def nonEmptyListEncoder[T](implicit encoder: Encoder[T]): Encoder[NonEmptyList[T]] = new Encoder[NonEmptyList[T]] {
 
     val schemaFor: SchemaFor[NonEmptyList[T]] = nonEmptyListSchemaFor(encoder.schemaFor)
 
@@ -25,7 +26,7 @@ package object cats {
     }
   }
 
-  implicit def nonEmptyVectorEncoder[T](implicit encoder: Encoder[T]) = new Encoder[NonEmptyVector[T]] {
+  implicit def nonEmptyVectorEncoder[T](implicit encoder: Encoder[T]): Encoder[NonEmptyVector[T]] = new Encoder[NonEmptyVector[T]] {
 
     val schemaFor: SchemaFor[NonEmptyVector[T]] = nonEmptyVectorSchemaFor(encoder.schemaFor)
 
@@ -35,24 +36,22 @@ package object cats {
     }
   }
 
-  implicit def nonEmptyListDecoder[T](implicit decoder: Decoder[T]) = new Decoder[NonEmptyList[T]] {
+  implicit def nonEmptyListDecoder[T](implicit decoder: Decoder[T]): Decoder[NonEmptyList[T]] = new Decoder[NonEmptyList[T]] {
 
     val schemaFor: SchemaFor[NonEmptyList[T]] = nonEmptyListSchemaFor(decoder.schemaFor)
 
-    override def decode(value: Any): NonEmptyList[T] = value match {
-      case array: Array[_] => NonEmptyList.fromListUnsafe(array.toList.map(decoder.decode))
-      case list: java.util.Collection[_] => NonEmptyList.fromListUnsafe(list.asScala.map(decoder.decode).toList)
+    override def decode(value: AvroValue): NonEmptyList[T] = value match {
+      case AvroList(list) =>  NonEmptyList.fromListUnsafe(list.map(decoder.decode))
       case other => sys.error("Unsupported type " + other)
     }
   }
 
-  implicit def nonEmptyVectorDecoder[T](implicit decoder: Decoder[T]) = new Decoder[NonEmptyVector[T]] {
+  implicit def nonEmptyVectorDecoder[T](implicit decoder: Decoder[T]): Decoder[NonEmptyVector[T]] = new Decoder[NonEmptyVector[T]] {
 
     val schemaFor: SchemaFor[NonEmptyVector[T]] = nonEmptyVectorSchemaFor(decoder.schemaFor)
 
-    override def decode(value: Any): NonEmptyVector[T] = value match {
-      case array: Array[_] => NonEmptyVector.fromVectorUnsafe(array.toVector.map(decoder.decode))
-      case list: java.util.Collection[_] => NonEmptyVector.fromVectorUnsafe(list.asScala.map(decoder.decode).toVector)
+    override def decode(value: AvroValue): NonEmptyVector[T] = value match {
+      case AvroList(list) => NonEmptyVector.fromVectorUnsafe(list.toVector.map(decoder.decode))
       case other => sys.error("Unsupported type " + other)
     }
   }

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/Avro4sException.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/Avro4sException.scala
@@ -1,9 +1,5 @@
 package com.sksamuel.avro4s
 
-/**
- *
- * @param message
- */
 class Avro4sException(message: String) extends Exception(message: String)
 
 class Avro4sConfigurationException(message: String) extends Avro4sException(message)
@@ -14,4 +10,11 @@ class Avro4sEncodingException(message: String, val value: Any, val encoder: Enco
 
 class Avro4sDecodingException(message: String, val value: Any, val decoder: Decoder[_]) extends Avro4sException(message) {
   def schema = decoder.schema
+}
+
+class Avro4sUnsupportedValueException(message: String) extends Avro4sException(message)
+
+object Avro4sUnsupportedValueException {
+  def apply(value: AvroValue, decoder: Decoder[_]) =
+    new Avro4sDecodingException(s"Unsupported type for this decoder [value=$value, decoder=$decoder]", value.toString, decoder)
 }

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroBinaryInputStream.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroBinaryInputStream.scala
@@ -33,7 +33,7 @@ class AvroBinaryInputStream[T](in: InputStream,
     */
   override def iterator: Iterator[T] = new Iterator[T] {
     override def hasNext: Boolean = _iter.hasNext
-    override def next(): T = decoder.decode(_iter.next())
+    override def next(): T = decoder.decode(AvroValue.unsafeFromAny(_iter.next()))
   }
 
   /**
@@ -42,7 +42,7 @@ class AvroBinaryInputStream[T](in: InputStream,
     */
   override def tryIterator: Iterator[Try[T]] = new Iterator[Try[T]] {
     override def hasNext: Boolean = _iter.hasNext
-    override def next(): Try[T] = Try(decoder.decode(_iter.next()))
+    override def next(): Try[T] = Try(decoder.decode(AvroValue.unsafeFromAny(_iter.next())))
   }
 
   override def close(): Unit = in.close()

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroDataInputStream.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroDataInputStream.scala
@@ -2,6 +2,7 @@ package com.sksamuel.avro4s
 
 import java.io.InputStream
 
+import com.sksamuel.avro4s.AvroValue.AvroRecord
 import org.apache.avro.Schema
 import org.apache.avro.file.DataFileStream
 import org.apache.avro.generic.{GenericData, GenericRecord}
@@ -26,7 +27,7 @@ class AvroDataInputStream[T](in: InputStream,
     override def hasNext: Boolean = dataFileReader.hasNext
     override def next(): T = {
       val record = dataFileReader.next
-      decoder.decode(record)
+      decoder.decode(AvroRecord(record))
     }
   }
 
@@ -34,7 +35,7 @@ class AvroDataInputStream[T](in: InputStream,
     override def hasNext: Boolean = dataFileReader.hasNext
     override def next(): Try[T] = Try {
       val record = dataFileReader.next
-      decoder.decode(record)
+      decoder.decode(AvroRecord(record))
     }
   }
 

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroJsonInputStream.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroJsonInputStream.scala
@@ -22,14 +22,18 @@ final case class AvroJsonInputStream[T](in: InputStream,
   def iterator: Iterator[T] = Iterator.continually(next)
     .takeWhile(_.isSuccess)
     .map(_.get)
-    .map(decoder.decode(_))
+    .map(AvroValue.unsafeFromAny)
+    .map(decoder.decode)
 
   def tryIterator: Iterator[Try[T]] = Iterator.continually(next)
     .takeWhile(_.isSuccess)
     .map(_.get)
+    .map(AvroValue.unsafeFromAny)
     .map(record => Try(decoder.decode(record)))
 
-  def singleEntity: Try[T] = next.map(decoder.decode(_))
+  def singleEntity: Try[T] = next
+    .map(AvroValue.unsafeFromAny)
+    .map(decoder.decode)
 
   override def close(): Unit = in.close()
 }

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroValue.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroValue.scala
@@ -1,0 +1,63 @@
+package com.sksamuel.avro4s
+
+import java.nio.ByteBuffer
+
+import org.apache.avro.generic.{GenericEnumSymbol, GenericFixed, GenericRecord}
+import org.apache.avro.util.Utf8
+
+sealed trait AvroValue
+
+object AvroValue {
+
+  import scala.collection.JavaConverters._
+
+  case class AvroString(s: String) extends AvroValue
+  case class AvroByteArray(bytes: Array[Byte]) extends AvroValue
+  case class AvroGenericFixed(fixed: GenericFixed) extends AvroValue
+  case class AvroBoolean(boolean: Boolean) extends AvroValue
+  case class AvroShort(short: Short) extends AvroValue
+  case class AvroByte(byte: Byte) extends AvroValue
+  case class AvroDouble(double: Double) extends AvroValue
+  case class AvroFloat(float: Float) extends AvroValue
+  case class AvroInt(int: Int) extends AvroValue
+  case class AvroLong(long: Long) extends AvroValue
+  case class AvroEnumSymbol(symbol: GenericEnumSymbol[_]) extends AvroValue
+  case class AvroList(list: List[AvroValue]) extends AvroValue
+  case class AvroMap(map: Map[String, AvroValue]) extends AvroValue
+  case object AvroNull extends AvroValue
+
+  case class AvroRecord(record: GenericRecord) extends AvroValue {
+    def get(name: String): Option[AvroValue] = Option(record.get(name)).map(AvroValue.unsafeFromAny)
+    def get(i: Int): Option[AvroValue] = Option(record.get(i)).map(AvroValue.unsafeFromAny)
+  }
+
+  private[avro4s] def unsafeFromAny(a: Any): AvroValue = a match {
+    case r: GenericRecord => AvroRecord(r)
+    case s: String => AvroString(s)
+    case u: Utf8 => AvroString(u.toString)
+    case c: CharSequence => AvroString(c.toString)
+    case b: Boolean => AvroBoolean(b)
+    case g: GenericFixed => AvroGenericFixed(g)
+    case b: ByteBuffer => AvroByteArray(b.array())
+    case a: Array[Byte] => AvroByteArray(a)
+    case a: Array[_] => AvroList(a.toList.map(AvroValue.unsafeFromAny))
+    case m: java.util.Map[_, _] => AvroMap(m.asScala.map { case (key, value) => key.toString -> unsafeFromAny(value) }.toMap)
+    case c: java.lang.Iterable[_] => AvroList(c.asScala.map(AvroValue.unsafeFromAny).toList)
+    case c: java.util.Collection[_] => AvroList(c.asScala.map(AvroValue.unsafeFromAny).toList)
+    case f: Float => AvroFloat(f)
+    case f: java.lang.Float => AvroFloat(f)
+    case d: Double => AvroDouble(d)
+    case d: java.lang.Double => AvroDouble(d)
+    case b: Byte => AvroByte(b)
+    case b: java.lang.Byte => AvroByte(b)
+    case s: Short => AvroShort(s)
+    case s: java.lang.Short => AvroShort(s)
+    case i: Int => AvroInt(i)
+    case i: java.lang.Integer => AvroInt(i)
+    case l: Long => AvroLong(l)
+    case l: java.lang.Long => AvroLong(l)
+    case e: GenericEnumSymbol[_] => AvroEnumSymbol(e)
+    case null => AvroNull
+    case _ => throw new Avro4sUnsupportedValueException(s"$a is not a supported type when decoding. All types must be wrapped in AvroValue.")
+  }
+}

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroValue.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/AvroValue.scala
@@ -3,61 +3,50 @@ package com.sksamuel.avro4s
 import java.nio.ByteBuffer
 
 import org.apache.avro.generic.{GenericEnumSymbol, GenericFixed, GenericRecord}
-import org.apache.avro.util.Utf8
 
-sealed trait AvroValue
+import scala.collection.JavaConverters._
+
+sealed trait AvroValue 
 
 object AvroValue {
 
-  import scala.collection.JavaConverters._
-
-  case class AvroString(s: String) extends AvroValue
-  case class AvroByteArray(bytes: Array[Byte]) extends AvroValue
-  case class AvroGenericFixed(fixed: GenericFixed) extends AvroValue
-  case class AvroBoolean(boolean: Boolean) extends AvroValue
-  case class AvroShort(short: Short) extends AvroValue
-  case class AvroByte(byte: Byte) extends AvroValue
-  case class AvroDouble(double: Double) extends AvroValue
-  case class AvroFloat(float: Float) extends AvroValue
-  case class AvroInt(int: Int) extends AvroValue
-  case class AvroLong(long: Long) extends AvroValue
-  case class AvroEnumSymbol(symbol: GenericEnumSymbol[_]) extends AvroValue
-  case class AvroList(list: List[AvroValue]) extends AvroValue
-  case class AvroMap(map: Map[String, AvroValue]) extends AvroValue
-  case object AvroNull extends AvroValue
+  case class AvroString(str: String) extends AvroValue 
+  case class AvroByteArray(bytes: Array[Byte]) extends AvroValue 
+  case class AvroGenericFixed(fixed: GenericFixed) extends AvroValue 
+  case class AvroBoolean(boolean: Boolean) extends AvroValue 
+  case class AvroShort(short: Short) extends AvroValue 
+  case class AvroByte(byte: Byte) extends AvroValue 
+  case class AvroDouble(double: Double) extends AvroValue 
+  case class AvroFloat(float: Float) extends AvroValue 
+  case class AvroInt(int: Int) extends AvroValue 
+  case class AvroLong(long: Long) extends AvroValue 
+  case class AvroEnumSymbol(symbol: GenericEnumSymbol[_]) extends AvroValue 
+  case class AvroList(list: List[AvroValue]) extends AvroValue 
+  case class AvroMap(map: Map[String, AvroValue]) extends AvroValue 
+  case object AvroNull extends AvroValue 
 
   case class AvroRecord(record: GenericRecord) extends AvroValue {
     def get(name: String): Option[AvroValue] = Option(record.get(name)).map(AvroValue.unsafeFromAny)
     def get(i: Int): Option[AvroValue] = Option(record.get(i)).map(AvroValue.unsafeFromAny)
   }
 
-  private[avro4s] def unsafeFromAny(a: Any): AvroValue = a match {
+  private[avro4s] def unsafeFromAny(a: Any): AvroValue = if (a == null) AvroNull else a match {
     case r: GenericRecord => AvroRecord(r)
-    case s: String => AvroString(s)
-    case u: Utf8 => AvroString(u.toString)
+    case i: java.lang.Integer => AvroInt(i)
+    case l: java.lang.Long => AvroLong(l)
+    case b: java.lang.Boolean => AvroBoolean(b)
+    case f: java.lang.Float => AvroFloat(f)
+    case d: java.lang.Double => AvroDouble(d)
+    case b: java.lang.Byte => AvroByte(b)
+    case s: java.lang.Short => AvroShort(s)
     case c: CharSequence => AvroString(c.toString)
-    case b: Boolean => AvroBoolean(b)
-    case g: GenericFixed => AvroGenericFixed(g)
-    case b: ByteBuffer => AvroByteArray(b.array())
     case a: Array[Byte] => AvroByteArray(a)
     case a: Array[_] => AvroList(a.toList.map(AvroValue.unsafeFromAny))
     case m: java.util.Map[_, _] => AvroMap(m.asScala.map { case (key, value) => key.toString -> unsafeFromAny(value) }.toMap)
     case c: java.lang.Iterable[_] => AvroList(c.asScala.map(AvroValue.unsafeFromAny).toList)
-    case c: java.util.Collection[_] => AvroList(c.asScala.map(AvroValue.unsafeFromAny).toList)
-    case f: Float => AvroFloat(f)
-    case f: java.lang.Float => AvroFloat(f)
-    case d: Double => AvroDouble(d)
-    case d: java.lang.Double => AvroDouble(d)
-    case b: Byte => AvroByte(b)
-    case b: java.lang.Byte => AvroByte(b)
-    case s: Short => AvroShort(s)
-    case s: java.lang.Short => AvroShort(s)
-    case i: Int => AvroInt(i)
-    case i: java.lang.Integer => AvroInt(i)
-    case l: Long => AvroLong(l)
-    case l: java.lang.Long => AvroLong(l)
     case e: GenericEnumSymbol[_] => AvroEnumSymbol(e)
-    case null => AvroNull
+    case g: GenericFixed => AvroGenericFixed(g)
+    case b: ByteBuffer => AvroByteArray(b.array())
     case _ => throw new Avro4sUnsupportedValueException(s"$a is not a supported type when decoding. All types must be wrapped in AvroValue.")
   }
 }

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/BaseTypes.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/BaseTypes.scala
@@ -280,7 +280,7 @@ trait BaseDecoders {
     override def decode(value: AvroValue): Short = value match {
       case AvroByte(b) => b.toShort
       case AvroShort(s) => s
-      case AvroInt(int) => int.shortValue()
+      case i: AvroInt => i.int.shortValue()
       case _ => throw Avro4sUnsupportedValueException(value, this)
     }
   }
@@ -290,7 +290,7 @@ trait BaseDecoders {
     override def decode(value: AvroValue): Int = value match {
       case AvroByte(b) => b.toInt
       case AvroShort(s) => s.toInt
-      case AvroInt(int) => int
+      case i: AvroInt => i.int
       case _ => throw Avro4sUnsupportedValueException(value, this)
     }
   }
@@ -301,7 +301,7 @@ trait BaseDecoders {
       case AvroByte(b) => b.toLong
       case AvroShort(s) => s.toLong
       case AvroInt(int) => int.toLong
-      case AvroLong(long) => long
+      case l: AvroLong => l.long
       case _ => throw Avro4sUnsupportedValueException(value, this)
     }
   }
@@ -350,7 +350,7 @@ trait BaseDecoders {
   implicit val Utf8Decoder: Decoder[Utf8] = new Decoder[Utf8] {
     val schemaFor: SchemaFor[Utf8] = SchemaFor.Utf8SchemaFor
     override def decode(value: AvroValue): Utf8 = value match {
-      case AvroString(str) => new Utf8(str)
+      case a: AvroString => new Utf8(a.str)
       case null => throw new Avro4sDecodingException("Cannot decode <null> as utf8", value, this)
       case _ => throw Avro4sUnsupportedValueException(value, this)
     }
@@ -359,7 +359,7 @@ trait BaseDecoders {
   private[avro4s] class StringDecoder(val schemaFor: SchemaFor[String]) extends Decoder[String] {
 
     override def decode(value: AvroValue): String = value match {
-      case AvroString(str) => str
+      case a: AvroString => a.str
       case AvroGenericFixed(fixed) => new String(fixed.bytes())
       case AvroByteArray(bytes) => new String(bytes)
       case null                => throw new Avro4sDecodingException("Cannot decode <null> as a string", value, this)

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/Codec.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/Codec.scala
@@ -17,8 +17,8 @@ trait Codec[T] extends Encoder[T] with Decoder[T] with SchemaAware[Codec, T] { s
     val sf = schemaFor
     new Codec[T] {
       def schemaFor: SchemaFor[T] = sf
-      def encode(value: T): AnyRef = self.encode(value)
-      def decode(value: Any): T = self.decode(value)
+      override def encode(value: T): AnyRef = self.encode(value)
+      override def decode(value: AvroValue): T = self.decode(value)
     }
   }
 }
@@ -35,9 +35,9 @@ object Codec {
   private class DelegatingCodec[T, S](codec: Codec[T], val schemaFor: SchemaFor[S], map: T => S, comap: S => T)
     extends Codec[S] {
 
-    def encode(value: S): AnyRef = codec.encode(comap(value))
+    override def encode(value: S): AnyRef = codec.encode(comap(value))
 
-    def decode(value: Any): S = map(codec.decode(value))
+    override def decode(value: AvroValue): S = map(codec.decode(value))
 
     override def withSchema(schemaFor: SchemaFor[S]): Codec[S] = {
       // pass through schema so that underlying decoder performs desired transformations.

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
@@ -12,6 +12,6 @@ trait FromRecord[T] extends Serializable {
 object FromRecord {
   def apply[T](implicit decoder: Decoder[T]): FromRecord[T] = new FromRecord[T] {
 
-    override def from(record: IndexedRecord): T = decoder.decode(record)
+    override def from(record: IndexedRecord): T = decoder.decode(AvroValue.unsafeFromAny(record))
   }
 }

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/RecordFields.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/RecordFields.scala
@@ -1,5 +1,6 @@
 package com.sksamuel.avro4s
 
+import com.sksamuel.avro4s.AvroValue.AvroNull
 import com.sksamuel.avro4s.SchemaUpdate.{FullSchemaUpdate, NamespaceUpdate, NoUpdate}
 import magnolia.{CaseClass, Param}
 import org.apache.avro.Schema.Field
@@ -56,24 +57,24 @@ object RecordFields {
 
       def fastDecodeFieldValue(record: IndexedRecord): Any =
         if (fieldPosition == -1) defaultFieldValue
-        else tryDecode(record.get(fieldPosition))
+        else tryDecode(AvroValue.unsafeFromAny(record.get(fieldPosition)))
 
       def safeDecodeFieldValue(record: IndexedRecord): Any =
         if (fieldPosition == -1) defaultFieldValue
         else {
           val schemaField = record.getSchema.getField(fieldName.get)
-          if (schemaField == null) defaultFieldValue else tryDecode(record.get(schemaField.pos))
+          if (schemaField == null) defaultFieldValue else tryDecode(AvroValue.unsafeFromAny(record.get(schemaField.pos)))
         }
 
       @inline
       private def defaultFieldValue: Any = param.default match {
         case Some(default) => default
         // there is no default, so the field must be an option
-        case None => decoder.decode(null)
+        case None => decoder.decode(AvroNull)
       }
 
       @inline
-      private def tryDecode(value: Any): Any =
+      private def tryDecode(value: AvroValue): Any =
         try {
           decoder.decode(value)
         } catch {

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/Records.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/Records.scala
@@ -1,5 +1,6 @@
 package com.sksamuel.avro4s
 
+import com.sksamuel.avro4s.AvroValue.AvroRecord
 import com.sksamuel.avro4s.RecordFields._
 import com.sksamuel.avro4s.Records._
 import com.sksamuel.avro4s.SchemaUpdate.{FullSchemaUpdate, NamespaceUpdate, NoUpdate}
@@ -37,8 +38,8 @@ class RecordDecoder[T: WeakTypeTag](ctx: CaseClass[Decoder, T], val schemaFor: S
 
   private[avro4s] var fieldDecoding: IndexedSeq[FieldDecoder[T]#ValueDecoder] = IndexedSeq.empty
 
-  def decode(value: Any): T = value match {
-    case record: IndexedRecord =>
+  def decode(value: AvroValue): T = value match {
+    case AvroRecord(record) =>
       // hot code path. Sacrificing functional programming to the gods of performance.
       val length = fieldDecoding.length
       val values = new Array[Any](length)

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/ScalaEnums.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/ScalaEnums.scala
@@ -1,10 +1,11 @@
 package com.sksamuel.avro4s
+import com.sksamuel.avro4s.AvroValue.{AvroEnumSymbol, AvroString}
 import magnolia.{SealedTrait, Subtype}
-import org.apache.avro.generic.{GenericData, GenericEnumSymbol}
+import org.apache.avro.generic.GenericData
 import org.apache.avro.{Schema, SchemaBuilder}
 
-import scala.reflect.runtime.universe
 import scala.collection.JavaConverters._
+import scala.reflect.runtime.universe
 
 object ScalaEnums {
 
@@ -37,13 +38,13 @@ object ScalaEnums {
   }
 
   private class EnumDecoder[T](data: CodecData[Decoder, T]) extends Decoder[T] {
-    val schemaFor = data.schemaFor
+    val schemaFor: SchemaFor[T] = data.schemaFor
 
     import data._
 
-    def decode(value: Any): T = value match {
-      case e: GenericEnumSymbol[_] => valueForSymbol(e.toString)
-      case s: String               => valueForSymbol(s)
+    override def decode(value: AvroValue): T = value match {
+      case AvroEnumSymbol(symbol) => valueForSymbol(symbol.toString)
+      case AvroString(str) => valueForSymbol(str)
     }
 
     override def withSchema(schemaFor: SchemaFor[T]): Decoder[T] = {
@@ -53,7 +54,7 @@ object ScalaEnums {
   }
 
   private class EnumEncoder[T](data: CodecData[Encoder, T]) extends Encoder[T] {
-    val schemaFor = data.schemaFor
+    val schemaFor: SchemaFor[T] = data.schemaFor
 
     import data._
 

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/ShapelessCoproducts.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/ShapelessCoproducts.scala
@@ -61,7 +61,8 @@ trait ShapelessCoproductDecoders {
   implicit val CNilDecoder: Decoder[CNil] = new Decoder[CNil] {
     val schemaFor: SchemaFor[CNil] = CNilSchemaFor
 
-    def decode(value: Any): CNil = throw new Avro4sDecodingException(s"Unable to decode value '$value'", value, this)
+    override def decode(value: AvroValue): CNil =
+      throw new Avro4sDecodingException(s"Unable to decode value '$value'", value, this)
 
     override def withSchema(schemaFor: SchemaFor[CNil]): Decoder[CNil] = this
   }
@@ -76,9 +77,9 @@ trait ShapelessCoproductDecoders {
 
           val schemaFor: SchemaFor[H :+: T] = buildCoproductSchemaFor(decoderH.schemaFor, decoderT.schemaFor)
 
-          private val elementDecoder: PartialFunction[Any, H] = TypeGuardedDecoding.guard(decoderH)
+          private val elementDecoder: PartialFunction[AvroValue, H] = TypeGuardedDecoding.guard(decoderH)
 
-          def decode(value: Any): H :+: T =
+          override def decode(value: AvroValue): H :+: T =
             if (elementDecoder.isDefinedAt(value)) Inl(elementDecoder(value)) else Inr(decoderT.decode(value))
 
           override def withSchema(schemaFor: SchemaFor[H :+: T]): Decoder[H :+: T] =

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/Temporals.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/Temporals.scala
@@ -64,13 +64,13 @@ trait TemporalDecoders {
       case _: TimeMillis =>
         value match {
           case AvroInt(i) => LocalTime.ofNanoOfDay(i.toLong * 1000000L)
-          case AvroLong(l) => LocalTime.ofNanoOfDay(l * 1000000L)
+          case l: AvroLong => LocalTime.ofNanoOfDay(l.long * 1000000L)
           case _ => throw Avro4sUnsupportedValueException(value, this)
         }
       case _: TimeMicros =>
         value match {
           case AvroInt(i) => LocalTime.ofNanoOfDay(i.toLong * 1000L)
-          case AvroLong(l) => LocalTime.ofNanoOfDay(l * 1000L)
+          case l: AvroLong => LocalTime.ofNanoOfDay(l.long * 1000L)
           case _ => throw Avro4sUnsupportedValueException(value, this)
         }
     }
@@ -90,15 +90,15 @@ trait TemporalDecoders {
     def decoder(value: AvroValue): LocalDateTime = schema.getLogicalType match {
       case _: TimestampMillis => value match {
         case AvroInt(i)  => LocalDateTime.ofInstant(Instant.ofEpochMilli(i.toLong), ZoneOffset.UTC)
-        case AvroLong(l) => LocalDateTime.ofInstant(Instant.ofEpochMilli(l), ZoneOffset.UTC)
+        case l: AvroLong => LocalDateTime.ofInstant(Instant.ofEpochMilli(l.long), ZoneOffset.UTC)
         case _ => throw Avro4sUnsupportedValueException(value, this)
       }
 
       case _: TimestampMicros => value match {
         case AvroInt(i) =>
           LocalDateTime.ofInstant(Instant.ofEpochMilli(i / 1000), ZoneOffset.UTC).plusNanos(i % 1000 * 1000)
-        case AvroLong(l) =>
-          LocalDateTime.ofInstant(Instant.ofEpochMilli(l / 1000), ZoneOffset.UTC).plusNanos(l % 1000 * 1000)
+        case l: AvroLong =>
+          LocalDateTime.ofInstant(Instant.ofEpochMilli(l.long / 1000), ZoneOffset.UTC).plusNanos(l.long % 1000 * 1000)
         case _ => throw Avro4sUnsupportedValueException(value, this)
       }
 

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/Tuples.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/Tuples.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.avro4s
 
-import org.apache.avro.generic.GenericRecord
+import com.sksamuel.avro4s.AvroValue.AvroRecord
 import org.apache.avro.{Schema, SchemaBuilder}
 
 trait TupleSchemaFors {
@@ -184,12 +184,13 @@ trait TupleDecoders {
 
           def schemaFor: SchemaFor[(A, B)] = createTuple2SchemaFor[A, B](decoderA.schemaFor, decoderB.schemaFor)
 
-          def decode(value: Any): (A, B) = {
-            val record = value.asInstanceOf[GenericRecord]
-            (
-              decoderA.decode(record.get("_1")),
-              decoderB.decode(record.get("_2"))
-            )
+          override def decode(value: AvroValue): (A, B) = value match {
+            case AvroRecord(record) =>
+              (
+                decoderA.decode(AvroValue.unsafeFromAny(record.get("_1"))),
+                decoderB.decode(AvroValue.unsafeFromAny(record.get("_2")))
+              )
+            case _ => throw Avro4sUnsupportedValueException(value, this)
           }
 
           override def withSchema(schemaFor: SchemaFor[(A, B)]): Decoder[(A, B)] =
@@ -212,13 +213,14 @@ trait TupleDecoders {
         def schemaFor: SchemaFor[(A, B, C)] =
           createTuple3SchemaFor[A, B, C](decoderA.schemaFor, decoderB.schemaFor, decoderC.schemaFor)
 
-        def decode(value: Any): (A, B, C) = {
-          val record = value.asInstanceOf[GenericRecord]
-          (
-            decoderA.decode(record.get("_1")),
-            decoderB.decode(record.get("_2")),
-            decoderC.decode(record.get("_3"))
-          )
+        override def decode(value: AvroValue): (A, B, C) = value match {
+          case AvroRecord(record) =>
+            (
+              decoderA.decode(AvroValue.unsafeFromAny(record.get("_1"))),
+              decoderB.decode(AvroValue.unsafeFromAny(record.get("_2"))),
+              decoderC.decode(AvroValue.unsafeFromAny(record.get("_3")))
+            )
+          case _ => throw Avro4sUnsupportedValueException(value, this)
         }
 
         override def withSchema(schemaFor: SchemaFor[(A, B, C)]): Decoder[(A, B, C)] =
@@ -246,14 +248,15 @@ trait TupleDecoders {
                                             decoderC.schemaFor,
                                             decoderD.schemaFor)
 
-        def decode(value: Any): (A, B, C, D) = {
-          val record = value.asInstanceOf[GenericRecord]
-          (
-            decoderA.decode(record.get("_1")),
-            decoderB.decode(record.get("_2")),
-            decoderC.decode(record.get("_3")),
-            decoderD.decode(record.get("_4"))
-          )
+        override def decode(value: AvroValue): (A, B, C, D) = value match {
+          case AvroRecord(record) =>
+            (
+              decoderA.decode(AvroValue.unsafeFromAny(record.get("_1"))),
+              decoderB.decode(AvroValue.unsafeFromAny(record.get("_2"))),
+              decoderC.decode(AvroValue.unsafeFromAny(record.get("_3"))),
+              decoderD.decode(AvroValue.unsafeFromAny(record.get("_4")))
+            )
+          case _ => throw Avro4sUnsupportedValueException(value, this)
         }
 
         override def withSchema(schemaFor: SchemaFor[(A, B, C, D)]): Decoder[(A, B, C, D)] =
@@ -285,15 +288,16 @@ trait TupleDecoders {
                                                  decoderD.schemaFor,
                                                  decoderE.schemaFor)
 
-          def decode(value: Any): (A, B, C, D, E) = {
-            val record = value.asInstanceOf[GenericRecord]
-            (
-              decoderA.decode(record.get("_1")),
-              decoderB.decode(record.get("_2")),
-              decoderC.decode(record.get("_3")),
-              decoderD.decode(record.get("_4")),
-              decoderE.decode(record.get("_5"))
-            )
+          override def decode(value: AvroValue): (A, B, C, D, E) = value match {
+            case AvroRecord(record) =>
+              (
+                decoderA.decode(AvroValue.unsafeFromAny(record.get("_1"))),
+                decoderB.decode(AvroValue.unsafeFromAny(record.get("_2"))),
+                decoderC.decode(AvroValue.unsafeFromAny(record.get("_3"))),
+                decoderD.decode(AvroValue.unsafeFromAny(record.get("_4"))),
+                decoderE.decode(AvroValue.unsafeFromAny(record.get("_5")))
+              )
+            case _ => throw Avro4sUnsupportedValueException(value, this)
           }
 
           override def withSchema(schemaFor: SchemaFor[(A, B, C, D, E)]): Decoder[(A, B, C, D, E)] =
@@ -313,7 +317,8 @@ object Tuples {
     schema.getFields.get(pos).schema()
   }
 
-  def mapTupleUpdate(pos: Int, update: SchemaUpdate) = EncoderHelpers.mapFullUpdate(extractTupleSchema(pos), update)
+  def mapTupleUpdate(pos: Int, update: SchemaUpdate): SchemaUpdate =
+    EncoderHelpers.mapFullUpdate(extractTupleSchema(pos), update)
 
   def createTuple2SchemaFor[A, B](implicit a: SchemaFor[A], b: SchemaFor[B]): SchemaFor[(A, B)] = {
     // format: off

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/TypeUnionEntry.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/TypeUnionEntry.scala
@@ -22,7 +22,7 @@ private[avro4s] object TypeUnionEntry {
       val schema = decoder.schema
       val fullName = schema.getFullName
 
-      def decodeSubtype(value: Any): T = decoder.decode(value)
+      def decodeSubtype(value: AvroValue): T = decoder.decode(value)
     }
 
     def apply(env: DefinitionEnvironment[Decoder], update: SchemaUpdate) =

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/Github396.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/Github396.scala
@@ -34,7 +34,7 @@ class Github396 extends AnyFunSuite with Matchers {
     record.put("b_wubble", "two")
 
 
-    Decoder[Foo].decode(record) shouldBe obj
+    Decoder[Foo].decode(AvroValue.unsafeFromAny(record)) shouldBe obj
   }
 
   test("@AvroName should override fieldmapping on encoding") {

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/GithubIssue387.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/GithubIssue387.scala
@@ -2,7 +2,7 @@ package com.sksamuel.avro4s.github
 
 import java.time.LocalTime
 
-import com.sksamuel.avro4s.{Decoder, Encoder}
+import com.sksamuel.avro4s.{AvroValue, Decoder, Encoder}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -26,14 +26,14 @@ class GithubIssue387 extends AnyWordSpec with Matchers {
     "encode and decode back to an equivalent LocalTime object when Local has microsecond precision" in {
       val localTime = LocalTime.now()
       val encoded = Encoder[LocalTime].encode(localTime)
-      val decoded = Decoder[LocalTime].decode(encoded)
+      val decoded = Decoder[LocalTime].decode(AvroValue.unsafeFromAny(encoded))
       decoded shouldBe localTime
       decoded.toNanoOfDay shouldBe localTime.toNanoOfDay
     }
 
     "encode and decode back to a LocalTime object with an equivalent time to  microsecond precision" in {
       val encoded = Encoder[LocalTime].encode(LocalTime.MAX)
-      val decoded = Decoder[LocalTime].decode(encoded)
+      val decoded = Decoder[LocalTime].decode(AvroValue.unsafeFromAny(encoded))
       decoded should not be LocalTime.MAX
       // compare to a LocalTime.MAX that has had the time precision truncated to milliseconds
       decoded shouldBe LocalTime.ofNanoOfDay((LocalTime.MAX.toNanoOfDay / NANOSECONDS_IN_A_MICROSECOND) * NANOSECONDS_IN_A_MICROSECOND)

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/GithubIssue389.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/GithubIssue389.scala
@@ -3,7 +3,8 @@ package com.sksamuel.avro4s.github
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 
-import com.sksamuel.avro4s.{AvroSchema, Decoder, Encoder}
+import com.sksamuel.avro4s.AvroValue.AvroString
+import com.sksamuel.avro4s.{AvroSchema, AvroValue, Decoder, Encoder}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -34,7 +35,7 @@ class GithubIssue389 extends AnyWordSpec with Matchers {
     "decode an iso formatted String to an equivalent OffsetDatetime object" in {
       def testDecode(datetime: OffsetDateTime): Unit = {
         val dateTimeString = datetime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
-        val decoder = Decoder[OffsetDateTime].decode(dateTimeString)
+        val decoder = Decoder[OffsetDateTime].decode(AvroString(dateTimeString))
         decoder shouldBe datetime
       }
       testDecode(NOW)
@@ -45,7 +46,7 @@ class GithubIssue389 extends AnyWordSpec with Matchers {
     "round trip encode and decode into an equivalent object" in {
       def testRoundTrip(datetime: OffsetDateTime): Unit = {
         val encoded = Encoder[OffsetDateTime].encode(datetime)
-        val decoded = Decoder[OffsetDateTime].decode(encoded)
+        val decoded = Decoder[OffsetDateTime].decode(AvroValue.unsafeFromAny(encoded))
         decoded shouldBe datetime
       }
       testRoundTrip(NOW)

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/GithubIssue484.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/GithubIssue484.scala
@@ -4,7 +4,7 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, 
 
 import com.sksamuel.avro4s.record.decoder.ScalaEnumClass
 import com.sksamuel.avro4s.schema.Colours
-import com.sksamuel.avro4s.{AvroSchema, Decoder, DefaultFieldMapper}
+import com.sksamuel.avro4s.{AvroSchema, AvroValue, Decoder}
 import org.apache.avro.generic.GenericData
 import org.apache.avro.generic.GenericData.EnumSymbol
 import org.scalatest.funsuite.AnyFunSuite
@@ -25,6 +25,6 @@ class GithubIssue484 extends AnyFunSuite with Matchers {
     val schema = AvroSchema[ScalaEnumClass]
     val record = new GenericData.Record(schema)
     record.put("colour", new EnumSymbol(schema.getField("colour").schema(), "Green"))
-    decoder.decode(record) shouldBe ScalaEnumClass(Colours.Green)
+    decoder.decode(AvroValue.unsafeFromAny(record)) shouldBe ScalaEnumClass(Colours.Green)
   }
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/GithubIssue485.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/GithubIssue485.scala
@@ -3,7 +3,7 @@ package com.sksamuel.avro4s.github
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
 
 import com.sksamuel.avro4s.record.decoder.CPWrapper
-import com.sksamuel.avro4s.{AvroSchema, Decoder, DefaultFieldMapper}
+import com.sksamuel.avro4s.{AvroSchema, AvroValue, Decoder}
 import org.apache.avro.generic.GenericData
 import org.apache.avro.util.Utf8
 import org.scalatest.funsuite.AnyFunSuite
@@ -24,6 +24,6 @@ class GithubIssue485 extends AnyFunSuite with Matchers {
     val schema = AvroSchema[CPWrapper]
     val record = new GenericData.Record(schema)
     record.put("u", new Utf8("wibble"))
-    decoder.decode(record) shouldBe CPWrapper(Coproduct[CPWrapper.ISBG]("wibble"))
+    decoder.decode(AvroValue.unsafeFromAny(record)) shouldBe CPWrapper(Coproduct[CPWrapper.ISBG]("wibble"))
   }
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/LocalDateTimeRoundTrip.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/LocalDateTimeRoundTrip.scala
@@ -2,7 +2,7 @@ package com.sksamuel.avro4s.record
 
 import java.time.LocalDateTime
 
-import com.sksamuel.avro4s.{Decoder, Encoder}
+import com.sksamuel.avro4s.{AvroValue, Decoder, Encoder}
 import org.apache.avro.{LogicalTypes, SchemaBuilder}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -15,7 +15,7 @@ class LocalDateTimeRoundTrip extends AnyFunSuite with Matchers {
 
     val encodedLocalDateTime = Encoder[LocalDateTime].encode(localDateTime)
 
-    Decoder[LocalDateTime].decode(encodedLocalDateTime) shouldEqual localDateTime
+    Decoder[LocalDateTime].decode(AvroValue.unsafeFromAny(encodedLocalDateTime)) shouldEqual localDateTime
   }
 
   test("local date time round trip with timestamp-micros") {
@@ -26,6 +26,6 @@ class LocalDateTimeRoundTrip extends AnyFunSuite with Matchers {
 
     val encodedLocalDateTime = Encoder[LocalDateTime].encode(localDateTime)
 
-    Decoder[LocalDateTime].decode(encodedLocalDateTime) shouldEqual localDateTime
+    Decoder[LocalDateTime].decode(AvroValue.unsafeFromAny(encodedLocalDateTime)) shouldEqual localDateTime
   }
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/ArrayDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/ArrayDecoderTest.scala
@@ -1,5 +1,6 @@
 package com.sksamuel.avro4s.record.decoder
 
+import com.sksamuel.avro4s.AvroValue.AvroRecord
 import com.sksamuel.avro4s._
 import org.apache.avro.generic.GenericData
 import org.apache.avro.util.Utf8
@@ -33,7 +34,7 @@ class ArrayDecoderTest extends AnyWordSpec with Matchers {
       val schema = AvroSchema[TestVectorBooleans]
       val record = new GenericData.Record(schema)
       record.put("booleans", List(true, false, true).asJava)
-      Decoder[TestVectorBooleans].decode(record) shouldBe TestVectorBooleans(Vector(true, false, true))
+      Decoder[TestVectorBooleans].decode(AvroRecord(record)) shouldBe TestVectorBooleans(Vector(true, false, true))
     }
 
     "support array for an vector of records" in {
@@ -52,7 +53,7 @@ class ArrayDecoderTest extends AnyWordSpec with Matchers {
       val container = new GenericData.Record(containerSchema)
       container.put("records", List(record1, record2).asJava)
 
-      Decoder[TestVectorRecords].decode(container) shouldBe TestVectorRecords(Vector(Record("qwe", 123.4), Record("wer", 8234.324)))
+      Decoder[TestVectorRecords].decode(AvroRecord(container)) shouldBe TestVectorRecords(Vector(Record("qwe", 123.4), Record("wer", 8234.324)))
     }
 
     "support array for a scala.collection.immutable.Seq of primitives" in {
@@ -65,7 +66,7 @@ class ArrayDecoderTest extends AnyWordSpec with Matchers {
       val schema = AvroSchema[TestArrayBooleans]
       val record = new GenericData.Record(schema)
       record.put("booleans", List(true, false, true).asJava)
-      Decoder[TestArrayBooleans].decode(record).booleans.toVector shouldBe Vector(true, false, true)
+      Decoder[TestArrayBooleans].decode(AvroRecord(record)).booleans.toVector shouldBe Vector(true, false, true)
     }
 
     "support array for a List of primitives" in {
@@ -73,7 +74,7 @@ class ArrayDecoderTest extends AnyWordSpec with Matchers {
       val schema = AvroSchema[TestListBooleans]
       val record = new GenericData.Record(schema)
       record.put("booleans", List(true, false, true).asJava)
-      Decoder[TestListBooleans].decode(record) shouldBe TestListBooleans(List(true, false, true))
+      Decoder[TestListBooleans].decode(AvroRecord(record)) shouldBe TestListBooleans(List(true, false, true))
     }
 
     "support array for a List of records" in {
@@ -92,7 +93,7 @@ class ArrayDecoderTest extends AnyWordSpec with Matchers {
       val container = new GenericData.Record(containerSchema)
       container.put("records", List(record1, record2).asJava)
 
-      Decoder[TestListRecords].decode(container) shouldBe TestListRecords(List(Record("qwe", 123.4), Record("wer", 8234.324)))
+      Decoder[TestListRecords].decode(AvroRecord(container)) shouldBe TestListRecords(List(Record("qwe", 123.4), Record("wer", 8234.324)))
     }
 
     "support array for a scala.collection.immutable.Seq of records" in {
@@ -111,7 +112,7 @@ class ArrayDecoderTest extends AnyWordSpec with Matchers {
       val container = new GenericData.Record(containerSchema)
       container.put("records", List(record1, record2).asJava)
 
-      Decoder[TestSeqRecords].decode(container) shouldBe TestSeqRecords(Seq(Record("qwe", 123.4), Record("wer", 8234.324)))
+      Decoder[TestSeqRecords].decode(AvroRecord(container)) shouldBe TestSeqRecords(Seq(Record("qwe", 123.4), Record("wer", 8234.324)))
     }
 
     "support array for an Array of records" in {
@@ -130,7 +131,7 @@ class ArrayDecoderTest extends AnyWordSpec with Matchers {
       val container = new GenericData.Record(containerSchema)
       container.put("records", List(record1, record2).asJava)
 
-      Decoder[TestArrayRecords].decode(container).records.toVector shouldBe Vector(Record("qwe", 123.4), Record("wer", 8234.324))
+      Decoder[TestArrayRecords].decode(AvroRecord(container)).records.toVector shouldBe Vector(Record("qwe", 123.4), Record("wer", 8234.324))
     }
 
     "support array for a Set of records" in {
@@ -149,19 +150,19 @@ class ArrayDecoderTest extends AnyWordSpec with Matchers {
       val container = new GenericData.Record(containerSchema)
       container.put("records", List(record1, record2).asJava)
 
-      Decoder[TestSetRecords].decode(container) shouldBe TestSetRecords(Set(Record("qwe", 123.4), Record("wer", 8234.324)))
+      Decoder[TestSetRecords].decode(AvroRecord(container)) shouldBe TestSetRecords(Set(Record("qwe", 123.4), Record("wer", 8234.324)))
     }
     "support array for a Set of strings" in {
       val schema = AvroSchema[TestSetString]
       val record = new GenericData.Record(schema)
       record.put("strings", List("Qwe", "324", "q").asJava)
-      Decoder[TestSetString].decode(record) shouldBe TestSetString(Set("Qwe", "324", "q"))
+      Decoder[TestSetString].decode(AvroRecord(record)) shouldBe TestSetString(Set("Qwe", "324", "q"))
     }
     "support array for a Set of doubles" in {
       val schema = AvroSchema[TestSetDoubles]
       val record = new GenericData.Record(schema)
       record.put("doubles", List(132.4324, 5.4, 0.123).asJava)
-      Decoder[TestSetDoubles].decode(record) shouldBe TestSetDoubles(Set(132.4324, 5.4, 0.123))
+      Decoder[TestSetDoubles].decode(AvroRecord(record)) shouldBe TestSetDoubles(Set(132.4324, 5.4, 0.123))
     }
     //    "support Seq[Tuple2] issue #156" in {
     //      val schema = SchemaEncoder[TupleTest2]
@@ -171,16 +172,16 @@ class ArrayDecoderTest extends AnyWordSpec with Matchers {
     //    }
 
     "support top level Seq[Double]" in {
-      Decoder[Seq[Double]].decode(Array(1.2, 34.5, 54.3)) shouldBe Seq(1.2, 34.5, 54.3)
+      Decoder[Seq[Double]].decode(AvroValue.unsafeFromAny(Array(1.2, 34.5, 54.3))) shouldBe Seq(1.2, 34.5, 54.3)
     }
     "support top level List[Int]" in {
-      Decoder[List[Int]].decode(Array(1, 4, 9)) shouldBe List(1, 4, 9)
+      Decoder[List[Int]].decode(AvroValue.unsafeFromAny(Array(1, 4, 9))) shouldBe List(1, 4, 9)
     }
     "support top level Vector[String]" in {
-      Decoder[Vector[String]].decode(Array("a", "z")) shouldBe Vector("a", "z")
+      Decoder[Vector[String]].decode(AvroValue.unsafeFromAny(Array("a", "z"))) shouldBe Vector("a", "z")
     }
     "support top level Set[Boolean]" in {
-      Decoder[Set[Boolean]].decode(Array(true, false, true)) shouldBe Set(true, false)
+      Decoder[Set[Boolean]].decode(AvroValue.unsafeFromAny(Array(true, false, true))) shouldBe Set(true, false)
     }
   }
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/AvroNameDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/AvroNameDecoderTest.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.avro4s.record.decoder
 
-import com.sksamuel.avro4s.{AvroName, Decoder, DefaultFieldMapper, FieldMapper}
+import com.sksamuel.avro4s.{AvroName, AvroValue, Decoder}
 import org.apache.avro.generic.GenericData
 import org.apache.avro.util.Utf8
 import org.scalatest.funsuite.AnyFunSuite
@@ -14,6 +14,6 @@ class AvroNameDecoderTest extends AnyFunSuite with Matchers {
     val decoder = Decoder[AvroNameDecoderTest]
     val record = new GenericData.Record(decoder.schema)
     record.put("bar", new Utf8("hello"))
-    decoder.decode(record) shouldBe AvroNameDecoderTest("hello")
+    decoder.decode(AvroValue.unsafeFromAny(record)) shouldBe AvroNameDecoderTest("hello")
   }
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/BasicDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/BasicDecoderTest.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.avro4s.record.decoder
 
 import com.sksamuel.avro4s.examples.UppercasePkg.ClassInUppercasePackage
-import com.sksamuel.avro4s.{AvroSchema, Decoder, DefaultFieldMapper, FieldMapper}
+import com.sksamuel.avro4s.{AvroSchema, AvroValue, Decoder}
 import org.apache.avro.generic.GenericData
 import org.apache.avro.util.Utf8
 import org.scalatest.matchers.should.Matchers
@@ -21,37 +21,37 @@ class BasicDecoderTest extends AnyWordSpec with Matchers {
       val schema = AvroSchema[FooString]
       val record = new GenericData.Record(schema)
       record.put("str", "hello")
-      Decoder[FooString].decode(record) shouldBe FooString("hello")
+      Decoder[FooString].decode(AvroValue.unsafeFromAny(record)) shouldBe FooString("hello")
     }
     "decode longs" in {
       val schema = AvroSchema[FooLong]
       val record = new GenericData.Record(schema)
       record.put("l", 123456L)
-      Decoder[FooLong].decode(record) shouldBe FooLong(123456L)
+      Decoder[FooLong].decode(AvroValue.unsafeFromAny(record)) shouldBe FooLong(123456L)
     }
     "decode doubles" in {
       val schema = AvroSchema[FooDouble]
       val record = new GenericData.Record(schema)
       record.put("d", 123.435D)
-      Decoder[FooDouble].decode(record) shouldBe FooDouble(123.435D)
+      Decoder[FooDouble].decode(AvroValue.unsafeFromAny(record)) shouldBe FooDouble(123.435D)
     }
     "decode booleans" in {
       val schema = AvroSchema[FooBoolean]
       val record = new GenericData.Record(schema)
       record.put("b", true)
-      Decoder[FooBoolean].decode(record) shouldBe FooBoolean(true)
+      Decoder[FooBoolean].decode(AvroValue.unsafeFromAny(record)) shouldBe FooBoolean(true)
     }
     "decode floats" in {
       val schema = AvroSchema[FooFloat]
       val record = new GenericData.Record(schema)
       record.put("f", 123.435F)
-      Decoder[FooFloat].decode(record) shouldBe FooFloat(123.435F)
+      Decoder[FooFloat].decode(AvroValue.unsafeFromAny(record)) shouldBe FooFloat(123.435F)
     }
     "decode ints" in {
       val schema = AvroSchema[FooInt]
       val record = new GenericData.Record(schema)
       record.put("i", 123)
-      Decoder[FooInt].decode(record) shouldBe FooInt(123)
+      Decoder[FooInt].decode(AvroValue.unsafeFromAny(record)) shouldBe FooInt(123)
     }
     "support uppercase packages" in {
 
@@ -61,7 +61,7 @@ class BasicDecoderTest extends AnyWordSpec with Matchers {
       val record = new GenericData.Record(schema)
       record.put("s", new Utf8("hello"))
 
-      decoder.decode(record) shouldBe com.sksamuel.avro4s.examples.UppercasePkg.ClassInUppercasePackage("hello")
+      decoder.decode(AvroValue.unsafeFromAny(record)) shouldBe com.sksamuel.avro4s.examples.UppercasePkg.ClassInUppercasePackage("hello")
     }
   }
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/BigDecimalDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/BigDecimalDecoderTest.scala
@@ -1,5 +1,6 @@
 package com.sksamuel.avro4s.record.decoder
 
+import com.sksamuel.avro4s.AvroValue.{AvroRecord, AvroString}
 import com.sksamuel.avro4s._
 import org.apache.avro.generic.GenericData
 import org.apache.avro.{Conversions, LogicalTypes, SchemaBuilder}
@@ -17,7 +18,7 @@ class BigDecimalDecoderTest extends AnyFlatSpec with Matchers {
     val bytes =
       new Conversions.DecimalConversion().toBytes(BigDecimal(123.45).bigDecimal, null, LogicalTypes.decimal(8, 2))
     record.put("decimal", bytes)
-    Decoder[WithBigDecimal].decode(record) shouldBe WithBigDecimal(BigDecimal(123.45))
+    Decoder[WithBigDecimal].decode(AvroRecord(record)) shouldBe WithBigDecimal(BigDecimal(123.45))
   }
 
   it should "support optional big decimals" in {
@@ -26,16 +27,16 @@ class BigDecimalDecoderTest extends AnyFlatSpec with Matchers {
       new Conversions.DecimalConversion().toBytes(BigDecimal(123.45).bigDecimal, null, LogicalTypes.decimal(8, 2))
     val record = new GenericData.Record(schema)
     record.put("big", bytes)
-    Decoder[OptionalBigDecimal].decode(record) shouldBe OptionalBigDecimal(Option(BigDecimal(123.45)))
+    Decoder[OptionalBigDecimal].decode(AvroValue.unsafeFromAny(record)) shouldBe OptionalBigDecimal(Option(BigDecimal(123.45)))
 
     val emptyRecord = new GenericData.Record(schema)
     emptyRecord.put("big", null)
-    Decoder[OptionalBigDecimal].decode(emptyRecord) shouldBe OptionalBigDecimal(None)
+    Decoder[OptionalBigDecimal].decode(AvroRecord(emptyRecord)) shouldBe OptionalBigDecimal(None)
   }
 
   it should "be able to decode strings as bigdecimals" in {
     val schemaFor = BigDecimals.AsString
-    Decoder[BigDecimal].withSchema(schemaFor).decode("123.45") shouldBe BigDecimal(123.45)
+    Decoder[BigDecimal].withSchema(schemaFor).decode(AvroString("123.45")) shouldBe BigDecimal(123.45)
   }
 
   it should "be able to decode generic fixed as bigdecimals" in {
@@ -45,7 +46,7 @@ class BigDecimalDecoderTest extends AnyFlatSpec with Matchers {
 
     val fixed =
       GenericData.get().createFixed(null, Array[Byte](0, 4, 98, -43, 55, 43, -114, 0), schemaFor.schema)
-    Decoder[BigDecimal].withSchema(schemaFor).decode(fixed) shouldBe BigDecimal(12345678)
+    Decoder[BigDecimal].withSchema(schemaFor).decode(AvroValue.unsafeFromAny(fixed)) shouldBe BigDecimal(12345678)
   }
 
 //  it should "be able to decode longs as bigdecimals" in {

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/ByteArrayDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/ByteArrayDecoderTest.scala
@@ -2,7 +2,7 @@ package com.sksamuel.avro4s.record.decoder
 
 import java.nio.ByteBuffer
 
-import com.sksamuel.avro4s.{AvroSchema, Decoder}
+import com.sksamuel.avro4s.{AvroSchema, AvroValue, Decoder}
 import org.apache.avro.SchemaBuilder
 import org.apache.avro.generic.GenericData
 import org.scalatest.funsuite.AnyFunSuite
@@ -22,59 +22,59 @@ class ByteArrayDecoderTest extends AnyFunSuite with Matchers {
     val schema = AvroSchema[ArrayTest]
     val record = new GenericData.Record(schema)
     record.put("z", ByteBuffer.wrap(Array[Byte](1, 4, 9)))
-    Decoder[ArrayTest].decode(record).z.toList shouldBe List[Byte](1, 4, 9)
+    Decoder[ArrayTest].decode(AvroValue.unsafeFromAny(record)).z.toList shouldBe List[Byte](1, 4, 9)
   }
 
   test("decode bytebuffers to array") {
     val schema = AvroSchema[ArrayTest]
     val record = new GenericData.Record(schema)
     record.put("z", ByteBuffer.wrap(Array[Byte](1, 4, 9)))
-    Decoder[ArrayTest].decode(record).z.toList shouldBe List[Byte](1, 4, 9)
+    Decoder[ArrayTest].decode(AvroValue.unsafeFromAny(record)).z.toList shouldBe List[Byte](1, 4, 9)
   }
 
   test("decode byte vectors") {
     val schema = AvroSchema[VectorTest]
     val record = new GenericData.Record(schema)
     record.put("z", ByteBuffer.wrap(Array[Byte](1, 4, 9)))
-    Decoder[VectorTest].decode(record).z shouldBe Vector[Byte](1, 4, 9)
+    Decoder[VectorTest].decode(AvroValue.unsafeFromAny(record)).z shouldBe Vector[Byte](1, 4, 9)
   }
 
   test("decode byte lists") {
     val schema = AvroSchema[ListTest]
     val record = new GenericData.Record(schema)
     record.put("z", ByteBuffer.wrap(Array[Byte](1, 4, 9)))
-    Decoder[ListTest].decode(record).z shouldBe List[Byte](1, 4, 9)
+    Decoder[ListTest].decode(AvroValue.unsafeFromAny(record)).z shouldBe List[Byte](1, 4, 9)
   }
 
   test("decode byte seqs") {
     val schema = AvroSchema[SeqTest]
     val record = new GenericData.Record(schema)
     record.put("z", ByteBuffer.wrap(Array[Byte](1, 4, 9)))
-    Decoder[SeqTest].decode(record).z shouldBe Seq[Byte](1, 4, 9)
+    Decoder[SeqTest].decode(AvroValue.unsafeFromAny(record)).z shouldBe Seq[Byte](1, 4, 9)
   }
 
   test("decode top level byte arrays") {
     val decoder = Decoder[Array[Byte]].resolveDecoder()
     decoder.schema shouldBe SchemaBuilder.builder().bytesType()
-    decoder.decode(ByteBuffer.wrap(Array[Byte](1, 4, 9))).toList shouldBe List[Byte](1, 4, 9)
+    decoder.decode(AvroValue.unsafeFromAny(ByteBuffer.wrap(Array[Byte](1, 4, 9)))).toList shouldBe List[Byte](1, 4, 9)
   }
 
   test("decode array to bytebuffers") {
     val schema = AvroSchema[ByteBufferTest]
     val record = new GenericData.Record(schema)
     record.put("z", Array[Byte](1, 4, 9))
-    Decoder[ByteBufferTest].decode(record).z.array().toList shouldBe List[Byte](1, 4, 9)
+    Decoder[ByteBufferTest].decode(AvroValue.unsafeFromAny(record)).z.array().toList shouldBe List[Byte](1, 4, 9)
   }
 
   test("decode bytebuffers") {
     val schema = AvroSchema[ByteBufferTest]
     val record = new GenericData.Record(schema)
     record.put("z", ByteBuffer.wrap(Array[Byte](1, 4, 9)))
-    Decoder[ByteBufferTest].decode(record).z.array().toList shouldBe List[Byte](1, 4, 9)
+    Decoder[ByteBufferTest].decode(AvroValue.unsafeFromAny(record)).z.array().toList shouldBe List[Byte](1, 4, 9)
   }
 
   test("decode top level ByteBuffers") {
-    Decoder[ByteBuffer].decode(ByteBuffer.wrap(Array[Byte](1, 4, 9))).array().toList shouldBe List[Byte](1, 4, 9)
+    Decoder[ByteBuffer].decode(AvroValue.unsafeFromAny(ByteBuffer.wrap(Array[Byte](1, 4, 9)))).array().toList shouldBe List[Byte](1, 4, 9)
   }
 }
 

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/CoproductDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/CoproductDecoderTest.scala
@@ -3,7 +3,7 @@ package com.sksamuel.avro4s.record.decoder
 import java.nio.ByteBuffer
 
 import com.sksamuel.avro4s.record.decoder.CPWrapper.{ISBG, ISCB}
-import com.sksamuel.avro4s.{AvroSchema, Decoder}
+import com.sksamuel.avro4s.{AvroSchema, AvroValue, Decoder}
 import org.apache.avro.generic.GenericData
 import org.apache.avro.util.Utf8
 import shapeless.{:+:, CNil, Coproduct}
@@ -18,7 +18,7 @@ class CoproductDecoderTest extends AnyFunSuite with Matchers {
     val decoder = Decoder[CPWrapper]
     val record = new GenericData.Record(decoder.schema)
     record.put("u", new Utf8("wibble"))
-    decoder.decode(record) shouldBe CPWrapper(Coproduct[CPWrapper.ISBG]("wibble"))
+    decoder.decode(AvroValue.unsafeFromAny(record)) shouldBe CPWrapper(Coproduct[CPWrapper.ISBG]("wibble"))
   }
 
   test("coproducts with case classes") {
@@ -27,7 +27,7 @@ class CoproductDecoderTest extends AnyFunSuite with Matchers {
     gimble.put("x", new Utf8("foo"))
     val record = new GenericData.Record(decoder.schema)
     record.put("u", gimble)
-    decoder.decode(record) shouldBe CPWrapper(Coproduct[CPWrapper.ISBG](Gimble("foo")))
+    decoder.decode(AvroValue.unsafeFromAny(record)) shouldBe CPWrapper(Coproduct[CPWrapper.ISBG](Gimble("foo")))
   }
 
   test("coproducts with options") {
@@ -36,7 +36,7 @@ class CoproductDecoderTest extends AnyFunSuite with Matchers {
     gimble.put("x", new Utf8("foo"))
     val record = new GenericData.Record(codec.schema)
     record.put("u", gimble)
-    codec.decode(record) shouldBe CPWithOption(Some(Coproduct[CPWrapper.ISBG](Gimble("foo"))))
+    codec.decode(AvroValue.unsafeFromAny(record)) shouldBe CPWithOption(Some(Coproduct[CPWrapper.ISBG](Gimble("foo"))))
   }
 
   test("coproduct with array") {
@@ -44,7 +44,7 @@ class CoproductDecoderTest extends AnyFunSuite with Matchers {
     val array = new GenericData.Array(AvroSchema[Seq[String]], List(new Utf8("a"), new Utf8("b")).asJava)
     val record = new GenericData.Record(schema)
     record.put("u", array)
-    Decoder[CPWithArray].decode(record) shouldBe CPWithArray(Coproduct[CPWrapper.SSI](Seq("a", "b")))
+    Decoder[CPWithArray].decode(AvroValue.unsafeFromAny(record)) shouldBe CPWithArray(Coproduct[CPWrapper.SSI](Seq("a", "b")))
   }
 
   test("coproduct with byte array") {
@@ -52,7 +52,7 @@ class CoproductDecoderTest extends AnyFunSuite with Matchers {
     val record = new GenericData.Record(schema)
     record.put("u", ByteBuffer.wrap(Array[Byte](1, 2, 3)))
 
-    val result = Decoder[CPWithByteArray].decode(record)
+    val result = Decoder[CPWithByteArray].decode(AvroValue.unsafeFromAny(record))
 
     result.u.select[Array[Byte]].get shouldBe Array[Byte](1, 2, 3)
   }
@@ -62,7 +62,7 @@ class CoproductDecoderTest extends AnyFunSuite with Matchers {
     val array = new GenericData.Array(AvroSchema[Seq[ISBG]], List(3, new Utf8("three")).asJava)
     val record = new GenericData.Record(AvroSchema[CoproductWithArrayOfCoproduct])
     record.put("union", array)
-    Decoder[CoproductWithArrayOfCoproduct].decode(record) shouldBe coproduct
+    Decoder[CoproductWithArrayOfCoproduct].decode(AvroValue.unsafeFromAny(record)) shouldBe coproduct
   }
 
   test("coproducts") {
@@ -70,7 +70,7 @@ class CoproductDecoderTest extends AnyFunSuite with Matchers {
     val record = new GenericData.Record(schema)
     record.put("union", new Utf8("foo"))
     val coproduct = Coproduct[Int :+: String :+: Boolean :+: CNil]("foo")
-    Decoder[Coproducts].decode(record) shouldBe Coproducts(coproduct)
+    Decoder[Coproducts].decode(AvroValue.unsafeFromAny(record)) shouldBe Coproducts(coproduct)
   }
 
   test("coproducts of coproducts") {
@@ -78,7 +78,7 @@ class CoproductDecoderTest extends AnyFunSuite with Matchers {
     val record = new GenericData.Record(schema)
     record.put("union", new Utf8("foo"))
     val coproduct = Coproduct[(Int :+: String :+: CNil) :+: Boolean :+: CNil](Coproduct[Int :+: String :+: CNil]("foo"))
-    Decoder[CoproductsOfCoproducts].decode(record) shouldBe CoproductsOfCoproducts(coproduct)
+    Decoder[CoproductsOfCoproducts].decode(AvroValue.unsafeFromAny(record)) shouldBe CoproductsOfCoproducts(coproduct)
   }
 }
 

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/DateDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/DateDecoderTest.scala
@@ -3,6 +3,7 @@ package com.sksamuel.avro4s.record.decoder
 import java.sql.{Date, Timestamp}
 import java.time.{Instant, LocalDate, LocalDateTime, LocalTime}
 
+import com.sksamuel.avro4s.AvroValue.AvroRecord
 import com.sksamuel.avro4s.SchemaFor.TimestampNanosLogicalType
 import com.sksamuel.avro4s.{AvroSchema, Decoder, SchemaFor}
 import org.apache.avro.generic.GenericData
@@ -24,21 +25,21 @@ class DateDecoderTest extends AnyFunSuite with Matchers {
     val schema = AvroSchema[WithLocalTime]
     val record = new GenericData.Record(schema)
     record.put("z", 46245000000L)
-    Decoder[WithLocalTime].decode(record) shouldBe WithLocalTime(LocalTime.of(12, 50, 45))
+    Decoder[WithLocalTime].decode(AvroRecord(record)) shouldBe WithLocalTime(LocalTime.of(12, 50, 45))
   }
 
   test("decode int to LocalDate") {
     val schema = AvroSchema[WithLocalDate]
     val record = new GenericData.Record(schema)
     record.put("z", 17784)
-    Decoder[WithLocalDate].decode(record) shouldBe WithLocalDate(LocalDate.of(2018, 9, 10))
+    Decoder[WithLocalDate].decode(AvroRecord(record)) shouldBe WithLocalDate(LocalDate.of(2018, 9, 10))
   }
 
   test("decode int to java.sql.Date") {
     val schema = AvroSchema[WithDate]
     val record = new GenericData.Record(schema)
     record.put("z", 17784)
-    Decoder[WithDate].decode(record) shouldBe WithDate(Date.valueOf(LocalDate.of(2018, 9, 10)))
+    Decoder[WithDate].decode(AvroRecord(record)) shouldBe WithDate(Date.valueOf(LocalDate.of(2018, 9, 10)))
   }
 
   test("decode timestamp-millis to LocalDateTime") {
@@ -46,7 +47,7 @@ class DateDecoderTest extends AnyFunSuite with Matchers {
     val schema = SchemaBuilder.record("foo").fields().name("z").`type`(dateSchema).noDefault().endRecord()
     val record = new GenericData.Record(schema)
     record.put("z", 1572707106376L)
-    Decoder[WithLocalDateTime].withSchema(SchemaFor(schema)).decode(record) shouldBe WithLocalDateTime(
+    Decoder[WithLocalDateTime].withSchema(SchemaFor(schema)).decode(AvroRecord(record)) shouldBe WithLocalDateTime(
       LocalDateTime.of(2019, 11, 2, 15, 5, 6, 376000000))
   }
 
@@ -55,7 +56,7 @@ class DateDecoderTest extends AnyFunSuite with Matchers {
     val schema = SchemaBuilder.record("foo").fields().name("z").`type`(dateSchema).noDefault().endRecord()
     val record = new GenericData.Record(schema)
     record.put("z", 1572707106376001L)
-    Decoder[WithLocalDateTime].withSchema(SchemaFor(schema)).decode(record) shouldBe WithLocalDateTime(
+    Decoder[WithLocalDateTime].withSchema(SchemaFor(schema)).decode(AvroRecord(record)) shouldBe WithLocalDateTime(
       LocalDateTime.of(2019, 11, 2, 15, 5, 6, 376001000))
   }
 
@@ -64,7 +65,7 @@ class DateDecoderTest extends AnyFunSuite with Matchers {
     val schema = SchemaBuilder.record("foo").fields().name("z").`type`(dateSchema).noDefault().endRecord()
     val record = new GenericData.Record(schema)
     record.put("z", 1572707106376000002L)
-    Decoder[WithLocalDateTime].decode(record) shouldBe WithLocalDateTime(
+    Decoder[WithLocalDateTime].decode(AvroRecord(record)) shouldBe WithLocalDateTime(
       LocalDateTime.of(2019, 11, 2, 15, 5, 6, 376000002))
   }
 
@@ -72,13 +73,13 @@ class DateDecoderTest extends AnyFunSuite with Matchers {
     val schema = AvroSchema[WithTimestamp]
     val record = new GenericData.Record(schema)
     record.put("z", 1538312231000L)
-    Decoder[WithTimestamp].decode(record) shouldBe WithTimestamp(new Timestamp(1538312231000L))
+    Decoder[WithTimestamp].decode(AvroRecord(record)) shouldBe WithTimestamp(new Timestamp(1538312231000L))
   }
 
   test("decode long to Instant") {
     val schema = AvroSchema[WithInstant]
     val record = new GenericData.Record(schema)
     record.put("z", 1538312231000L)
-    Decoder[WithInstant].decode(record) shouldBe WithInstant(Instant.ofEpochMilli(1538312231000L))
+    Decoder[WithInstant].decode(AvroRecord(record)) shouldBe WithInstant(Instant.ofEpochMilli(1538312231000L))
   }
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/EitherDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/EitherDecoderTest.scala
@@ -1,5 +1,6 @@
 package com.sksamuel.avro4s.record.decoder
 
+import com.sksamuel.avro4s.AvroValue.AvroRecord
 import com.sksamuel.avro4s._
 import org.apache.avro.SchemaBuilder
 import org.apache.avro.util.Utf8
@@ -35,20 +36,20 @@ class EitherDecoderTest extends AnyFunSuite with Matchers {
 
   test("decode union:T,U for Either[T,U] of primitives") {
     val schema = AvroSchema[Test]
-    Decoder[Test].decode(ImmutableRecord(schema, Vector(new Utf8("foo")))) shouldBe Test(Left("foo"))
-    Decoder[Test].decode(ImmutableRecord(schema, Vector(java.lang.Double.valueOf(234.4D)))) shouldBe Test(Right(234.4D))
+    Decoder[Test].decode(AvroRecord(ImmutableRecord(schema, Vector(new Utf8("foo"))))) shouldBe Test(Left("foo"))
+    Decoder[Test].decode(AvroRecord(ImmutableRecord(schema, Vector(java.lang.Double.valueOf(234.4D))))) shouldBe Test(Right(234.4D))
   }
 
   test("decode union:T,U for Either[T,U] of top level classes") {
     val schema = AvroSchema[Test2]
-    Decoder[Test2].decode(ImmutableRecord(schema, Vector(ImmutableRecord(AvroSchema[Goo], Vector(new Utf8("zzz")))))) shouldBe Test2(Left(Goo("zzz")))
-    Decoder[Test2].decode(ImmutableRecord(schema, Vector(ImmutableRecord(AvroSchema[Foo], Vector(java.lang.Boolean.valueOf(true)))))) shouldBe Test2(Right(Foo(true)))
+    Decoder[Test2].decode(AvroRecord(ImmutableRecord(schema, Vector(ImmutableRecord(AvroSchema[Goo], Vector(new Utf8("zzz"))))))) shouldBe Test2(Left(Goo("zzz")))
+    Decoder[Test2].decode(AvroRecord(ImmutableRecord(schema, Vector(ImmutableRecord(AvroSchema[Foo], Vector(java.lang.Boolean.valueOf(true))))))) shouldBe Test2(Right(Foo(true)))
   }
 
   test("decode union:T,U for Either[T,U] of nested classes") {
     val schema = AvroSchema[Test3]
-    Decoder[Test3].decode(ImmutableRecord(schema, Vector(ImmutableRecord(AvroSchema[Voo], Vector(new Utf8("zzz")))))) shouldBe Test3(Left(Voo("zzz")))
-    Decoder[Test3].decode(ImmutableRecord(schema, Vector(ImmutableRecord(AvroSchema[Woo], Vector(java.lang.Boolean.valueOf(true)))))) shouldBe Test3(Right(Woo(true)))
+    Decoder[Test3].decode(AvroRecord(ImmutableRecord(schema, Vector(ImmutableRecord(AvroSchema[Voo], Vector(new Utf8("zzz"))))))) shouldBe Test3(Left(Voo("zzz")))
+    Decoder[Test3].decode(AvroRecord(ImmutableRecord(schema, Vector(ImmutableRecord(AvroSchema[Woo], Vector(java.lang.Boolean.valueOf(true))))))) shouldBe Test3(Right(Woo(true)))
   }
 
   test("use @AvroName defined on a class when choosing which Either to decode") {
@@ -58,8 +59,8 @@ class EitherDecoderTest extends AnyFunSuite with Matchers {
     val union = SchemaBuilder.unionOf().`type`(wschema).and().`type`(tschema).endUnion()
     val schema = SchemaBuilder.record("Test4").fields().name("either").`type`(union).noDefault().endRecord()
 
-    Decoder[Test4].decode(ImmutableRecord(schema, Vector(ImmutableRecord(tschema, Vector(java.lang.Boolean.valueOf(true)))))) shouldBe Test4(Right(Topple(true)))
-    Decoder[Test4].decode(ImmutableRecord(schema, Vector(ImmutableRecord(wschema, Vector(new Utf8("zzz")))))) shouldBe Test4(Left(Wobble("zzz")))
+    Decoder[Test4].decode(AvroRecord(ImmutableRecord(schema, Vector(ImmutableRecord(tschema, Vector(java.lang.Boolean.valueOf(true))))))) shouldBe Test4(Right(Topple(true)))
+    Decoder[Test4].decode(AvroRecord(ImmutableRecord(schema, Vector(ImmutableRecord(wschema, Vector(new Utf8("zzz"))))))) shouldBe Test4(Left(Wobble("zzz")))
   }
 
   test("use @AvroNamespace when choosing which Either to decode") {
@@ -69,8 +70,8 @@ class EitherDecoderTest extends AnyFunSuite with Matchers {
     val union = SchemaBuilder.unionOf().`type`(appleschema).and().`type`(orangeschema).endUnion()
     val schema = SchemaBuilder.record("Test5").fields().name("either").`type`(union).noDefault().endRecord()
 
-    Decoder[Test5].decode(ImmutableRecord(schema, Vector(ImmutableRecord(orangeschema, Vector(java.lang.Boolean.valueOf(true)))))) shouldBe Test5(Right(Orange(true)))
-    Decoder[Test5].decode(ImmutableRecord(schema, Vector(ImmutableRecord(appleschema, Vector(new Utf8("zzz")))))) shouldBe Test5(Left(Apple("zzz")))
+    Decoder[Test5].decode(AvroRecord(ImmutableRecord(schema, Vector(ImmutableRecord(orangeschema, Vector(java.lang.Boolean.valueOf(true))))))) shouldBe Test5(Right(Orange(true)))
+    Decoder[Test5].decode(AvroRecord(ImmutableRecord(schema, Vector(ImmutableRecord(appleschema, Vector(new Utf8("zzz"))))))) shouldBe Test5(Left(Apple("zzz")))
   }
 }
 

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/EnumDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/EnumDecoderTest.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.avro4s.record.decoder
 
-import com.sksamuel.avro4s.{AvroEnumDefault, AvroSchema, Decoder}
+import com.sksamuel.avro4s.{AvroEnumDefault, AvroSchema, AvroValue, Decoder}
 import com.sksamuel.avro4s.schema.{Colours, CupcatAnnotatedEnum, CupcatEnum, CuppersAnnotatedEnum, SnoutleyEnum, Wine}
 import org.apache.avro.generic.GenericData
 import org.apache.avro.generic.GenericData.EnumSymbol
@@ -25,7 +25,7 @@ class EnumDecoderTest extends AnyWordSpec with Matchers {
       val schema = AvroSchema[JavaEnumClass]
       val record = new GenericData.Record(schema)
       record.put("wine", new EnumSymbol(schema.getField("wine").schema(), "CabSav"))
-      Decoder[JavaEnumClass].decode(record) shouldBe JavaEnumClass(Wine.CabSav)
+      Decoder[JavaEnumClass].decode(AvroValue.unsafeFromAny(record)) shouldBe JavaEnumClass(Wine.CabSav)
     }
     "support optional java enums" in {
       val schema = AvroSchema[JavaOptionEnumClass]
@@ -33,17 +33,17 @@ class EnumDecoderTest extends AnyWordSpec with Matchers {
 
       val record1 = new GenericData.Record(schema)
       record1.put("wine", new EnumSymbol(wineSchema, "Merlot"))
-      Decoder[JavaOptionEnumClass].decode(record1) shouldBe JavaOptionEnumClass(Some(Wine.Merlot))
+      Decoder[JavaOptionEnumClass].decode(AvroValue.unsafeFromAny(record1)) shouldBe JavaOptionEnumClass(Some(Wine.Merlot))
 
       val record2 = new GenericData.Record(schema)
       record2.put("wine", null)
-      Decoder[JavaOptionEnumClass].decode(record2) shouldBe JavaOptionEnumClass(None)
+      Decoder[JavaOptionEnumClass].decode(AvroValue.unsafeFromAny(record2)) shouldBe JavaOptionEnumClass(None)
     }
     "support scala enums" in {
       val schema = AvroSchema[ScalaEnumClass]
       val record = new GenericData.Record(schema)
       record.put("colour", new EnumSymbol(schema.getField("colour").schema(), "Green"))
-      Decoder[ScalaEnumClass].decode(record) shouldBe ScalaEnumClass(Colours.Green)
+      Decoder[ScalaEnumClass].decode(AvroValue.unsafeFromAny(record)) shouldBe ScalaEnumClass(Colours.Green)
     }
     "support optional scala enums" in {
       val schema = AvroSchema[ScalaOptionEnumClass]
@@ -51,25 +51,25 @@ class EnumDecoderTest extends AnyWordSpec with Matchers {
 
       val record1 = new GenericData.Record(schema)
       record1.put("colour", new EnumSymbol(colourSchema, "Amber"))
-      Decoder[ScalaOptionEnumClass].decode(record1) shouldBe ScalaOptionEnumClass(Some(Colours.Amber))
+      Decoder[ScalaOptionEnumClass].decode(AvroValue.unsafeFromAny(record1)) shouldBe ScalaOptionEnumClass(Some(Colours.Amber))
 
       val record2 = new GenericData.Record(schema)
       record2.put("colour", null)
-      Decoder[ScalaOptionEnumClass].decode(record2) shouldBe ScalaOptionEnumClass(None)
+      Decoder[ScalaOptionEnumClass].decode(AvroValue.unsafeFromAny(record2)) shouldBe ScalaOptionEnumClass(None)
     }
     "support scala enum default values" in {
       val schema = AvroSchema[ScalaEnumClassWithDefault]
       val record = new GenericData.Record(schema)
 
       record.put("colour", new EnumSymbol(schema.getField("colour").schema(), "Puce"))
-      Decoder[ScalaEnumClassWithDefault].decode(record) shouldBe ScalaEnumClassWithDefault(Colours.Red)
+      Decoder[ScalaEnumClassWithDefault].decode(AvroValue.unsafeFromAny(record)) shouldBe ScalaEnumClassWithDefault(Colours.Red)
     }
     "support sealed trait enum default values in a record" in {
       val schema = AvroSchema[ScalaSealedTraitEnumWithDefault]
       val record = new GenericData.Record(schema)
 
       record.put("cupcat", new EnumSymbol(schema.getField("cupcat").schema(), "NoVarg"))
-      Decoder[ScalaSealedTraitEnumWithDefault].decode(record) shouldBe ScalaSealedTraitEnumWithDefault(SnoutleyEnum)
+      Decoder[ScalaSealedTraitEnumWithDefault].decode(AvroValue.unsafeFromAny(record)) shouldBe ScalaSealedTraitEnumWithDefault(SnoutleyEnum)
     }
     "support annotated sealed trait enum default values" ignore {
 
@@ -79,7 +79,7 @@ class EnumDecoderTest extends AnyWordSpec with Matchers {
       val record = new EnumSymbol(schema, NotCupcat)
 
       // TODO clarify is this really intended to work? it decodes an enum as case class with enum field.
-      Decoder[ScalaAnnotatedSealedTraitEnumWithDefault].decode(record) shouldBe ScalaAnnotatedSealedTraitEnumWithDefault(CuppersAnnotatedEnum)
+      Decoder[ScalaAnnotatedSealedTraitEnumWithDefault].decode(AvroValue.unsafeFromAny(record)) shouldBe ScalaAnnotatedSealedTraitEnumWithDefault(CuppersAnnotatedEnum)
     }
 
     "support annotated sealed trait enum default values - corrected" in {
@@ -90,7 +90,7 @@ class EnumDecoderTest extends AnyWordSpec with Matchers {
       val e = new EnumSymbol(schema, NotCupcat)
       val record = new GenericData.Record(AvroSchema[ScalaAnnotatedSealedTraitEnumWithDefault])
       record.put("cupcat", e)
-      Decoder[ScalaAnnotatedSealedTraitEnumWithDefault].decode(record) shouldBe ScalaAnnotatedSealedTraitEnumWithDefault(CuppersAnnotatedEnum)
+      Decoder[ScalaAnnotatedSealedTraitEnumWithDefault].decode(AvroValue.unsafeFromAny(record)) shouldBe ScalaAnnotatedSealedTraitEnumWithDefault(CuppersAnnotatedEnum)
     }
   }
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/FieldMapperDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/FieldMapperDecoderTest.scala
@@ -1,7 +1,8 @@
 package com.sksamuel.avro4s.record.decoder
 
+import com.sksamuel.avro4s.AvroValue.AvroRecord
 import com.sksamuel.avro4s.record.encoder.NamingTest
-import com.sksamuel.avro4s.{AvroSchema, Decoder, FieldMapper, SchemaFor, SnakeCase}
+import com.sksamuel.avro4s.{AvroSchema, Decoder, FieldMapper, SnakeCase}
 import org.apache.avro.generic.GenericData
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -14,7 +15,7 @@ class FieldMapperDecoderTest extends AnyFunSuite with Matchers {
     val decoder = Decoder[NamingTest]
     val record = new GenericData.Record(schema)
     record.put("camel_case", "foo")
-    val result = decoder.decode(record)
+    val result = decoder.decode(AvroRecord(record))
     result shouldBe NamingTest("foo")
   }
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/FixedDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/FixedDecoderTest.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.avro4s.record.decoder
 
 import com.sksamuel.avro4s.record.encoder.FixedValueType
-import com.sksamuel.avro4s.{AvroFixed, AvroSchema, Decoder}
+import com.sksamuel.avro4s.{AvroFixed, AvroSchema, AvroValue, Decoder}
 import org.apache.avro.generic.GenericData
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -15,13 +15,13 @@ class FixedDecoderTest extends AnyFunSuite with Matchers {
     val schema = AvroSchema[FixedString]
     val record = new GenericData.Record(schema)
     record.put("z", Array[Byte](115, 97, 109))
-    Decoder[FixedString].decode(record) shouldBe FixedString("sam")
+    Decoder[FixedString].decode(AvroValue.unsafeFromAny(record)) shouldBe FixedString("sam")
   }
 
   test("support options of fixed") {
     val schema = AvroSchema[OptionalFixedValueType]
     val record = new GenericData.Record(schema)
     record.put("z", new GenericData.Fixed(AvroSchema[FixedValueType], Array[Byte](115, 97, 109)))
-    Decoder[OptionalFixedValueType].decode(record) shouldBe OptionalFixedValueType(Some(FixedValueType("sam")))
+    Decoder[OptionalFixedValueType].decode(AvroValue.unsafeFromAny(record)) shouldBe OptionalFixedValueType(Some(FixedValueType("sam")))
   }
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/OptionDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/OptionDecoderTest.scala
@@ -2,7 +2,7 @@ package com.sksamuel.avro4s.record.decoder
 
 import java.util
 
-import com.sksamuel.avro4s.{AvroSchema, Decoder}
+import com.sksamuel.avro4s.{AvroSchema, AvroValue, Decoder}
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericData
 import org.scalatest.matchers.should.Matchers
@@ -35,48 +35,46 @@ class OptionDecoderTest extends AnyWordSpec with Matchers {
 
       val record1 = new GenericData.Record(schema)
       record1.put("s", "hello")
-      Decoder[OptionString].decode(record1) shouldBe OptionString(Some("hello"))
+      Decoder[OptionString].decode(AvroValue.unsafeFromAny(record1)) shouldBe OptionString(Some("hello"))
 
       val record2 = new GenericData.Record(schema)
       record2.put("s", null)
-      Decoder[OptionString].decode(record2) shouldBe OptionString(None)
+      Decoder[OptionString].decode(AvroValue.unsafeFromAny(record2)) shouldBe OptionString(None)
     }
     "support decoding required fields as Option" in {
       val requiredStringSchema = AvroSchema[RequiredString]
 
       val requiredStringRecord = new GenericData.Record(requiredStringSchema)
       requiredStringRecord.put("s", "hello")
-      Decoder[OptionString].decode(requiredStringRecord) shouldBe OptionString(Some("hello"))
+      Decoder[OptionString].decode(AvroValue.unsafeFromAny(requiredStringRecord)) shouldBe OptionString(Some("hello"))
     }
     "support boolean options" in {
       val schema = AvroSchema[OptionBoolean]
 
       val record1 = new GenericData.Record(schema)
       record1.put("b", true)
-      Decoder[OptionBoolean].decode(record1) shouldBe OptionBoolean(Some(true))
+      Decoder[OptionBoolean].decode(AvroValue.unsafeFromAny(record1)) shouldBe OptionBoolean(Some(true))
 
       val record2 = new GenericData.Record(schema)
       record2.put("b", null)
-      Decoder[OptionBoolean].decode(record2) shouldBe OptionBoolean(None)
+      Decoder[OptionBoolean].decode(AvroValue.unsafeFromAny(record2)) shouldBe OptionBoolean(None)
     }
     "if a field is missing, use default value" in {
-      val record1 = new GenericData.Record(AvroSchema[SchemaWithoutExpectedField])
-
-      Decoder[OptionStringDefault].decode(record1) shouldBe OptionStringDefault(Some("cupcat"))
+      val record = new GenericData.Record(AvroSchema[SchemaWithoutExpectedField])
+      Decoder[OptionStringDefault].decode(AvroValue.unsafeFromAny(record)) shouldBe OptionStringDefault(Some("cupcat"))
     }
     "if an enum field is missing, use default value" in {
-      val record1 = new GenericData.Record(AvroSchema[SchemaWithoutExpectedField])
-
-      Decoder[OptionEnumDefault].decode(record1) shouldBe OptionEnumDefault(Some(CuppersOptionEnum))
+      val record = new GenericData.Record(AvroSchema[SchemaWithoutExpectedField])
+      Decoder[OptionEnumDefault].decode(AvroValue.unsafeFromAny(record)) shouldBe OptionEnumDefault(Some(CuppersOptionEnum))
     }
     "decode a null field to None" in {
       val schema = AvroSchema[OptionEnumDefaultWithNone]
 
-      val record1 = new GenericData.Record(schema)
-      record1.put("s", null)
-      record1.put("t", "cupcat")
+      val record = new GenericData.Record(schema)
+      record.put("s", null)
+      record.put("t", "cupcat")
 
-      Decoder[OptionEnumDefaultWithNone].decode(record1) shouldBe OptionEnumDefaultWithNone(None, "cupcat")
+      Decoder[OptionEnumDefaultWithNone].decode(AvroValue.unsafeFromAny(record)) shouldBe OptionEnumDefaultWithNone(None, "cupcat")
     }
     "option of seq of case class" in {
       val schema = AvroSchema[OptionOfSeqOfCaseClass]
@@ -97,12 +95,12 @@ class OptionDecoderTest extends AnyWordSpec with Matchers {
       val record1 = new GenericData.Record(schema)
       record1.put("foo", array)
 
-      Decoder[OptionOfSeqOfCaseClass].decode(record1) shouldBe OptionOfSeqOfCaseClass(Some(List(Foo(true), Foo(false))))
+      Decoder[OptionOfSeqOfCaseClass].decode(AvroValue.unsafeFromAny(record1)) shouldBe OptionOfSeqOfCaseClass(Some(List(Foo(true), Foo(false))))
 
       val record2 = new GenericData.Record(schema)
       record2.put("foo", null)
 
-      Decoder[OptionOfSeqOfCaseClass].decode(record2) shouldBe OptionOfSeqOfCaseClass(None)
+      Decoder[OptionOfSeqOfCaseClass].decode(AvroValue.unsafeFromAny(record2)) shouldBe OptionOfSeqOfCaseClass(None)
     }
 
   }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/SchemaEvolutionTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/SchemaEvolutionTest.scala
@@ -48,7 +48,7 @@ class SchemaEvolutionTest extends AnyFunSuite with Matchers {
     val schema = SchemaBuilder.record("foo").fields().requiredString("a").endRecord()
     val record = new GenericData.Record(schema)
     record.put("a", new Utf8("hello"))
-    Decoder[DefaultStringTest].decode(record) shouldBe DefaultStringTest("hello")
+    Decoder[DefaultStringTest].decode(AvroValue.unsafeFromAny(record)) shouldBe DefaultStringTest("hello")
   }
 
   test("when decoding, if the record is missing a field that is present in the schema and the type is option, then set to None") {
@@ -56,6 +56,6 @@ class SchemaEvolutionTest extends AnyFunSuite with Matchers {
     val schema2 = SchemaBuilder.record("foo").fields().requiredString("a").optionalString("b").endRecord()
     val record = new GenericData.Record(schema1)
     record.put("a", new Utf8("hello"))
-    Decoder[OptionalStringTest].decode(record) shouldBe OptionalStringTest("hello", None)
+    Decoder[OptionalStringTest].decode(AvroValue.unsafeFromAny(record)) shouldBe OptionalStringTest("hello", None)
   }
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/SealedTraitDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/SealedTraitDecoderTest.scala
@@ -1,5 +1,6 @@
 package com.sksamuel.avro4s.record.decoder
 
+import com.sksamuel.avro4s.AvroValue.AvroRecord
 import com.sksamuel.avro4s._
 import org.apache.avro.SchemaBuilder
 import org.apache.avro.generic.{GenericData, GenericRecord}
@@ -16,7 +17,7 @@ class SealedTraitDecoderTest extends AnyFunSuite with Matchers {
     wobble.put("str", new Utf8("foo"))
     record.put("wibble", wobble)
 
-    val wrapper = Decoder[Wrapper].decode(record)
+    val wrapper = Decoder[Wrapper].decode(AvroRecord(record))
     wrapper shouldBe Wrapper(Wobble("foo"))
   }
 
@@ -28,7 +29,7 @@ class SealedTraitDecoderTest extends AnyFunSuite with Matchers {
     tobble.put("place", new Utf8("bar"))
     record.put("tibble", tobble)
 
-    val trapper = Decoder[Trapper].decode(record)
+    val trapper = Decoder[Trapper].decode(AvroRecord(record))
     trapper shouldBe Trapper(Tobble("foo", "bar"))
   }
 
@@ -40,7 +41,7 @@ class SealedTraitDecoderTest extends AnyFunSuite with Matchers {
     nabble.put("age", java.lang.Integer.valueOf(44))
     record.put("nibble", nabble)
 
-    val napper = Decoder[Napper].decode(record)
+    val napper = Decoder[Napper].decode(AvroRecord(record))
     napper shouldBe Napper(Nabble("foo", 44))
   }
 
@@ -50,7 +51,7 @@ class SealedTraitDecoderTest extends AnyFunSuite with Matchers {
     nabble.put("str", new Utf8("foo"))
     nabble.put("age", java.lang.Integer.valueOf(44))
 
-    Decoder[Nibble].decode(nabble) shouldBe Nabble("foo", 44)
+    Decoder[Nibble].decode(AvroRecord(nabble)) shouldBe Nabble("foo", 44)
   }
 
   test("use @AvroNamespace when choosing which type to decode") {
@@ -60,8 +61,8 @@ class SealedTraitDecoderTest extends AnyFunSuite with Matchers {
     val union = SchemaBuilder.unionOf().`type`(appleschema).and().`type`(orangeschema).endUnion()
     val schema = SchemaBuilder.record("Buy").fields().name("fruit").`type`(union).noDefault().endRecord()
 
-    Decoder[Buy].decode(ImmutableRecord(schema, Vector(ImmutableRecord(appleschema, Vector(java.lang.Double.valueOf(0.3)))))) shouldBe Buy(Apple(0.3))
-    Decoder[Buy].decode(ImmutableRecord(schema, Vector(ImmutableRecord(orangeschema, Vector(new Utf8("bright orange")))))) shouldBe Buy(Orange("bright orange"))
+    Decoder[Buy].decode(AvroValue.unsafeFromAny(ImmutableRecord(schema, Vector(ImmutableRecord(appleschema, Vector(java.lang.Double.valueOf(0.3))))))) shouldBe Buy(Apple(0.3))
+    Decoder[Buy].decode(AvroValue.unsafeFromAny(ImmutableRecord(schema, Vector(ImmutableRecord(orangeschema, Vector(new Utf8("bright orange"))))))) shouldBe Buy(Orange("bright orange"))
   }
 
   test("use @AvroNamespace and @AvroName with sealed traits of case objects") {
@@ -73,8 +74,8 @@ class SealedTraitDecoderTest extends AnyFunSuite with Matchers {
     val record2 = new GenericData.Record(schema)
     record2.put("thing", "widget")
 
-    Decoder[ThingHolder].decode(record1) shouldBe ThingHolder(WhimWham)
-    Decoder[ThingHolder].decode(record2) shouldBe ThingHolder(Widget)
+    Decoder[ThingHolder].decode(AvroRecord(record1)) shouldBe ThingHolder(WhimWham)
+    Decoder[ThingHolder].decode(AvroRecord(record2)) shouldBe ThingHolder(Widget)
   }
 
   test("use @AvroNamespace and @AvroName with sealed traits of case objects in a round trip") {
@@ -83,7 +84,7 @@ class SealedTraitDecoderTest extends AnyFunSuite with Matchers {
 
     val value = ThingHolder(WhimWham)
     val encodedRecord: GenericRecord = Encoder[ThingHolder].encode(value).asInstanceOf[GenericRecord]
-    val decoded = Decoder[ThingHolder].decode(encodedRecord)
+    val decoded = Decoder[ThingHolder].decode(AvroRecord(encodedRecord))
     decoded shouldBe value
   }
 

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/StructDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/StructDecoderTest.scala
@@ -1,5 +1,6 @@
 package com.sksamuel.avro4s.record.decoder
 
+import com.sksamuel.avro4s.AvroValue.AvroRecord
 import com.sksamuel.avro4s.{AvroSchema, Decoder}
 import org.apache.avro.generic.GenericData
 import org.scalatest.matchers.should.Matchers
@@ -36,7 +37,7 @@ class StructDecoderTest extends AnyWordSpec with Matchers {
       bucks.put("lat", 12.34)
       bucks.put("long", 0.123)
 
-      Decoder[County].decode(bucks) shouldBe obj
+      Decoder[County].decode(AvroRecord(bucks)) shouldBe obj
     }
 
     "decode optional structs" in {
@@ -64,12 +65,12 @@ class StructDecoderTest extends AnyWordSpec with Matchers {
       val record = new GenericData.Record(optionCountySchema)
       record.put("county", bucks)
 
-      Decoder[OptionCounty].decode(record) shouldBe obj
+      Decoder[OptionCounty].decode(AvroRecord(record)) shouldBe obj
 
       val emptyRecord = new GenericData.Record(optionCountySchema)
       emptyRecord.put("county", null)
 
-      Decoder[OptionCounty].decode(emptyRecord) shouldBe OptionCounty(None)
+      Decoder[OptionCounty].decode(AvroRecord(emptyRecord)) shouldBe OptionCounty(None)
     }
   }
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/TransientDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/TransientDecoderTest.scala
@@ -1,5 +1,6 @@
 package com.sksamuel.avro4s.record.decoder
 
+import com.sksamuel.avro4s.AvroValue.AvroRecord
 import com.sksamuel.avro4s.{AvroSchema, AvroTransient, Decoder}
 import org.apache.avro.generic.GenericData
 import org.apache.avro.util.Utf8
@@ -14,6 +15,6 @@ class TransientDecoderTest extends AnyFunSuite with Matchers {
     val schema = AvroSchema[TransientFoo]
     val record = new GenericData.Record(schema)
     record.put("a", new Utf8("hello"))
-    Decoder[TransientFoo].decode(record) shouldBe TransientFoo("hello", None)
+    Decoder[TransientFoo].decode(AvroRecord(record)) shouldBe TransientFoo("hello", None)
   }
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/TupleDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/TupleDecoderTest.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.avro4s.record.decoder
 
-import com.sksamuel.avro4s.{AvroSchema, Decoder}
+import com.sksamuel.avro4s.{AvroSchema, AvroValue, Decoder}
 import org.apache.avro.generic.GenericData
 import org.apache.avro.util.Utf8
 import org.scalatest.funsuite.AnyFunSuite
@@ -26,7 +26,7 @@ class TupleDecoderTest extends AnyFunSuite with Matchers {
     z.put("_2", java.lang.Integer.valueOf(214))
     val record = new GenericData.Record(schema)
     record.put("z", z)
-    Decoder[Test2].decode(record) shouldBe Test2(("hello", 214))
+    Decoder[Test2].decode(AvroValue.unsafeFromAny(record)) shouldBe Test2(("hello", 214))
   }
 
   test("decode tuple2 with seq") {
@@ -36,7 +36,7 @@ class TupleDecoderTest extends AnyFunSuite with Matchers {
     z.put("_2", java.lang.Integer.valueOf(214))
     val record = new GenericData.Record(schema)
     record.put("z", z)
-    Decoder[Test2Seq].decode(record) shouldBe Test2Seq((Seq("hello"), 214))
+    Decoder[Test2Seq].decode(AvroValue.unsafeFromAny(record)) shouldBe Test2Seq((Seq("hello"), 214))
   }
 
   test("decode tuple3") {
@@ -47,7 +47,7 @@ class TupleDecoderTest extends AnyFunSuite with Matchers {
     z.put("_3", java.lang.Boolean.valueOf(true))
     val record = new GenericData.Record(schema)
     record.put("z", z)
-    Decoder[Test3].decode(record) shouldBe Test3(("hello", 214, true))
+    Decoder[Test3].decode(AvroValue.unsafeFromAny(record)) shouldBe Test3(("hello", 214, true))
   }
 
   test("decode tuple3 with seq") {
@@ -58,7 +58,7 @@ class TupleDecoderTest extends AnyFunSuite with Matchers {
     z.put("_3", java.lang.Boolean.valueOf(true))
     val record = new GenericData.Record(schema)
     record.put("z", z)
-    Decoder[Test3Seq].decode(record) shouldBe Test3Seq(("hello", Seq(214), true))
+    Decoder[Test3Seq].decode(AvroValue.unsafeFromAny(record)) shouldBe Test3Seq(("hello", Seq(214), true))
   }
 
   test("decode tuple4") {
@@ -70,7 +70,7 @@ class TupleDecoderTest extends AnyFunSuite with Matchers {
     z.put("_4", java.lang.Double.valueOf(56.45))
     val record = new GenericData.Record(schema)
     record.put("z", z)
-    Decoder[Test4].decode(record) shouldBe Test4(("hello", 214, true, 56.45))
+    Decoder[Test4].decode(AvroValue.unsafeFromAny(record)) shouldBe Test4(("hello", 214, true, 56.45))
   }
 
   test("decode tuple4 with seq") {
@@ -82,7 +82,7 @@ class TupleDecoderTest extends AnyFunSuite with Matchers {
     z.put("_4", List(java.lang.Double.valueOf(56.45)).asJava)
     val record = new GenericData.Record(schema)
     record.put("z", z)
-    Decoder[Test4Seq].decode(record) shouldBe Test4Seq(("hello", 214, true, Seq(56.45)))
+    Decoder[Test4Seq].decode(AvroValue.unsafeFromAny(record)) shouldBe Test4Seq(("hello", 214, true, Seq(56.45)))
   }
 
   test("decode tuple5") {
@@ -95,7 +95,7 @@ class TupleDecoderTest extends AnyFunSuite with Matchers {
     z.put("_5", java.lang.Long.valueOf(9999999999L))
     val record = new GenericData.Record(schema)
     record.put("z", z)
-    Decoder[Test5].decode(record) shouldBe Test5(("hello", 214, true, 56.45, 9999999999L))
+    Decoder[Test5].decode(AvroValue.unsafeFromAny(record)) shouldBe Test5(("hello", 214, true, 56.45, 9999999999L))
   }
 
   test("decode tuple5 with seq") {
@@ -108,7 +108,7 @@ class TupleDecoderTest extends AnyFunSuite with Matchers {
     z.put("_5", List(java.lang.Long.valueOf(9999999999L)).asJava)
     val record = new GenericData.Record(schema)
     record.put("z", z)
-    Decoder[Test5Seq].decode(record) shouldBe Test5Seq(("hello", 214, true, 56.45, Seq(9999999999L)))
+    Decoder[Test5Seq].decode(AvroValue.unsafeFromAny(record)) shouldBe Test5Seq(("hello", 214, true, 56.45, Seq(9999999999L)))
   }
 }
 

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/UUIDDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/UUIDDecoderTest.scala
@@ -2,6 +2,7 @@ package com.sksamuel.avro4s.record.decoder
 
 import java.util.UUID
 
+import com.sksamuel.avro4s.AvroValue.AvroRecord
 import com.sksamuel.avro4s.{AvroSchema, Decoder}
 import org.apache.avro.generic.GenericData
 import org.apache.avro.util.Utf8
@@ -18,14 +19,14 @@ class UUIDDecoderTest extends AnyWordSpec with Matchers {
       val schema = AvroSchema[UUIDTest]
       val record = new GenericData.Record(schema)
       record.put("uuid", uuid.toString)
-      Decoder[UUIDTest].decode(record) shouldBe UUIDTest(uuid)
+      Decoder[UUIDTest].decode(AvroRecord(record)) shouldBe UUIDTest(uuid)
     }
     "decode UUIDSs encoded as Utf8" in {
       val uuid = UUID.randomUUID()
       val schema = AvroSchema[UUIDTest]
       val record = new GenericData.Record(schema)
       record.put("uuid", new Utf8(uuid.toString))
-      Decoder[UUIDTest].decode(record) shouldBe UUIDTest(uuid)
+      Decoder[UUIDTest].decode(AvroRecord(record)) shouldBe UUIDTest(uuid)
     }
     "decode seq of uuids" in {
       val schema = AvroSchema[UUIDSeq]
@@ -36,7 +37,7 @@ class UUIDDecoderTest extends AnyWordSpec with Matchers {
       val record = new GenericData.Record(schema)
       record.put("uuids", List(uuid1.toString, uuid2.toString).asJava)
 
-      Decoder[UUIDSeq].decode(record) shouldBe UUIDSeq(List(uuid1, uuid2))
+      Decoder[UUIDSeq].decode(AvroRecord(record)) shouldBe UUIDSeq(List(uuid1, uuid2))
     }
     "decode Option[UUID]" in {
       val schema = AvroSchema[UUIDOption]
@@ -45,12 +46,12 @@ class UUIDDecoderTest extends AnyWordSpec with Matchers {
       val record1 = new GenericData.Record(schema)
       record1.put("uuid", uuid.toString)
 
-      Decoder[UUIDOption].decode(record1) shouldBe UUIDOption(Some(uuid))
+      Decoder[UUIDOption].decode(AvroRecord(record1)) shouldBe UUIDOption(Some(uuid))
 
       val record2 = new GenericData.Record(schema)
       record2.put("uuid", null)
 
-      Decoder[UUIDOption].decode(record2) shouldBe UUIDOption(None)
+      Decoder[UUIDOption].decode(AvroRecord(record2)) shouldBe UUIDOption(None)
     }
   }
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/ValueTypeDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/ValueTypeDecoderTest.scala
@@ -1,5 +1,6 @@
 package com.sksamuel.avro4s.record.decoder
 
+import com.sksamuel.avro4s.AvroValue.{AvroRecord, AvroString}
 import com.sksamuel.avro4s.{AvroSchema, Decoder}
 import org.apache.avro.generic.GenericData
 import org.apache.avro.util.Utf8
@@ -12,7 +13,7 @@ class ValueTypeDecoderTest extends AnyFunSuite with Matchers {
   case class OptionTest(foo: Option[FooValueType])
 
   test("top level value types") {
-    val actual = Decoder[FooValueType].decode("hello")
+    val actual = Decoder[FooValueType].decode(AvroString("hello"))
     actual shouldBe FooValueType("hello")
   }
 
@@ -22,7 +23,7 @@ class ValueTypeDecoderTest extends AnyFunSuite with Matchers {
     val record1 = new GenericData.Record(schema)
     record1.put("foo", new Utf8("hello"))
 
-    Decoder[Test].decode(record1) shouldBe Test(FooValueType("hello"))
+    Decoder[Test].decode(AvroRecord(record1)) shouldBe Test(FooValueType("hello"))
   }
 
   test("support value types inside Options") {
@@ -31,7 +32,7 @@ class ValueTypeDecoderTest extends AnyFunSuite with Matchers {
     val record1 = new GenericData.Record(schema)
     record1.put("foo", new Utf8("hello"))
 
-    Decoder[OptionTest].decode(record1) shouldBe OptionTest(Some(FooValueType("hello")))
+    Decoder[OptionTest].decode(AvroRecord(record1)) shouldBe OptionTest(Some(FooValueType("hello")))
   }
 }
 

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/AvroNameEncoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/AvroNameEncoderTest.scala
@@ -35,7 +35,7 @@ class AvroNameEncoderTest extends AnyFunSuite with Matchers {
   test("support encoding and decoding with empty namespaces") {
     val spaceship = Spaceship(MiserableCosmos(true))
     val encoded = Encoder[Spaceship].encode(spaceship)
-    val decoded = Decoder[Spaceship].decode(encoded)
+    val decoded = Decoder[Spaceship].decode(AvroValue.unsafeFromAny(encoded))
     spaceship shouldBe decoded
   }
 

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/SchemaForUtf8Test.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/SchemaForUtf8Test.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.avro4s.schema
 
-import com.sksamuel.avro4s.{AvroSchema, Encoder, FromRecord, ImmutableRecord, ToRecord}
+import com.sksamuel.avro4s.{AvroSchema, FromRecord, ImmutableRecord, ToRecord}
 import org.apache.avro.util.Utf8
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
@@ -46,7 +46,7 @@ class SchemaForUtf8Test extends AnyFunSpec with Matchers {
     it("should deserialize objects that contains Optional Utf8 attributes") {
       case class Person(name: Utf8, familyName: Option[Utf8], alias: Option[Utf8], age: Int)
 
-      val record = ImmutableRecord(AvroSchema[Person], Vector(new Utf8("Name"), None, Some(new Utf8("Alias")), 30.asInstanceOf[AnyRef]))
+      val record = ImmutableRecord(AvroSchema[Person], Vector(new Utf8("Name"), null, new Utf8("Alias"), 30.asInstanceOf[AnyRef]))
       FromRecord[Person].from(record)
     }
   }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/streams/output/EnumOutputStreamTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/streams/output/EnumOutputStreamTest.scala
@@ -19,7 +19,7 @@ class EnumOutputStreamTest extends AnyFunSuite with Matchers with OutputStreamTe
   test("optional java enum") {
     case class Test(z: Option[Wine])
     val schema = AvroSchema[Wine]
-    writeRead(Test(Some(Wine.Malbec))) { record =>
+    writeRead(Test(Option(Wine.Malbec))) { record =>
       record.get("z") shouldBe GenericData.get.createEnum(Wine.Malbec.name, schema)
     }
     writeRead(Test(None)) { record =>
@@ -38,7 +38,7 @@ class EnumOutputStreamTest extends AnyFunSuite with Matchers with OutputStreamTe
   test("optional scala enum") {
     case class Test(z: Option[Colours.Value])
     val schema = AvroSchema[Wine]
-    writeRead(Test(Some(Colours.Green))) { record =>
+    writeRead(Test(Option(Colours.Green))) { record =>
       record.get("z") shouldBe GenericData.get.createEnum(Colours.Green.toString, schema)
     }
     writeRead(Test(None)) { record =>

--- a/avro4s-kafka/src/main/scala/com/sksamuel/avro4s/kafka/GenericSerde.scala
+++ b/avro4s-kafka/src/main/scala/com/sksamuel/avro4s/kafka/GenericSerde.scala
@@ -9,10 +9,10 @@ import org.apache.kafka.common.serialization.{Deserializer, Serde, Serializer}
 /**
   * Kafka Serde using Avro4s for serializing to/deserialising from case classes into Avro records, without integration
   * with the Confluent schema registry.
- *
- * The implicit schemaFor instance is used as the writer schema when deserializing, in case it needs to diverge
- * from both writer schema used in serialize, and the desired schema in deserialize.
- */
+  *
+  * The implicit schemaFor instance is used as the writer schema when deserializing, in case it needs to diverge
+  * from both writer schema used in serialize, and the desired schema in deserialize.
+  */
 class GenericSerde[T >: Null : SchemaFor : Encoder : Decoder](avroFormat: AvroFormat = BinaryFormat) extends Serde[T]
   with Deserializer[T]
   with Serializer[T]

--- a/benchmarks/src/main/scala/benchmarks/Decoding.scala
+++ b/benchmarks/src/main/scala/benchmarks/Decoding.scala
@@ -5,6 +5,7 @@ import java.nio.ByteBuffer
 import java.util.Collections
 
 import benchmarks.record._
+import com.sksamuel.avro4s.AvroValue.AvroRecord
 import com.sksamuel.avro4s._
 import org.apache.avro.generic.{GenericDatumReader, GenericDatumWriter, GenericRecord}
 import org.apache.avro.io.{DecoderFactory, EncoderFactory}
@@ -60,7 +61,7 @@ class Decoding extends CommonParams with BenchmarkHelpers {
     val dec =
       DecoderFactory.get().binaryDecoder(new ByteBufferInputStream(Collections.singletonList(bytes.duplicate)), null)
     val record = reader.read(null, dec)
-    decoder.decode(record)
+    decoder.decode(AvroRecord(record))
   }
 
 

--- a/benchmarks/src/main/scala/benchmarks/handrolled_codecs/package.scala
+++ b/benchmarks/src/main/scala/benchmarks/handrolled_codecs/package.scala
@@ -37,7 +37,7 @@ package object handrolled_codecs {
     val emptySn: String = emptyDecoder.schema.getFullName
     val invalidSn: String = invalidDecoder.schema.getFullName
 
-    def decode(value: Any): AttributeValue[T] = {
+    override def decode(value: AvroValue): AttributeValue[T] = {
       val schema = value match {
         case r: GenericData.Record => r.getSchema
         case i: ImmutableRecord    => i.schema

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -74,7 +74,7 @@ object Build extends AutoPlugin {
     if (isTravis) {
       version := s"4.1.0.$travisBuildNumber-SNAPSHOT"
     } else {
-      version := "4.0.0-RC1"
+      version := "4.0.0-RC2"
     },
     publishTo := {
       val nexus = "https://oss.sonatype.org/"


### PR DESCRIPTION
Added `AvroValue` ADT and changed `Decoder` trait to define `def decode(value: AvroValue): T`

Some points:

* I decided to do the normalization of values at the time we build the ADT. For example for strings, possibly "stringy" types are CharSequence, String and UTF8. Rather than define 3 types in the ADT, I just normalize to a single type, AvroString. Another example is instead of two types for byte arrays and ByteBuffer, I normalize both to AvroByteArray.
* The decoders are simplified because they no longer need to match on multiple possible "java" types.
* For records, I defined AvroRecord which wraps GenericRecord. I don't know if we want to wrap IndexedRecord instead, or even have multiple types in the ADT.
* This change only covers Decoder and not Encoders.
* All tests are passing but I have **not** measured performance.