### PR TITLE
Add scala set case to default resolver pattern matching

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/DefaultResolver.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/DefaultResolver.scala
@@ -40,6 +40,7 @@ object DefaultResolver {
     case x: scala.Float => java.lang.Float.valueOf(x)
     case x: Map[_,_] => x.asJava
     case x: Seq[_] => x.asJava
+    case x: Set[_] => x.asJava
     case shapeless.Inl(x) => apply(x, schema)
     case p: Product => customDefault(p, schema)
     case v if isScalaEnumeration(v) => customScalaEnumDefault(value)

--- a/avro4s-core/src/test/resources/defaultvalues.json
+++ b/avro4s-core/src/test/resources/defaultvalues.json
@@ -55,6 +55,31 @@
         "symbols": ["Malbec", "Shiraz", "CabSav", "Merlot"]
       },
       "default": "CabSav"
+    },
+    {
+      "name": "luckyNumbers",
+      "type": {
+        "type": "array",
+        "items": "int"
+      },
+      "default": [7, 9]
+    },
+    {
+      "name": "favoriteSongs",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "Song",
+          "fields": [
+            {
+              "name": "title",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "default": []
     }
   ]
 }

--- a/avro4s-core/src/test/resources/optional_default_values.json
+++ b/avro4s-core/src/test/resources/optional_default_values.json
@@ -55,6 +55,31 @@
         "symbols": ["Malbec", "Shiraz", "CabSav", "Merlot"]
       }, "null"],
       "default": "CabSav"
+    },
+    {
+      "name": "luckyNumbers",
+      "type": [{
+          "type": "array",
+          "items": "int"
+        }, "null"],
+      "default": [7, 9]
+    },
+    {
+      "name": "favoriteSongs",
+      "type": [{
+          "type": "array",
+          "items": {
+            "type": "record",
+            "name": "Song",
+            "fields": [
+              {
+                "name": "title",
+                "type": "string"
+              }
+            ]
+          }
+        }, "null"],
+      "default": []
     }
   ]
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/DefaultValueSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/DefaultValueSchemaTest.scala
@@ -39,7 +39,7 @@ class DefaultValueSchemaTest extends AnyWordSpec with Matchers {
       val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/default_values_float.json"))
       schema.toString(true) shouldBe expected.toString(true)
     }
-    "support default values for maps and seqs" in {
+    "support default values for maps, sets and seqs" in {
       val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/defaultvalues.json"))
       val schema = AvroSchema[DefaultValues]
       schema.toString(true) shouldBe expected.toString(true)
@@ -50,7 +50,7 @@ class DefaultValueSchemaTest extends AnyWordSpec with Matchers {
       schema.toString(true) shouldBe expected.toString(true)
     }
 
-    "support default values of optional Seq and Map" in {
+    "support default values of optional Seq, Set and Map" in {
       val schema = AvroSchema[OptionalDefaultValues]
       val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/optional_default_values.json"))
       schema.toString(true) shouldBe expected.toString(true)
@@ -78,16 +78,19 @@ case class UpperDog(how_fortunate: Double) extends Dog
 case class DogProspect(dog: Option[Dog] = None)
 
 case class OptionalDefaultValues(name: Option[String] = Some("sammy"),
-                         age: Option[Int] = Some(21),
-                         isFemale: Option[Boolean] = Some(false),
-                         length: Option[Double] = Some(6.2),
-                         timestamp: Option[Long] = Some(1468920998000l),
-                         address: Option[Map[String, String]] = Some(Map(
-                           "home" -> "sammy's home address",
-                           "work" -> "sammy's work address"
-                         )),
-                         traits: Option[Seq[String]] = Some(Seq("Adventurous", "Helpful")),
-                         favoriteWine: Option[Wine] = Some(Wine.CabSav))
+                                 age: Option[Int] = Some(21),
+                                 isFemale: Option[Boolean] = Some(false),
+                                 length: Option[Double] = Some(6.2),
+                                 timestamp: Option[Long] = Some(1468920998000l),
+                                 address: Option[Map[String, String]] = Some(Map(
+                                   "home" -> "sammy's home address",
+                                   "work" -> "sammy's work address"
+                                 )),
+                                 traits: Option[Seq[String]] = Some(Seq("Adventurous", "Helpful")),
+                                 favoriteWine: Option[Wine] = Some(Wine.CabSav),
+                                 luckyNumbers: Option[Set[Int]] = Some(Set(7, 9)),
+                                 favoriteSongs: Option[Set[Song]] = Some(Set.empty[Song])
+                                )
 
 
 case class ClassWithDefaultString(s: String = "foo")
@@ -107,7 +110,10 @@ case class DefaultValues(name: String = "sammy",
                            "work" -> "sammy's work address"
                          ),
                          traits: Seq[String] = Seq("Adventurous", "Helpful"),
-                         favoriteWine: Wine = Wine.CabSav)
+                         favoriteWine: Wine = Wine.CabSav,
+                         luckyNumbers: Set[Int] = Set(7, 9),
+                         favoriteSongs: Set[Song] = Set.empty[Song]
+                        )
 
 sealed trait Cupcat
 case object Rendal extends Cupcat
@@ -115,3 +121,5 @@ case class Snoutley(snoutley: String) extends Cupcat
 
 case class Cuppers(cupcat: Cupcat = Snoutley("hates varg"))
 case class NoVarg(cupcat: Cupcat = Rendal)
+
+case class Song(title: String)


### PR DESCRIPTION
Hey, 

I added the default value support for sets and enhanced the related est cases.

As for seqs, this works only with primitives right now if one wants to use actual default values. Empty seqs and sets are also working with non-primitive types.

E.g:

```scala
case class Song(title: String)

case class TestA(uniqueSongs: Set[Song] = Set.empty[Song]) // works
case class TestB(uniqueSongs: Set[Song] = Set(Song("Smoke on the Water")) // does not work

case class TestC(luckyNumbers: Set[Int] = Set(7, 9)) //works
```

I need to dig deeper into the codebase to understand the problem with non-primitive types and default values. Another issue related to this will be coming soon.
 