### PR TITLE
Add support for java.time.Instant default values. Fixes #542

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/CustomDefaults.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/CustomDefaults.scala
@@ -1,5 +1,7 @@
 package com.sksamuel.avro4s
 
+import java.time.Instant
+
 import magnolia.{SealedTrait, Subtype}
 import org.json4s.native.JsonMethods.parse
 import org.json4s.native.Serialization.write
@@ -54,6 +56,12 @@ object CustomDefaults {
   }
 
   def isScalaEnumeration(value: Any) = value.getClass.getCanonicalName == "scala.Enumeration.Val"
+
+  def customInstantDefault(instant: Instant): java.lang.Long = instant match {
+    case Instant.MAX => Instant.ofEpochMilli(Long.MaxValue).toEpochMilli()
+    case Instant.MIN => Instant.ofEpochMilli(Long.MinValue).toEpochMilli()
+    case _ => instant.toEpochMilli()
+  }
 
   private def isEnum(product: Product, schemaType: Schema.Type) =
     product.productArity == 0 && schemaType == Schema.Type.ENUM

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/DefaultResolver.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/DefaultResolver.scala
@@ -1,6 +1,7 @@
 package com.sksamuel.avro4s
 
 import java.nio.ByteBuffer
+import java.time.Instant
 import java.util.UUID
 
 import org.apache.avro.LogicalTypes.Decimal
@@ -26,6 +27,7 @@ object DefaultResolver {
     case u: Utf8 => u.toString
     case uuid: UUID => uuid.toString
     case enum: GenericEnumSymbol[_] => enum.toString
+    case instant: Instant => customInstantDefault(instant)
     case fixed: GenericFixed => fixed.bytes()
     case bd: BigDecimal => bd.toString()
     case byteBuffer: ByteBuffer if schema.getLogicalType.isInstanceOf[Decimal] =>

--- a/avro4s-core/src/test/resources/default_values_instant.json
+++ b/avro4s-core/src/test/resources/default_values_instant.json
@@ -1,0 +1,31 @@
+{
+    "type": "record",
+    "name": "ClassWithDefaultInstant",
+    "namespace": "com.sksamuel.avro4s.schema",
+    "fields": [
+        {
+            "name": "min",
+            "type": {
+                "type": "long",
+                "logicalType": "timestamp-millis"
+            },
+            "default": -9223372036854775808
+        },
+        {
+            "name": "max",
+            "type": {
+                "type": "long",
+                "logicalType": "timestamp-millis"
+            },
+            "default": 9223372036854775807
+        },
+        {
+            "name": "epoch",
+            "type": {
+                "type": "long",
+                "logicalType": "timestamp-millis"
+            },
+            "default": 0
+        }
+    ]
+}

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/DefaultValueSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/DefaultValueSchemaTest.scala
@@ -1,5 +1,7 @@
 package com.sksamuel.avro4s.schema
 
+import java.time.Instant
+
 import com.sksamuel.avro4s.AvroSchema
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -37,6 +39,11 @@ class DefaultValueSchemaTest extends AnyWordSpec with Matchers {
     "support default values for floats in top level classes" in {
       val schema = AvroSchema[ClassWithDefaultFloat]
       val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/default_values_float.json"))
+      schema.toString(true) shouldBe expected.toString(true)
+    }
+    "support default values for instants in top level classes" in {
+      implicit val schema = AvroSchema[ClassWithDefaultInstant]
+      val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/default_values_instant.json"))
       schema.toString(true) shouldBe expected.toString(true)
     }
     "support default values for maps, sets and seqs" in {
@@ -99,6 +106,7 @@ case class ClassWithDefaultBoolean(b: Boolean = true)
 case class ClassWithDefaultLong(l: Long = 1468920998000l)
 case class ClassWithDefaultFloat(f: Float = 123.458F)
 case class ClassWithDefaultDouble(d: Double = 123.456)
+case class ClassWithDefaultInstant(min: Instant = Instant.MIN, max: Instant = Instant.MAX, epoch: Instant = Instant.EPOCH)
 
 case class DefaultValues(name: String = "sammy",
                          age: Int = 21,
@@ -123,3 +131,4 @@ case class Cuppers(cupcat: Cupcat = Snoutley("hates varg"))
 case class NoVarg(cupcat: Cupcat = Rendal)
 
 case class Song(title: String)
+


### PR DESCRIPTION
Hey 

I added `java.time.Instant` top-level default value support for class definitions like:

```scala
case class ClassWithDefaultInstant(min: Instant = Instant.MIN, max: Instant = Instant.MAX, epoch: Instant = Instant.EPOCH)
```

To support `Instant.MAX` and `Instant.MIN` I used the boxed primitive max and min value from `scala.Long` in order to avoid an `java.lang.ArithmeticException: long overflow`. 

If this is an issue I need to come up with a different solution. I also thought about using a `scala.math.BigInt` or `scala.math.BigDecimal` in combination with Avro's `"logicalType": "decimal"`, but this would break the avro4s default `java.time.Instant` to `"logicalType": "timestamp-millis"` conversion. 

Please let me know if further action on my side is required :slightly_smiling_face: 

Best Regards, 
Roman