### PR TITLE
Change type guard order. Fixes #545

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/TypeGuardedDecoding.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/TypeGuardedDecoding.scala
@@ -21,10 +21,10 @@ object TypeGuardedDecoding {
     else if (tpe <:< typeOf[Double]) doubleDecoder(decoder)
     else if (tpe <:< typeOf[Float]) floatDecoder(decoder)
     else if (tpe <:< typeOf[Array[Byte]]) byteArrayDecoder(decoder)
-    else if (tpe <:< typeOf[Array[_]] || tpe <:< typeOf[java.util.Collection[_]] || tpe <:< typeOf[Iterable[_]]) {
-      arrayDecoder(decoder)
-    } else if (tpe <:< typeOf[java.util.Map[_, _]] || tpe <:< typeOf[Map[_, _]]) {
+    else if (tpe <:< typeOf[java.util.Map[_, _]] || tpe <:< typeOf[Map[_, _]]) {
       mapDecoder(decoder)
+    } else if (tpe <:< typeOf[Array[_]] || tpe <:< typeOf[java.util.Collection[_]] || tpe <:< typeOf[Iterable[_]]) {
+      arrayDecoder(decoder)
     } else if (tpe <:< typeOf[shapeless.Coproduct]) {
       coproductDecoder(decoder)
     } else {

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/GithubIssue545.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/GithubIssue545.scala
@@ -10,8 +10,6 @@ import scala.reflect.runtime.universe._
 import scala.collection.JavaConverters._
 
 class GithubIssue545 extends AnyWordSpec with Matchers {
-//  implicit val left: Decoder[Map[String, String]] = _
-
   "TypeGuardedDecoding" should {
     "create a map decoder instead of an array decoder" in {
       val mapDecoder = Decoder.mapDecoder[String]

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/GithubIssue545.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/GithubIssue545.scala
@@ -1,0 +1,25 @@
+package com.sksamuel.avro4s.github
+
+import com.sksamuel.avro4s.{Decoder, TypeGuardedDecoding}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe._
+
+import scala.collection.JavaConverters._
+
+class GithubIssue545 extends AnyWordSpec with Matchers {
+//  implicit val left: Decoder[Map[String, String]] = _
+
+  "TypeGuardedDecoding" should {
+    "create a map decoder instead of an array decoder" in {
+      val mapDecoder = Decoder.mapDecoder[String]
+
+      val typeGuard = TypeGuardedDecoding.guard[Map[String, String]](mapDecoder)
+      val value = Map().asJava
+
+      typeGuard.isDefinedAt(value) shouldBe true
+    }
+  }
+}


### PR DESCRIPTION
Hello!

I've added a change in the order of how internal decoders from scenarios using `Either[X, Map[_, _]]` or Shapeless coproduct (including a map in the coproduct) are being returned.

In case of having `Either[X, Map[_, _]]` it will return a decoder of type `Either[X, ArrayDecoder]` instead of `Either[X, MapDecoder]` since there is a small bug in the order how the types are being checked.