### PR TITLE
Fix FieldMapper not sealed to allow free implementation

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/FieldMapper.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/FieldMapper.scala
@@ -9,7 +9,7 @@ import scala.collection.mutable.ListBuffer
   * The [[FieldMapper]] is used to map fields in a schema to fields in a class by
   * transforming the class field name to the wire name format.
   */
-sealed trait FieldMapper {
+trait FieldMapper {
 
   /**
     * Takes a field name from a type and converts it to the wire format.


### PR DESCRIPTION
I would like to feel free to implement FieldMapper.
For example, implement names transformation as snake_case to CamelCase using `guava` lib or something else.