### PR TITLE
Constrain refinedSchemaFor to require a RefType

### DIFF
--- a/avro4s-refined/src/main/scala/com/sksamuel/avro4s/refined/package.scala
+++ b/avro4s-refined/src/main/scala/com/sksamuel/avro4s/refined/package.scala
@@ -4,7 +4,7 @@ import eu.timepit.refined.api.{RefType, Validate}
 
 package object refined {
 
-  implicit def refinedSchemaFor[T, P, F[_, _]](implicit schemaFor: SchemaFor[T]): SchemaFor[F[T, P]] =
+  implicit def refinedSchemaFor[T, P, F[_, _] : RefType](implicit schemaFor: SchemaFor[T]): SchemaFor[F[T, P]] =
     schemaFor.forType
 
   implicit def refinedEncoder[T: Encoder, P, F[_, _] : RefType]: Encoder[F[T, P]] =

--- a/avro4s-refined/src/test/scala/com/sksamuel/avro4s/refined/RefinedTest.scala
+++ b/avro4s-refined/src/test/scala/com/sksamuel/avro4s/refined/RefinedTest.scala
@@ -27,6 +27,14 @@ class RefinedTest extends AnyWordSpec with Matchers {
           |}
         """.stripMargin)
     }
+
+    "generate correct schemas for a Map when refined instances are in scope" in {
+      case class Test(map: Map[String, Int], nonEmptyStr: String Refined NonEmpty)
+      val schema = AvroSchema[Test]
+
+      schema.getField("map").schema().getType shouldBe Schema.Type.MAP
+      schema.getField("nonEmptyStr").schema().getType shouldBe Schema.Type.STRING
+    }
   }
 
   "refinedEncoder" should {


### PR DESCRIPTION
Fixes #571 

```scala
implicit def refinedSchemaFor[T, P, F[_, _]](implicit schemaFor: SchemaFor[T]): SchemaFor[F[T, P]]
```
The above signature doesn't constrain `F[_, _]` to be a refined type. So I think when trying to resolve a schema for `Map[String, String]`, this actually matches the shape of the above instance intended for a refined type `SchemaFor[F[T, P]]` where `T` is now a string - so this just uses the `SchemaFor[String]` instance and we end up with a schema typed as a string.

By saying that `F` needs a `RefType` instance, `refinedSchemaFor` now can't be used for for a `Map[_, _]` which can now correctly resolve to `mapSchemaFor`.