### PR TITLE
Refined + TypeGuardedDecoding issues

### DIFF
--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/GithubIssue545.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/GithubIssue545.scala
@@ -14,7 +14,7 @@ class GithubIssue545 extends AnyWordSpec with Matchers {
     "create a map decoder instead of an array decoder" in {
       val mapDecoder = Decoder.mapDecoder[String]
 
-      val typeGuard = TypeGuardedDecoding.guard[Map[String, String]](mapDecoder)
+      val typeGuard = TypeGuardedDecoding[Map[String, String]].guard(mapDecoder)
       val value = Map().asJava
 
       typeGuard.isDefinedAt(value) shouldBe true

--- a/avro4s-refined/src/main/scala/com/sksamuel/avro4s/refined/package.scala
+++ b/avro4s-refined/src/main/scala/com/sksamuel/avro4s/refined/package.scala
@@ -2,6 +2,8 @@ package com.sksamuel.avro4s
 
 import eu.timepit.refined.api.{RefType, Validate}
 
+import scala.reflect.runtime.universe._
+
 package object refined {
 
   implicit def refinedSchemaFor[T, P, F[_, _] : RefType](implicit schemaFor: SchemaFor[T]): SchemaFor[F[T, P]] =
@@ -12,4 +14,9 @@ package object refined {
 
   implicit def refinedDecoder[T: Decoder, P, F[_, _] : RefType](implicit validate: Validate[T, P]): Decoder[F[T, P]] =
     Decoder[T].map(RefType[F].refine[P].unsafeFrom[T])
+
+  implicit def refinedTypeGuardedDecoding[T: WeakTypeTag, P, F[_, _]: RefType]: TypeGuardedDecoding[F[T, P]] = new TypeGuardedDecoding[F[T, P]] {
+    override final def guard(decoderT: Decoder[F[T, P]]): PartialFunction[Any, F[T, P]] =
+      TypeGuardedDecoding[T].guard(decoderT.map(RefType[F].unwrap)).andThen(RefType[F].unsafeWrap(_))
+  }
 }

--- a/avro4s-refined/src/test/scala/com/sksamuel/avro4s/refined/RefinedRoundtripTest.scala
+++ b/avro4s-refined/src/test/scala/com/sksamuel/avro4s/refined/RefinedRoundtripTest.scala
@@ -1,0 +1,43 @@
+package com.sksamuel.avro4s.refined
+
+import com.sksamuel.avro4s.streams.input.InputStreamTest
+import eu.timepit.refined.types.numeric.PosInt
+import eu.timepit.refined.types.string.NonEmptyString
+import shapeless._
+
+import scala.util.Failure
+
+class RefinedRoundtripTest extends InputStreamTest {
+
+  type C1 = NonEmptyString :+: CNil
+  case class Container1(c1: C1)
+  type C2 = Int :+: NonEmptyString :+: CNil
+  case class Container2(c2: C2)
+  type C3 = PosInt :+: NonEmptyString :+: CNil
+  case class Container3(c3: C3)
+  case class Container4(map: Map[String, NonEmptyString], c3: C3, list: List[(Int, PosInt)])
+  type C1b = String :+: CNil
+  case class Container1b(c1: C1b)
+
+  test("a union of one refined type inside a record should rountrip") {
+    writeRead(Container1(Coproduct[C1](NonEmptyString("a"))))
+  }
+
+  test("a union of one refined type and more standard types inside a record should rountrip") {
+    writeRead(Container2(Coproduct[C2](NonEmptyString("a"))))
+  }
+
+  test("a union of more than one refined type inside a record should rountrip") {
+    writeRead(Container3(Coproduct[C3](PosInt(42))))
+  }
+
+  test("a more complex record should rountrip") {
+    writeRead(Container4(Map("bla" -> NonEmptyString("a")), Coproduct[C3](NonEmptyString("b")), List(23 -> PosInt(42), 42 -> PosInt(23))))
+  }
+
+  test("a broken encoder will not decode") {
+    val out = writeData(Container1b(Coproduct[C1b]("")))
+    val result = tryReadData[Container1](out.toByteArray).next()
+    result should matchPattern { case Failure(iae: IllegalArgumentException) if iae.getMessage == "Predicate isEmpty() did not fail." => }
+  }
+}

--- a/avro4s-refined/src/test/scala/com/sksamuel/avro4s/refined/RefinedRoundtripTest.scala
+++ b/avro4s-refined/src/test/scala/com/sksamuel/avro4s/refined/RefinedRoundtripTest.scala
@@ -18,6 +18,7 @@ class RefinedRoundtripTest extends InputStreamTest {
   case class Container4(map: Map[String, NonEmptyString], c3: C3, list: List[(Int, PosInt)])
   type C1b = String :+: CNil
   case class Container1b(c1: C1b)
+  case class Container5(c5: Either[NonEmptyString, Int])
 
   test("a union of one refined type inside a record should rountrip") {
     writeRead(Container1(Coproduct[C1](NonEmptyString("a"))))
@@ -39,5 +40,9 @@ class RefinedRoundtripTest extends InputStreamTest {
     val out = writeData(Container1b(Coproduct[C1b]("")))
     val result = tryReadData[Container1](out.toByteArray).next()
     result should matchPattern { case Failure(iae: IllegalArgumentException) if iae.getMessage == "Predicate isEmpty() did not fail." => }
+  }
+
+  test("an either of one refined type inside a record should roundtrip") {
+    writeRead(Container5(Left(NonEmptyString("a"))))
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ val `avro4s-kafka` = project.in(file("avro4s-kafka"))
   )
 
 val `avro4s-refined` = project.in(file("avro4s-refined"))
-  .dependsOn(`avro4s-core`)
+  .dependsOn(`avro4s-core` % "compile->compile;test->test")
   .settings(
     libraryDependencies ++= Seq(
       "eu.timepit" %% "refined" % RefinedVersion


### PR DESCRIPTION
Hi @sksamuel 

Been trying a few things on version 4.0.0 recently and stumbled across a set of problems when combining `Refined` and shapeless' `Coproduct`. I believe the issue is clear in the tests I've added to this.

I pinpointed the problem in the `TypeGuardedDecoding` and how - for example - `implicitly[WeakTypeTag[NonEmptyString]].tpe <:< typeOf[String]` will never be true.

The solution I propose may not be ideal but I wanted to keep the spirit of what was there already.