### PR TITLE
Allow to set default/first element of unions for sealed traits

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,43 @@ into the following AVRO `enum` schema:
 }
 ```
 
+If you just want to set the first element of the union and leave the other elements automatically 
+sorted you can use the `@AvroUnionDefault` attribute:
+
+```scala
+  sealed trait Fruit
+  @AvroUnionDefault
+  case object Unknown extends Fruit
+  case class Mango(size: Int) extends Fruit
+  case class Orange(size: Int) extends Fruit
+```
+That will generate the following AVRO schema, where the `Unknown` element will be the first of the list:
+```json
+[
+    {
+        "type" : "record",
+        "name" : "Unknown",
+        "fields" : [ ]
+    },
+    {
+        "type" : "record",
+        "name" : "Mango",
+        "fields" : [ {
+            "name" : "size",
+            "type" : "int"
+        } ]
+    },
+    {
+        "type" : "record",
+        "name" : "Orange",
+        "fields" : [ {
+            "name" : "size",
+            "type" : "int"
+        } ]
+    }
+]
+``` 
+
 #### Field Defaults vs. Enum Defaults
 
 As with any AVRO field, you can specify an enum field's default value as follows:

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/AnnotationExtractors.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/AnnotationExtractors.scala
@@ -20,7 +20,9 @@ class AnnotationExtractors(annos: Seq[Any]) {
   def aliases: Seq[String] = findAll[AvroAliasable].map(_.alias).filterNot(_.trim.isEmpty)
   def fixed: Option[Int] = findFirst[AvroFixable].map(_.size)
   def name: Option[String] = findFirst[AvroNameable].map(_.name).filterNot(_.trim.isEmpty)
-  def sortPriority: Option[Float] = findFirst[AvroSortPriority].map(_.priority)
+  def sortPriority: Option[Float] =
+    findFirst[AvroSortPriority].map(_.priority)
+      .orElse(findFirst[AvroUnionDefault].map(_ => Float.MaxValue))
 
   def enumDefault: Option[Any] = findFirst[AvroEnumDefault].map(_.default)
 

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/annotations.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/annotations.scala
@@ -120,3 +120,5 @@ sealed trait AvroFieldReflection extends StaticAnnotation {
 case class AvroSortPriority(priority: Float) extends AvroFieldReflection
 
 case class AvroEnumDefault(default: Any) extends StaticAnnotation
+
+case class AvroUnionDefault() extends StaticAnnotation

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/Github586.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/Github586.scala
@@ -1,0 +1,145 @@
+package com.sksamuel.avro4s.github
+
+import java.io.ByteArrayOutputStream
+
+import com.sksamuel.avro4s._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+object SampleV1 {
+  sealed trait Fruit
+  @AvroUnionDefault
+  case object Unknown extends Fruit
+  case class Mango(size: Int) extends Fruit
+  case class Orange(size: Int) extends Fruit
+  case class Lemon(size: Int) extends Fruit
+  case class Banana(size: Int) extends Fruit
+}
+
+object SampleV2 {
+  sealed trait Fruit
+  @AvroUnionDefault
+  case object Unknown extends Fruit
+  case class Mango(size: Int, color: String) extends Fruit // new field without default value
+  case class Orange(size: Int, color: String = "orange") extends Fruit // new field with default value
+  case class Lemon(color: String) extends Fruit // new field, incompatible with prev one
+  case class Banana(size: Int) extends Fruit
+  case class Apple(size: Int) extends Fruit  // new type
+}
+
+class Github586 extends AnyFunSuite with Matchers {
+
+  test("Schema union elements order") {
+    val v1 = AvroSchema[SampleV1.Fruit]
+    assert(v1.isUnion)
+    assert(v1.getTypes.get(0).getName == "Unknown")
+    assert(v1.getTypes.get(1).getName == "Banana")
+    assert(v1.getTypes.get(2).getName == "Lemon")
+    assert(v1.getTypes.get(3).getName == "Mango")
+    assert(v1.getTypes.get(4).getName == "Orange")
+
+    val v2 = AvroSchema[SampleV2.Fruit]
+    assert(v2.isUnion)
+    assert(v2.getTypes.get(0).getName == "Unknown")
+    assert(v2.getTypes.get(1).getName == "Apple")
+    assert(v2.getTypes.get(2).getName == "Banana")
+    assert(v2.getTypes.get(3).getName == "Lemon")
+    assert(v2.getTypes.get(4).getName == "Mango")
+    assert(v2.getTypes.get(5).getName == "Orange")
+  }
+
+  test("Backward compatibility: Banana V2 => V1 expected V1.Banana because it is not changed") {
+    val bytes = serializeV2(SampleV2.Banana(81))
+    val result = deserializeV2toV1(bytes)
+
+    assert(result == SampleV1.Banana(81))
+  }
+
+  test("Backward compatibility: Mango V2 => V1 expected V1.Mango because new field is ignored") {
+    val bytes = serializeV2(SampleV2.Mango(81, "green"))
+    val result = deserializeV2toV1(bytes)
+
+    assert(result == SampleV1.Mango(81))
+  }
+
+  // Require AvroUnionDefault
+  test("Backward compatibility: Apple V2 => V1 expected Unknown because Apple doesn't exists in V1") {
+    val bytes = serializeV2(SampleV2.Apple(81))
+    val result = deserializeV2toV1(bytes)
+
+    assert(result == SampleV1.Unknown)
+  }
+
+
+  test("Forward compatibility: Banana V1 => V2 expected V2.Banana because it is not changed") {
+    val bytes = serializeV1(SampleV1.Banana(81))
+    val result = deserializeV1toV2(bytes)
+
+    assert(result == SampleV2.Banana(81))
+  }
+
+  // Require AvroUnionDefault
+  test("Forward compatibility: Mango V1 => V2 expected Unknown because color field is missing") {
+    val bytes = serializeV1(SampleV1.Mango(81))
+    val result = deserializeV1toV2(bytes)
+
+    assert(result == SampleV2.Unknown)
+  }
+
+  test("Forward compatibility: Orange V1 => V2 expected V2.Orange with default color value") {
+    val bytes = serializeV1(SampleV1.Orange(81))
+    val result = deserializeV1toV2(bytes)
+
+    assert(result == SampleV2.Orange(81))
+  }
+
+  // Require AvroUnionDefault
+  test("Forward compatibility: Lemon V1 => V2 expected Unknown because of incompatible fields (color/size)") {
+    val bytes = serializeV1(SampleV1.Lemon(81))
+    val result = deserializeV1toV2(bytes)
+
+    assert(result == SampleV2.Unknown)
+  }
+
+  private def serializeV2(value: SampleV2.Fruit): Array[Byte] = {
+    val stream = new ByteArrayOutputStream()
+    val output = AvroOutputStream.binary[SampleV2.Fruit].to(stream).build()
+    try {
+      output.write(value)
+      output.flush()
+      stream.toByteArray
+    } finally {
+      output.close()
+    }
+  }
+
+  private def deserializeV2toV1(value: Array[Byte]): SampleV1.Fruit = {
+    val stream = AvroInputStream.binary[SampleV1.Fruit].from(value).build(AvroSchema[SampleV2.Fruit])
+    try {
+      stream.iterator.toSeq.head
+    } finally {
+      stream.close()
+    }
+  }
+
+  private def serializeV1(value: SampleV1.Fruit): Array[Byte] = {
+    val stream = new ByteArrayOutputStream()
+    val output = AvroOutputStream.binary[SampleV1.Fruit].to(stream).build()
+    try {
+      output.write(value)
+      output.flush()
+      stream.toByteArray
+    } finally {
+      output.close()
+    }
+  }
+
+  private def deserializeV1toV2(value: Array[Byte]): SampleV2.Fruit = {
+    val stream = AvroInputStream.binary[SampleV2.Fruit].from(value).build(AvroSchema[SampleV1.Fruit])
+    try {
+      stream.iterator.toSeq.head
+    } finally {
+      stream.close()
+    }
+  }
+}


### PR DESCRIPTION
I have some records defined using a sealed trait like:

```
sealed trait Event
case object Unknown extends Event
case class Event1(...) extends Event
case class Event2(...) extends Event
```

When serialized using AVRO it will be encoded as an union of `[Event1, Event2, Unknown]`, sorting elements alphabetically.

The problem is that the first element of the union is used as the default value when the element cannot be found or is not compatible (for example if at some time I add an `Event3` class).

Using `@AvroSortPriority` I can solve this problem but it is not very "semantic". I think that, in most of the cases, only the first element is important, the other elements can be put in any order.

I propose to add a `@AvroUnionDefault` that internally can be used to force that element to be first in the list (priority=`Float.MaxValue`), but doesn't expose the internal implementation details. (maybe it can be called `@AvroTraitDefault`?)

Usage: 
```
sealed trait Event
@AvroUnionDefault
case object Unknown extends Event
case class Event1(...) extends Event
case class Event2(...) extends Event
```

I have added some tests to verify this feature and the corresponding attribute to solve it.