### PR TITLE
add AvroUnionPosition attributute to control position of elements in unions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
 
       - name: setup sbt
-        uses: olafurpg/setup-scala@v5
+        uses: olafurpg/setup-scala@v10
 
       - name: run tests
         run: sbt ++2.12.10 test
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
 
       - name: setup sbt
-        uses: olafurpg/setup-scala@v5
+        uses: olafurpg/setup-scala@v10
 
       - name: run tests
         run: sbt ++2.13.3 test

--- a/README.md
+++ b/README.md
@@ -454,6 +454,53 @@ into the following AVRO `enum` schema:
 }
 ```
 
+With `@AvroSortPriority` attribute, elements are sorted in descending order, by the priority specified
+(the element with the highest priority will be put as first).
+
+According to Avro specification, when an element is not found the first compatible element defined in the union is used.
+For this reason order of the elements should not be changed when compatibility is important.
+Add new elements at the end.
+
+An alternative solution is to use the `@AvroUnionPosition` attribute passing a number that will be sorted ascending,
+from lower to upper:
+
+```scala
+  sealed trait Fruit
+  @AvroUnionPosition(0)
+  case object Unknown extends Fruit
+  @AvroUnionPosition(1)
+  case class Orange(size: Int) extends Fruit
+  @AvroUnionPosition(2)
+  case class Mango(size: Int) extends Fruit
+```
+
+This will generate the following AVRO schema:
+```json
+[
+    {
+        "type" : "record",
+        "name" : "Unknown",
+        "fields" : [ ]
+    },
+    {
+        "type" : "record",
+        "name" : "Orange",
+        "fields" : [ {
+            "name" : "size",
+            "type" : "int"
+        } ]
+    },
+    {
+        "type" : "record",
+        "name" : "Mango",
+        "fields" : [ {
+            "name" : "size",
+            "type" : "int"
+        } ]
+    }
+]
+``` 
+
 #### Field Defaults vs. Enum Defaults
 
 As with any AVRO field, you can specify an enum field's default value as follows:

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/AnnotationExtractors.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/AnnotationExtractors.scala
@@ -20,7 +20,9 @@ class AnnotationExtractors(annos: Seq[Any]) {
   def aliases: Seq[String] = findAll[AvroAliasable].map(_.alias).filterNot(_.trim.isEmpty)
   def fixed: Option[Int] = findFirst[AvroFixable].map(_.size)
   def name: Option[String] = findFirst[AvroNameable].map(_.name).filterNot(_.trim.isEmpty)
-  def sortPriority: Option[Float] = findFirst[AvroSortPriority].map(_.priority)
+  def sortPriority: Option[Float] =
+    findFirst[AvroSortPriority].map(_.priority)
+      .orElse(findFirst[AvroUnionPosition].map(attr => 999999 - attr.position))
 
   def enumDefault: Option[Any] = findFirst[AvroEnumDefault].map(_.default)
 

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/annotations.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/annotations.scala
@@ -120,3 +120,5 @@ sealed trait AvroFieldReflection extends StaticAnnotation {
 case class AvroSortPriority(priority: Float) extends AvroFieldReflection
 
 case class AvroEnumDefault(default: Any) extends StaticAnnotation
+
+case class AvroUnionPosition(position: Int) extends StaticAnnotation

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/Github587.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/Github587.scala
@@ -1,0 +1,176 @@
+package com.sksamuel.avro4s.github
+
+import java.io.ByteArrayOutputStream
+
+import com.sksamuel.avro4s._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import Github587._
+
+object Github587 {
+  object SampleV1 {
+    sealed trait Fruit
+    @AvroUnionPosition(0)
+    case object Unknown extends Fruit
+    @AvroUnionPosition(1)
+    case class Mango(size: Int) extends Fruit
+    @AvroUnionPosition(2)
+    case class Orange(size: Int) extends Fruit
+    @AvroUnionPosition(3)
+    case class Lemon(size: Int) extends Fruit
+    @AvroUnionPosition(4)
+    case class Banana(size: Int) extends Fruit
+  }
+
+  object SampleV2 {
+    sealed trait Fruit
+    @AvroUnionPosition(0)
+    case object Unknown extends Fruit
+    @AvroUnionPosition(1)
+    case class Mango(size: Int, color: String) extends Fruit // new field without default value
+    @AvroUnionPosition(2)
+    case class Orange(size: Int, color: String = "orange") extends Fruit // new field with default value
+    @AvroUnionPosition(3)
+    case class Lemon(color: String) extends Fruit // new field, incompatible with prev one
+    @AvroUnionPosition(4)
+    case class Banana(size: Int) extends Fruit
+    @AvroUnionPosition(5)
+    case class Apple(size: Int) extends Fruit  // new type
+  }
+
+  sealed trait Superhero
+  @AvroUnionPosition(2)
+  case class SpiderMan(realName: String) extends Superhero
+  @AvroUnionPosition(1)
+  case class Batman(realName: String) extends Superhero
+  // no attribute, it should be put at the end
+  case class BlackPanther(realName: String) extends Superhero
+  @AvroUnionPosition(0)
+  case class JDoe() extends Superhero
+}
+
+class Github587 extends AnyFunSuite with Matchers {
+
+  test("Schema union elements order when an attribute is not found") {
+    val heroSchema = AvroSchema[Superhero]
+    assert(heroSchema.isUnion)
+    assert(heroSchema.getTypes.get(0).getName == "JDoe")
+    assert(heroSchema.getTypes.get(1).getName == "Batman")
+    assert(heroSchema.getTypes.get(2).getName == "SpiderMan")
+    assert(heroSchema.getTypes.get(3).getName == "BlackPanther")
+  }
+
+  test("Schema union elements order") {
+    val v1 = AvroSchema[SampleV1.Fruit]
+    assert(v1.isUnion)
+    assert(v1.getTypes.get(0).getName == "Unknown")
+    assert(v1.getTypes.get(1).getName == "Mango")
+    assert(v1.getTypes.get(2).getName == "Orange")
+    assert(v1.getTypes.get(3).getName == "Lemon")
+    assert(v1.getTypes.get(4).getName == "Banana")
+
+    val v2 = AvroSchema[SampleV2.Fruit]
+    assert(v2.isUnion)
+    assert(v2.getTypes.get(0).getName == "Unknown")
+    assert(v2.getTypes.get(1).getName == "Mango")
+    assert(v2.getTypes.get(2).getName == "Orange")
+    assert(v2.getTypes.get(3).getName == "Lemon")
+    assert(v2.getTypes.get(4).getName == "Banana")
+    assert(v2.getTypes.get(5).getName == "Apple")
+  }
+
+  test("Backward compatibility: Banana V2 => V1 expected V1.Banana because it is not changed") {
+    val bytes = serializeV2(SampleV2.Banana(81))
+    val result = deserializeV2toV1(bytes)
+
+    assert(result == SampleV1.Banana(81))
+  }
+
+  test("Backward compatibility: Mango V2 => V1 expected V1.Mango because new field is ignored") {
+    val bytes = serializeV2(SampleV2.Mango(81, "green"))
+    val result = deserializeV2toV1(bytes)
+
+    assert(result == SampleV1.Mango(81))
+  }
+
+  // Require AvroUnionDefault
+  test("Backward compatibility: Apple V2 => V1 expected Unknown because Apple doesn't exists in V1") {
+    val bytes = serializeV2(SampleV2.Apple(81))
+    val result = deserializeV2toV1(bytes)
+
+    assert(result == SampleV1.Unknown)
+  }
+
+
+  test("Forward compatibility: Banana V1 => V2 expected V2.Banana because it is not changed") {
+    val bytes = serializeV1(SampleV1.Banana(81))
+    val result = deserializeV1toV2(bytes)
+
+    assert(result == SampleV2.Banana(81))
+  }
+
+  // Require AvroUnionDefault
+  test("Forward compatibility: Mango V1 => V2 expected Unknown because color field is missing") {
+    val bytes = serializeV1(SampleV1.Mango(81))
+    val result = deserializeV1toV2(bytes)
+
+    assert(result == SampleV2.Unknown)
+  }
+
+  test("Forward compatibility: Orange V1 => V2 expected V2.Orange with default color value") {
+    val bytes = serializeV1(SampleV1.Orange(81))
+    val result = deserializeV1toV2(bytes)
+
+    assert(result == SampleV2.Orange(81))
+  }
+
+  // Require AvroUnionDefault
+  test("Forward compatibility: Lemon V1 => V2 expected Unknown because of incompatible fields (color/size)") {
+    val bytes = serializeV1(SampleV1.Lemon(81))
+    val result = deserializeV1toV2(bytes)
+
+    assert(result == SampleV2.Unknown)
+  }
+
+  private def serializeV2(value: SampleV2.Fruit): Array[Byte] = {
+    val stream = new ByteArrayOutputStream()
+    val output = AvroOutputStream.binary[SampleV2.Fruit].to(stream).build()
+    try {
+      output.write(value)
+      output.flush()
+      stream.toByteArray
+    } finally {
+      output.close()
+    }
+  }
+
+  private def deserializeV2toV1(value: Array[Byte]): SampleV1.Fruit = {
+    val stream = AvroInputStream.binary[SampleV1.Fruit].from(value).build(AvroSchema[SampleV2.Fruit])
+    try {
+      stream.iterator.toSeq.head
+    } finally {
+      stream.close()
+    }
+  }
+
+  private def serializeV1(value: SampleV1.Fruit): Array[Byte] = {
+    val stream = new ByteArrayOutputStream()
+    val output = AvroOutputStream.binary[SampleV1.Fruit].to(stream).build()
+    try {
+      output.write(value)
+      output.flush()
+      stream.toByteArray
+    } finally {
+      output.close()
+    }
+  }
+
+  private def deserializeV1toV2(value: Array[Byte]): SampleV2.Fruit = {
+    val stream = AvroInputStream.binary[SampleV2.Fruit].from(value).build(AvroSchema[SampleV1.Fruit])
+    try {
+      stream.iterator.toSeq.head
+    } finally {
+      stream.close()
+    }
+  }
+}


### PR DESCRIPTION
`AvroSortPriority` takes a `priority` to sort the elements of the union, but it is quite strange from the user perspective because the main goal is to set the elements inside the union in the order that we expect.

I have written a `@AvroUnionPosition` attribute that works in the same way but takes a `position`. It will be used like:

```scala
  sealed trait Fruit
  @AvroUnionPosition(0)
  case object Unknown extends Fruit
  @AvroUnionPosition(1)
  case class Orange(size: Int) extends Fruit
  @AvroUnionPosition(2)
  case class Mango(size: Int) extends Fruit
```

And it will produce an union with `[Unknown, Orange, Mango]`. I think it is more clear from the user perspective.

Also when we want to ensure backward/forward compatibility this can allow us to just add new elements without touching the existing ones. For example I can add an `Apple` with position `3`.