### PR TITLE
Make sys.error hygienic in macro 2.0.x

### DIFF
--- a/avro4s-macros/src/main/scala/com/sksamuel/avro4s/Decoder.scala
+++ b/avro4s-macros/src/main/scala/com/sksamuel/avro4s/Decoder.scala
@@ -401,7 +401,7 @@ object Decoder extends CoproductDecoders with TupleDecoders {
               val fullName = $fullName
               value match {
                 case record: _root_.org.apache.avro.generic.GenericRecord => $companion.apply(..$fields)
-                case _ => sys.error("This decoder decodes GenericRecord => " + fullName + " but has been invoked with " + value)
+                case _ => _root_.scala.sys.error("This decoder decodes GenericRecord => " + fullName + " but has been invoked with " + value)
               }
             }
           }


### PR DESCRIPTION
Details are here https://stackoverflow.com/questions/64903163/implicit-resolution-fail-in-reflection-with-toolbox

Without this fix the following runtime-reflection code

```scala
toolBox.eval(q"""
    import com.sksamuel.avro4s.Decoder
    import mypackage.MyCaseClass
    Decoder.applyMacro[MyCaseClass]
  """)
```

throws

```none
scala.tools.reflect.ToolBoxError: reflective compilation has failed:
object error is not a member of package sys
```