### PR TITLE
Added instances for Encoder/Decoder/SchemaFor for Maps that have refined strings as keys

### DIFF
--- a/avro4s-refined/src/main/scala/com/sksamuel/avro4s/refined/package.scala
+++ b/avro4s-refined/src/main/scala/com/sksamuel/avro4s/refined/package.scala
@@ -18,8 +18,8 @@ package object refined {
   implicit def refinedStringMapKeyEncoder[A: Encoder, B: Encoder, P, F[_, _]: RefType](
     implicit isString: A <:< String
   ): Encoder[Map[F[A, P], B]] =
-    Encoder.mapEncoder[B].comap { theMap =>
-      theMap.map[String, B] { case (k, v) => (RefType[F].unwrap(k), v) }
+    Encoder.mapEncoder[B].comap[Map[F[A, P], B]] { theMap =>
+      theMap.map { case (k, v) => RefType[F].unwrap(k).asInstanceOf[String] -> v }
     }
 
   implicit def refinedDecoder[T: Decoder, P, F[_, _] : RefType](implicit validate: Validate[T, P]): Decoder[F[T, P]] =

--- a/avro4s-refined/src/main/scala/com/sksamuel/avro4s/refined/package.scala
+++ b/avro4s-refined/src/main/scala/com/sksamuel/avro4s/refined/package.scala
@@ -9,11 +9,30 @@ package object refined {
   implicit def refinedSchemaFor[T, P, F[_, _] : RefType](implicit schemaFor: SchemaFor[T]): SchemaFor[F[T, P]] =
     schemaFor.forType
 
+  implicit def refinedStringMapKeySchemaFor[A, P, F[_, _]: RefType, B](implicit schemaForA: SchemaFor[A], schemaForB: SchemaFor[B], isString: A <:< String): SchemaFor[Map[F[A, P], B]] =
+    SchemaFor.mapSchemaFor[B].forType
+
   implicit def refinedEncoder[T: Encoder, P, F[_, _] : RefType]: Encoder[F[T, P]] =
     Encoder[T].comap(RefType[F].unwrap)
 
+  implicit def refinedStringMapKeyEncoder[A: Encoder, B: Encoder, P, F[_, _]: RefType](
+    implicit isString: A <:< String
+  ): Encoder[Map[F[A, P], B]] =
+    Encoder.mapEncoder[B].comap { theMap =>
+      theMap.map[String, B] { case (k, v) => (RefType[F].unwrap(k), v) }
+    }
+
   implicit def refinedDecoder[T: Decoder, P, F[_, _] : RefType](implicit validate: Validate[T, P]): Decoder[F[T, P]] =
     Decoder[T].map(RefType[F].refine[P].unsafeFrom[T])
+
+  implicit def refinedMapKeyDecoder[A: Decoder, B: Decoder, P, F[_, _]: RefType](
+    implicit validate: Validate[A, P],
+    isString: A <:< String
+  ): Decoder[Map[F[A, P], B]] =
+    Decoder.mapDecoder[B].map { theMap =>
+      theMap.map { case (str, b) => (RefType[F].refine[P].unsafeFrom[A](str.asInstanceOf[A]), b) }
+    }
+
 
   implicit def refinedTypeGuardedDecoding[T: WeakTypeTag, P, F[_, _]: RefType]: TypeGuardedDecoding[F[T, P]] = new TypeGuardedDecoding[F[T, P]] {
     override final def guard(decoderT: Decoder[F[T, P]]): PartialFunction[Any, F[T, P]] =

--- a/avro4s-refined/src/test/scala/com/sksamuel/avro4s/refined/RefinedRoundtripTest.scala
+++ b/avro4s-refined/src/test/scala/com/sksamuel/avro4s/refined/RefinedRoundtripTest.scala
@@ -19,6 +19,7 @@ class RefinedRoundtripTest extends InputStreamTest {
   type C1b = String :+: CNil
   case class Container1b(c1: C1b)
   case class Container5(c5: Either[NonEmptyString, Int])
+  case class Container6(c6: Map[NonEmptyString, PosInt])
 
   test("a union of one refined type inside a record should rountrip") {
     writeRead(Container1(Coproduct[C1](NonEmptyString("a"))))
@@ -44,5 +45,11 @@ class RefinedRoundtripTest extends InputStreamTest {
 
   test("an either of one refined type inside a record should roundtrip") {
     writeRead(Container5(Left(NonEmptyString("a"))))
+  }
+
+  test("a map with refined types on both key and value should roundtrip") {
+    val key: NonEmptyString = NonEmptyString("foo")
+    val value: PosInt = PosInt(1)
+    writeRead(Container6(Map(key -> value)))
   }
 }

--- a/avro4s-refined/src/test/scala/com/sksamuel/avro4s/refined/RefinedTest.scala
+++ b/avro4s-refined/src/test/scala/com/sksamuel/avro4s/refined/RefinedTest.scala
@@ -7,8 +7,11 @@ import eu.timepit.refined.collection.NonEmpty
 import org.apache.avro.Schema
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import eu.timepit.refined.types.string.NonEmptyString
+import eu.timepit.refined.types.numeric.NonNegInt
 
 case class Foo(nonEmptyStr: String Refined NonEmpty)
+case class FooMap(nonEmptyStrKeyMap: Map[NonEmptyString, NonNegInt])
 
 class RefinedTest extends AnyWordSpec with Matchers {
 
@@ -37,11 +40,42 @@ class RefinedTest extends AnyWordSpec with Matchers {
     }
   }
 
+  "refinedStringMapKeySchemaFor" should {
+    "use the schema for the underlying type" in {
+      AvroSchema[FooMap] shouldBe new Schema.Parser().parse(
+        """
+          |{
+          |	"type": "record",
+          |	"name": "FooMap",
+          |	"namespace": "com.sksamuel.avro4s.refined",
+          |	"fields": [{
+          |		"name": "nonEmptyStrKeyMap",
+          |		"type": {
+          |     "type": "map",
+          |     "values": "int"
+          |   }
+          |	}]
+          |}
+        """.stripMargin)
+    }
+  }
+
   "refinedEncoder" should {
     "use the encoder for the underlying type" in {
       val expected: String Refined NonEmpty = "foo"
       val record = ToRecord[Foo].to(Foo(expected))
       record.get("nonEmptyStr").toString shouldBe expected.value
+    }
+  }
+
+  "refinedStringMapKeyEncoder" should {
+    "use the encoder for the underlying type" in {
+      val key: NonEmptyString = "foo"
+      val value: NonNegInt = 1
+      val expected: Map[NonEmptyString, NonNegInt] = Map(key -> value)
+      val record = ToRecord[FooMap].to(FooMap(expected))
+      val encodedMap = record.get("nonEmptyStrKeyMap").asInstanceOf[java.util.Map[String, Int]]
+      encodedMap.get(key.value) shouldBe value.value
     }
   }
 
@@ -55,6 +89,21 @@ class RefinedTest extends AnyWordSpec with Matchers {
     "throw when the value does not conform to the refined predicate" in {
       val record = ImmutableRecord(AvroSchema[Foo], Vector(""))
       assertThrows[IllegalArgumentException](FromRecord[Foo].from(record))
+    }
+  }
+
+  "refinedStringMapKeyDecoder" should {
+    "use the decoder for the underlying type" in {
+      val key: NonEmptyString = "foo"
+      val value: NonNegInt = 1
+
+      val jMap = new java.util.HashMap[String, Int]()
+      jMap.put(key.value, value.value)
+
+      val expected = Map(key -> value)
+      val record = ImmutableRecord(AvroSchema[FooMap], Vector(jMap))
+
+      FromRecord[FooMap].from(record) shouldBe FooMap(expected)
     }
   }
 }


### PR DESCRIPTION
Having a Map[String Refined T, A] is quite common and the only option at the moment is to convert the keys to string. This should not be required only if the type of the key is a refined String.

This PR adds support for refined keys on Maps.