### PR TITLE
Fix "namespace" in the derivation of SchemaFor for ADTs and minor fixes in examples from the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ And likewise, avro4s will convert a sealed trait such as:
 ```scala
 sealed trait Animal
 @AvroSortPriority(0) case object Cat extends Animal
-@AvroSortPriority(1) case object Dog extends Animal
+@AvroSortPriority(-1) case object Dog extends Animal
 ```
 into the following AVRO `enum` schema:
 ```json
@@ -765,7 +765,7 @@ For sealed traits, you can define the trait's default enum using the `@AvroEnumD
 @AvroEnumDefault(Dog)
 sealed trait Animal
 @AvroSortPriority(0) case object Cat extends Animal
-@AvroSortPriority(1) case object Dog extends Animal
+@AvroSortPriority(-1) case object Dog extends Animal
 ```
 resulting in the following AVRO schema:
 ```json

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/TypeUnionEntry.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/TypeUnionEntry.scala
@@ -4,6 +4,16 @@ import magnolia.Subtype
 
 private[avro4s] object TypeUnionEntry {
 
+  class UnionSchemaFor[T](st: Subtype[SchemaFor, T]) {
+    class SubtypeSchemaFor(schemaFor: SchemaFor[st.SType]) {
+      val subtype = st
+      val schema = schemaFor.schema
+    }
+
+    def apply(env: DefinitionEnvironment[SchemaFor], update: SchemaUpdate) =
+      new SubtypeSchemaFor(st.typeclass.resolveSchemaFor(env, update))
+  }
+
   class UnionEncoder[T](st: Subtype[Encoder, T]) {
     class SubtypeEncoder(encoder: Encoder[st.SType]) {
       val subtype = st

--- a/avro4s-core/src/test/resources/namespace_class_adt_field.avsc
+++ b/avro4s-core/src/test/resources/namespace_class_adt_field.avsc
@@ -1,0 +1,14 @@
+[ {
+  "type" : "record",
+  "name" : "TestAnnotatedImpl",
+  "namespace" : "com.yuval",
+  "fields" : [ {
+    "name" : "value",
+    "type" : {
+      "type" : "record",
+      "name" : "AnnotatedNested",
+      "namespace" : "com.yuval.nested",
+      "fields" : [ ]
+    }
+  } ]
+} ]

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/AvroNamespaceSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/AvroNamespaceSchemaTest.scala
@@ -65,6 +65,19 @@ class AvroNamespaceTest extends AnyWordSpec with Matchers {
       schema.toString(true) shouldBe expected.toString(true)
     }
 
+    "support namespace annotations on classes that are used by an ADT" in {
+      @AvroNamespace("com.yuval")
+      sealed trait TestAnnotated
+      final case class TestAnnotatedImpl(value: AnnotatedNested) extends TestAnnotated
+
+      @AvroNamespace("com.yuval.nested")
+      case class AnnotatedNested()
+
+      val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/namespace_class_adt_field.avsc"))
+      val schema = AvroSchema[TestAnnotated]
+      schema.toString(true) shouldBe expected.toString(true)
+    }
+
     "empty namespace" in {
 
       @AvroNamespace("")


### PR DESCRIPTION
Thanks for your work on avro4s!

Currently, given the following code:
```scala
@AvroNamespace("com.yuval")
sealed trait TestAnnotated
final case class TestAnnotatedImpl(value: AnnotatedNested) extends TestAnnotated

@AvroNamespace("com.yuval.nested")
case class AnnotatedNested()
```

`SchemaFor[TestAnnotated]` will produce the following schema:
```json
[ {
  "type" : "record",
  "name" : "TestAnnotatedImpl",
  "namespace" : "com.yuval",
  "fields" : [ {
    "name" : "value",
    "type" : {
      "type" : "record",
      "name" : "AnnotatedNested",
      "fields" : [ ]
    }
  } ]
} ]
```
mainly, the `namespace` field is missing from the `AnnotatedNested` record. 

Note, that `Encoder[TestAnnotated].schema` produces schema that contains `namespace` field for the `AnnotatedNested ` record:
```json
[ {
  "type" : "record",
  "name" : "TestAnnotatedImpl",
  "namespace" : "com.yuval",
  "fields" : [ {
    "name" : "value",
    "type" : {
      "type" : "record",
      "name" : "AnnotatedNested",
      "namespace" : "com.yuval.nested",
      "fields" : [ ]
    }
  } ]
} ]
```

This PR adds an appropriate test, makes `TypeUnions.schema` use the same approach as the one used for `TypeUnions.encoder` and `TypeUnions.decoder`. This PR also fixes in the documentation few examples that use `@AvroSortPriority` annotation.