### PR TITLE
Fix #664: When value classes are used as default parameter, they're not eliminated by the compiler anymore

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/ValueTypes.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/ValueTypes.scala
@@ -66,7 +66,7 @@ object ValueTypes {
       val name = nameExtractor.name
 
       // if the class is a value type, then we need to use the schema for the single field inside the type
-      // in other words, if we have `case class Foo(str:String)` then this just acts like a string
+      // in other words, if we have `case class Foo(str:String) extends AnyVal` then this just acts like a string
       // if we have a value type AND @AvroFixed is present on the class, then we simply return a schema of type fixed
 
       annotationExtractor.fixed match {

--- a/avro4s-refined/src/test/scala/com/sksamuel/avro4s/refined/RefinedTest.scala
+++ b/avro4s-refined/src/test/scala/com/sksamuel/avro4s/refined/RefinedTest.scala
@@ -11,7 +11,11 @@ import eu.timepit.refined.types.string.NonEmptyString
 import eu.timepit.refined.types.numeric.NonNegInt
 
 case class Foo(nonEmptyStr: String Refined NonEmpty)
+case class Bar(value: NonEmptyString = "Babar")
 case class FooMap(nonEmptyStrKeyMap: Map[NonEmptyString, NonNegInt])
+
+case class Tata(tutu: String) extends AnyVal
+case class Toto(tata: Tata = Tata("Default Tata Value"))
 
 class RefinedTest extends AnyWordSpec with Matchers {
 
@@ -24,8 +28,40 @@ class RefinedTest extends AnyWordSpec with Matchers {
           |	"name": "Foo",
           |	"namespace": "com.sksamuel.avro4s.refined",
           |	"fields": [{
-          |		"name": "nonEmptyStr",
-          |		"type": "string"
+          |    "name": "nonEmptyStr",
+          |    "type": "string"
+          |	}]
+          |}
+        """.stripMargin)
+    }
+
+    "accept default value" in {
+      AvroSchema[Bar] shouldBe new Schema.Parser().parse(
+        """
+          |{
+          |	"type": "record",
+          |	"name": "Bar",
+          |	"namespace": "com.sksamuel.avro4s.refined",
+          |	"fields": [{
+          |    "name": "value",
+          |    "type": "string",
+          |    "default": "Babar"
+          |	}]
+          |}
+        """.stripMargin)
+    }
+
+    "accept default value AnyVal" in {
+      AvroSchema[Toto] shouldBe new Schema.Parser().parse(
+        """
+          |{
+          |	"type": "record",
+          |	"name": "Toto",
+          |	"namespace": "com.sksamuel.avro4s.refined",
+          |	"fields": [{
+          |    "name": "tata",
+          |    "type": "string",
+          |    "default": "Default Tata Value"
           |	}]
           |}
         """.stripMargin)


### PR DESCRIPTION
Fix #664

Hi @sksamuel,

I'm using Avro4s with refined and I notice this bug.

The good thing with my fix here is that it solves the problem with refined but also with any value class. 🙂