### PR TITLE
Use an alternative constructor for Schema.Field for better Avro backward compatibility

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/Records.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/Records.scala
@@ -233,7 +233,7 @@ object Records {
       .getOrElse(schemaWithOrderedUnion)
 
     val field = encodedDefault match {
-      case null => new Schema.Field(name, schemaWithResolvedNamespace, doc)
+      case null => new Schema.Field(name, schemaWithResolvedNamespace, doc, null)
       case CustomArrayDefault(m) =>
         new Schema.Field(name, schemaWithResolvedNamespace, doc, m)
       case CustomUnionDefault(_, m) =>


### PR DESCRIPTION
# Motivation
When using `avro4s` with other open-source projects relying on Avro, sometimes Avro version conflicts arise. For instance, the `4.0.x` release series of `avro4s` uses Avro 1.9.2, while Apache Spark 3.1.x uses Avro 1.8.2.

We've noticed that when using `avro4s` 4.0.x with Spark 3.1.1, sometimes the Spark job would crash with the following error (see **Test Result** below for a reproducible example):
```
java.lang.NoSuchMethodError: org.apache.avro.Schema$Field.<init>(Ljava/lang/String;Lorg/apache/avro/Schema;Ljava/lang/String;)V
  at com.sksamuel.avro4s.Records$.buildSchemaField(Records.scala:236)
  at com.sksamuel.avro4s.Records$.$anonfun$schema$1(Records.scala:149)
```

which is caused by this line in `avro4s-core/src/main/scala/com/sksamuel/avro4s/Records.scala`:
https://github.com/sksamuel/avro4s/blob/06e777878e5f7a7a0dc06a30a80d4fabad523693/avro4s-core/src/main/scala/com/sksamuel/avro4s/Records.scala#L235-L236

This constructor method [was only introduced since Avro 1.9.x](https://github.com/apache/avro/blob/bf20128ca6138a830b2ea13e0490f3df6b035639/lang/java/avro/src/main/java/org/apache/avro/Schema.java#L548-L550), and is not available for Avro 1.8.2:
```java
    public Field(String name, Schema schema, String doc) {
      this(name, schema, doc, (JsonNode) null, true, Order.ASCENDING);
    }
```

To make avro4s more backward compatible with older versions of Avro (e.g. `1.8.2`), we could consider using a slightly different constructor method whose signature exists in both 1.8.2 and 1.9.x+, which is:
```java
    public Field(String name, Schema schema, String doc, Object defaultValue) {
      this(name, schema, doc,
          defaultValue == NULL_DEFAULT_VALUE ? NullNode.getInstance() : JacksonUtils.toJsonNode(defaultValue), true,
          Order.ASCENDING);
    }
```

And given that the two constructors both dispatch to a more explicit constructor with default values, substituting the first one with the second one shouldn't have any impact on the `avro4s` logic, except that we can now use `avro4s` with Avro 1.8.2 in Spark jobs.

# Change details
The proposed change is to use the constructor of `Schema.Field` with 4 fields, by explicitly passing a `null` value to the `Object defaultValue` argument. Note that setting `defaultValue` to `null` would be the behavior of the current constructor (with 3 arguments) anyway, as can be seen from the Java code snippet above.

# Test results
Without this PR, we can reproduce this issue with avro4s 4.0.4 and Apache Spark 3.1.1 with the following `spark-shell` snippet:

```scala
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 3.1.1.0.1.0
      /_/

Using Scala version 2.12.10 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_121)
Type in expressions to have them evaluated.
Type :help for more information.

scala> case class Foo(foo: String, bar: Option[Int])
defined class Foo

scala> import com.sksamuel.avro4s.SchemaFor
import com.sksamuel.avro4s.SchemaFor

scala> implicitly[SchemaFor[Foo]].schema
warning: there was one feature warning; for details, enable `:setting -feature' or `:replay -feature'
java.lang.NoSuchMethodError: org.apache.avro.Schema$Field.<init>(Ljava/lang/String;Lorg/apache/avro/Schema;Ljava/lang/String;)V
  at com.sksamuel.avro4s.Records$.buildSchemaField(Records.scala:236)
  at com.sksamuel.avro4s.Records$.$anonfun$schema$1(Records.scala:149)
  at scala.collection.TraversableLike.$anonfun$flatMap$1(TraversableLike.scala:245)
  at scala.collection.IndexedSeqOptimized.foreach(IndexedSeqOptimized.scala:36)
  at scala.collection.IndexedSeqOptimized.foreach$(IndexedSeqOptimized.scala:33)
  at scala.collection.mutable.WrappedArray.foreach(WrappedArray.scala:38)
  at scala.collection.TraversableLike.flatMap(TraversableLike.scala:245)
  at scala.collection.TraversableLike.flatMap$(TraversableLike.scala:242)
  at scala.collection.AbstractTraversable.flatMap(Traversable.scala:108)
  at com.sksamuel.avro4s.Records$.schema(Records.scala:143)
  at com.sksamuel.avro4s.MagnoliaDerivedSchemaFors$$anon$2.$anonfun$schemaFor$2(MagnoliaDerived.scala:30)
  at scala.Option.getOrElse(Option.scala:189)
  at com.sksamuel.avro4s.MagnoliaDerivedSchemaFors$$anon$2.schemaFor(MagnoliaDerived.scala:29)
  at com.sksamuel.avro4s.ResolvableSchemaFor.adhocInstance(SchemaFor.scala:83)
  at com.sksamuel.avro4s.ResolvableSchemaFor.adhocInstance$(SchemaFor.scala:83)
  at com.sksamuel.avro4s.MagnoliaDerivedSchemaFors$$anon$2.adhocInstance$lzycompute(MagnoliaDerived.scala:26)
  at com.sksamuel.avro4s.MagnoliaDerivedSchemaFors$$anon$2.adhocInstance(MagnoliaDerived.scala:26)
  at com.sksamuel.avro4s.ResolvableSchemaFor.schema(SchemaFor.scala:85)
  at com.sksamuel.avro4s.ResolvableSchemaFor.schema$(SchemaFor.scala:85)
  at com.sksamuel.avro4s.MagnoliaDerivedSchemaFors$$anon$2.schema(MagnoliaDerived.scala:26)
  ... 47 elided
```

With this small change, we can get `SchemaFor[T]` to work properly even with Avro 1.8.2:
```scala
scala> case class Foo(foo: String, bar: Option[Int])
defined class Foo

scala> import com.sksamuel.avro4s.SchemaFor
import com.sksamuel.avro4s.SchemaFor

scala> implicitly[SchemaFor[Foo]].schema
warning: there was one feature warning; for details, enable `:setting -feature' or `:replay -feature'
res0: org.apache.avro.Schema = {"type":"record","name":"Foo","namespace":"line14.read.iw.iw","fields":[{"name":"foo","type":"string"},{"name":"bar","type":["null","int"]}]}
```