### PR TITLE
Magnolia upgrade to V1.0.0. Fix Enums SerDe

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/decoders/magnolia.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/decoders/magnolia.scala
@@ -2,7 +2,7 @@ package com.sksamuel.avro4s.decoders
 
 import com.sksamuel.avro4s.typeutils.{CaseClassShape, DatatypeShape, SealedTraitShape}
 import com.sksamuel.avro4s.{Decoder, Encoder}
-import magnolia.{AutoDerivation, CaseClass, SealedTrait}
+import magnolia1.{AutoDerivation, CaseClass, SealedTrait}
 
 trait MagnoliaDerivedDecoder extends AutoDerivation[Decoder] :
 
@@ -15,5 +15,5 @@ trait MagnoliaDerivedDecoder extends AutoDerivation[Decoder] :
   override def split[T](ctx: SealedTrait[Decoder, T]): Decoder[T] =
     DatatypeShape.of[T](ctx) match {
       case SealedTraitShape.TypeUnion => TypeUnions.decoder(ctx)
-      case SealedTraitShape.Enum => ??? // SealedTraits.encoder(ctx)
+      case SealedTraitShape.Enum => SealedTraits.decoder(ctx)
     }

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/decoders/records.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/decoders/records.scala
@@ -8,8 +8,9 @@ import org.apache.avro.generic.IndexedRecord
 
 import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
+import org.apache.avro.generic.GenericData
 
-class RecordDecoder[T](ctx: magnolia.CaseClass[Decoder, T]) extends Decoder[T] {
+class RecordDecoder[T](ctx: magnolia1.CaseClass[Decoder, T]) extends Decoder[T] {
 
   override def decode(schema: Schema): Any => T = {
     val decoders: Array[FieldDecoder[T]] = ctx.params
@@ -31,6 +32,8 @@ class RecordDecoder[T](ctx: magnolia.CaseClass[Decoder, T]) extends Decoder[T] {
         i += 1
       }
       ctx.rawConstruct(values.toIndexedSeq)
+    case enumSymbol: GenericData.EnumSymbol =>
+      ctx.rawConstruct(ctx.params)
     case _ =>
       throw new Avro4sDecodingException(
         s"This decoder can only handle IndexedRecords or its subtypes such as GenericRecord [was ${value.getClass}]",
@@ -52,7 +55,7 @@ object TransientFieldDecoder extends FieldDecoder[Nothing] {
 /**
   * Decodes normal fields based on the schema.
   */
-class SchemaFieldDecoder[T](param: magnolia.CaseClass.Param[Decoder, T], schema: Schema) extends FieldDecoder[T] :
+class SchemaFieldDecoder[T](param: magnolia1.CaseClass.Param[Decoder, T], schema: Schema) extends FieldDecoder[T] :
   require(schema.getType == Schema.Type.RECORD)
 
   private val fieldName = Annotations(param.annotations).name.getOrElse(param.label)

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/decoders/sealedtraits.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/decoders/sealedtraits.scala
@@ -1,0 +1,29 @@
+package com.sksamuel.avro4s.decoders
+
+import com.sksamuel.avro4s.{ Decoder, Avro4sConfigurationException }
+import org.apache.avro.Schema
+import com.sksamuel.avro4s.avroutils.SchemaHelper
+import com.sksamuel.avro4s.typeutils.{Annotations, Names, SubtypeOrdering}
+import org.apache.avro.generic.GenericData
+import magnolia1.SealedTrait
+
+object SealedTraits {
+
+  def decoder[T](ctx: magnolia1.SealedTrait[Decoder, T]): Decoder[T] = new Decoder[T] {
+    override def decode(schema: Schema): Any => T = {
+      require(schema.getType == Schema.Type.ENUM && ctx.isEnum)
+      val typeForSymbol: Map[GenericData.EnumSymbol, SealedTrait.Subtype[Decoder, T, _]] = 
+        ctx.subtypes.sorted(SubtypeOrdering).zipWithIndex.map { (st, i) => 
+          val enumSymbol = GenericData.get.createEnum(schema.getEnumSymbols.get(i), schema).asInstanceOf[GenericData.EnumSymbol]
+          enumSymbol -> st
+        }.toMap
+      
+      { case value: GenericData.EnumSymbol => 
+        val symtype = typeForSymbol(value)
+        val tc = symtype.typeclass
+        Console.err.println(tc)
+        tc.decode(value.getSchema)(value)
+      }
+    }
+  }
+}

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/decoders/unions.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/decoders/unions.scala
@@ -3,7 +3,7 @@ package com.sksamuel.avro4s.decoders
 import com.sksamuel.avro4s.{Avro4sDecodingException, Decoder, Encoder}
 import com.sksamuel.avro4s.avroutils.SchemaHelper
 import com.sksamuel.avro4s.typeutils.{Annotations, Names, SubtypeOrdering}
-import magnolia.SealedTrait
+import magnolia1.SealedTrait
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericContainer
 

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/magnolia.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/magnolia.scala
@@ -2,7 +2,7 @@ package com.sksamuel.avro4s.encoders
 
 import com.sksamuel.avro4s.typeutils.{CaseClassShape, DatatypeShape, SealedTraitShape}
 import com.sksamuel.avro4s.{Encoder, SchemaFor}
-import magnolia.{CaseClass, AutoDerivation, SealedTrait, TypeInfo}
+import magnolia1.{CaseClass, AutoDerivation, SealedTrait, TypeInfo}
 import org.apache.avro.{Schema, SchemaBuilder}
 
 import scala.deriving.Mirror

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/records.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/records.scala
@@ -2,14 +2,14 @@ package com.sksamuel.avro4s.encoders
 
 import com.sksamuel.avro4s.typeutils.{Annotations, Names}
 import com.sksamuel.avro4s.{Avro4sConfigurationException, Encoder, ImmutableRecord, SchemaFor}
-import magnolia.CaseClass
+import magnolia1.CaseClass
 import org.apache.avro.Schema
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 
-class RecordEncoder[T](ctx: magnolia.CaseClass[Encoder, T]) extends Encoder[T] {
+class RecordEncoder[T](ctx: magnolia1.CaseClass[Encoder, T]) extends Encoder[T] {
 
   def encode(schema: Schema): T => Any = {
     // the order of the encoders comes from the schema
@@ -25,7 +25,7 @@ class RecordEncoder[T](ctx: magnolia.CaseClass[Encoder, T]) extends Encoder[T] {
   /**
     * Finds the matching param from the case class for the given avro [[Schema.Field]].
     */
-  private def findParam(field: Schema.Field, ctx: magnolia.CaseClass[Encoder, T]): Option[CaseClass.Param[Encoder, T]] = {
+  private def findParam(field: Schema.Field, ctx: magnolia1.CaseClass[Encoder, T]): Option[CaseClass.Param[Encoder, T]] = {
     ctx.params.find { param =>
       val annotations = new Annotations(param.annotations)
       val paramName = annotations.name.getOrElse(param.label)
@@ -46,7 +46,7 @@ class RecordEncoder[T](ctx: magnolia.CaseClass[Encoder, T]) extends Encoder[T] {
   }
 }
 
-class FieldEncoder[T](param: magnolia.CaseClass.Param[Encoder, T], schema: Schema) extends Serializable :
+class FieldEncoder[T](param: magnolia1.CaseClass.Param[Encoder, T], schema: Schema) extends Serializable :
 
   private val encode = param.typeclass.encode(schema)
 

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/sealedtraits.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/sealedtraits.scala
@@ -2,7 +2,7 @@ package com.sksamuel.avro4s.encoders
 
 import com.sksamuel.avro4s.typeutils.{Annotations, Names, SubtypeOrdering}
 import com.sksamuel.avro4s.{Encoder, SchemaFor}
-import magnolia.SealedTrait
+import magnolia1.SealedTrait
 import org.apache.avro.generic.GenericData
 import org.apache.avro.{Schema, SchemaBuilder}
 

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/unions.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/unions.scala
@@ -4,7 +4,7 @@ import com.sksamuel.avro4s.avroutils.SchemaHelper
 import com.sksamuel.avro4s.typeutils.SubtypeOrdering
 import com.sksamuel.avro4s.typeutils.{Annotations, Names}
 import com.sksamuel.avro4s.{Encoder, SchemaFor}
-import magnolia.SealedTrait
+import magnolia1.SealedTrait
 import org.apache.avro.Schema
 
 object TypeUnions {

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/schemas/magnolia.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/schemas/magnolia.scala
@@ -2,7 +2,7 @@ package com.sksamuel.avro4s.schemas
 
 import com.sksamuel.avro4s.typeutils.{CaseClassShape, DatatypeShape, SealedTraitShape}
 import com.sksamuel.avro4s.{SchemaFor}
-import magnolia.{CaseClass, AutoDerivation, SealedTrait, TypeInfo}
+import magnolia1.{CaseClass, AutoDerivation, SealedTrait, TypeInfo}
 import org.apache.avro.{Schema, SchemaBuilder}
 
 import scala.deriving.Mirror

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/schemas/records.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/schemas/records.scala
@@ -3,7 +3,7 @@ package com.sksamuel.avro4s.schemas
 import com.sksamuel.avro4s.avroutils.SchemaHelper
 import com.sksamuel.avro4s.typeutils.{Annotations, Names}
 import com.sksamuel.avro4s.{FieldMapper, SchemaFor}
-import magnolia.CaseClass
+import magnolia1.CaseClass
 import org.apache.avro.{Schema, SchemaBuilder}
 
 import scala.jdk.CollectionConverters._

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/schemas/sealedtraits.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/schemas/sealedtraits.scala
@@ -2,19 +2,27 @@ package com.sksamuel.avro4s.schemas
 
 import com.sksamuel.avro4s.SchemaFor
 import com.sksamuel.avro4s.typeutils.{Annotations, Names, SubtypeOrdering}
-import magnolia.SealedTrait
+import magnolia1.SealedTrait
 import org.apache.avro.{Schema, SchemaBuilder}
 
 object SealedTraits {
   def schema[T](ctx: SealedTrait[SchemaFor, T]): Schema = {
 
+    ctx.subtypes.sorted(SubtypeOrdering).foreach { st =>
+      Console.err.println(st.annotations.collectFirst( {
+        case a: com.sksamuel.avro4s.AvroNamespace => a
+        case a: com.sksamuel.avro4s.AvroName => a
+      }
+    ))
+    }
+
     val symbols = ctx.subtypes.sorted(SubtypeOrdering).map { st =>
       Names(st.typeInfo, Annotations(st.annotations)).name
     }
 
-    val names = Names(ctx.typeInfo, Annotations(ctx.annotations))
+    val names = Names(ctx.typeInfo, Annotations(ctx.annotations))   
 
-    val builder = SchemaBuilder.enumeration(names.name).namespace(names.namespace)
+    SchemaBuilder.enumeration(names.name).namespace(names.namespace).symbols(symbols*)
 
     // todo once magnolia supports scala 3 defaults
     //    val builderWithDefault = sealedTraitEnumDefaultValue(ctx) match {
@@ -22,7 +30,5 @@ object SealedTraits {
     //      case None          => builder
     //    }
     //
-
-    builder.symbols(symbols: _*)
   }
 }

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/schemas/sealedtraits.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/schemas/sealedtraits.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.avro4s.schemas
 
-import com.sksamuel.avro4s.SchemaFor
+import com.sksamuel.avro4s.{AvroName, SchemaFor}
 import com.sksamuel.avro4s.typeutils.{Annotations, Names, SubtypeOrdering}
 import magnolia1.SealedTrait
 import org.apache.avro.{Schema, SchemaBuilder}
@@ -8,19 +8,25 @@ import org.apache.avro.{Schema, SchemaBuilder}
 object SealedTraits {
   def schema[T](ctx: SealedTrait[SchemaFor, T]): Schema = {
 
-    ctx.subtypes.sorted(SubtypeOrdering).foreach { st =>
-      Console.err.println(st.annotations.collectFirst( {
-        case a: com.sksamuel.avro4s.AvroNamespace => a
-        case a: com.sksamuel.avro4s.AvroName => a
-      }
-    ))
-    }
+    val names = Names(ctx.typeInfo, Annotations(ctx.annotations))
 
+    // It currently appears (magnolia1, v 1) that all the enum elements carry the same annotation set
+    // as the enumeration symbol itself, which leads to name clash in the generated schema. 
+    // For now I'm disabling AvroName annotation interpretation of the symbols
+    // if its name equals to the whole enumeration name.
+    // Annotaions that are attached to the enum elements are not visible here.
+    // Looks lilke we ned to have a look into either Magnolia or Scala 3.
     val symbols = ctx.subtypes.sorted(SubtypeOrdering).map { st =>
-      Names(st.typeInfo, Annotations(st.annotations)).name
+      Names(
+        st.typeInfo,
+        Annotations(
+          st.annotations.filter {
+            case an: AvroName => an.name != names.name
+            case _ => true
+          }
+        )
+      ).name
     }
-
-    val names = Names(ctx.typeInfo, Annotations(ctx.annotations))   
 
     SchemaBuilder.enumeration(names.name).namespace(names.namespace).symbols(symbols*)
 

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/schemas/unions.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/schemas/unions.scala
@@ -3,7 +3,7 @@ package com.sksamuel.avro4s.schemas
 import com.sksamuel.avro4s.SchemaFor
 import com.sksamuel.avro4s.avroutils.SchemaHelper
 import com.sksamuel.avro4s.typeutils.{Annotations, SubtypeOrdering}
-import magnolia.SealedTrait
+import magnolia1.SealedTrait
 import org.apache.avro.SchemaBuilder
 
 object TypeUnions {

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/schemas/valuetypes.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/schemas/valuetypes.scala
@@ -2,7 +2,7 @@ package com.sksamuel.avro4s.schemas
 
 import com.sksamuel.avro4s.SchemaFor
 import com.sksamuel.avro4s.typeutils.{Annotations, Names}
-import magnolia.CaseClass
+import magnolia1.CaseClass
 import org.apache.avro.SchemaBuilder
 import org.apache.avro.Schema
 

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/typeutils/Annotations.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/typeutils/Annotations.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.avro4s.typeutils
 
 import com.sksamuel.avro4s.{AvroAliasable, AvroDoc, AvroDocumentable, AvroErasedName, AvroError, AvroFixed, AvroName, AvroNameable, AvroNamespace, AvroProp, AvroProperty, AvroSortPriority, AvroTransient, AvroUnionPosition}
-import magnolia.{CaseClass, TypeInfo}
+import magnolia1.{CaseClass, TypeInfo}
 
 class Annotations(annos: Seq[Any]) {
 

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/typeutils/DatatypeShape.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/typeutils/DatatypeShape.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.avro4s.typeutils
 
 import com.sksamuel.avro4s.SchemaFor
-import magnolia.{CaseClass, SealedTrait}
+import magnolia1.{CaseClass, SealedTrait}
 
 enum CaseClassShape:
   case ValueType, Record
@@ -13,7 +13,7 @@ object DatatypeShape:
 
   def of[T](ctx: SealedTrait[_, T]): SealedTraitShape = {
     val allSubtypesAreObjects = ctx.subtypes.forall(_.isObject)
-    if (allSubtypesAreObjects) SealedTraitShape.Enum else SealedTraitShape.TypeUnion
+    if (ctx.isEnum || allSubtypesAreObjects) SealedTraitShape.Enum else SealedTraitShape.TypeUnion
   }
 
   def of[Typeclass[_], T](ctx: CaseClass[Typeclass, T]): CaseClassShape =

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/typeutils/Names.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/typeutils/Names.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.avro4s.typeutils
 
-import magnolia.TypeInfo
+import magnolia1.TypeInfo
 
 /**
   * Extracts names and namespaces from a type.

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/typeutils/Subtypes.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/typeutils/Subtypes.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.avro4s.typeutils
 
-import magnolia.SealedTrait
+import magnolia1.SealedTrait
 
 object SubtypeOrdering extends Ordering[SealedTrait.Subtype[_, _, _]] {
   override def compare(a: SealedTrait.Subtype[_, _, _], b: SealedTrait.Subtype[_, _, _]): Int = {

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/Scala3EnumDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/Scala3EnumDecoderTest.scala
@@ -1,0 +1,50 @@
+package com.sksamuel.avro4s.record.decoder
+
+import com.sksamuel.avro4s.{Avro4sException, AvroSchema, Decoder, Encoder}
+import org.apache.avro.SchemaBuilder
+import org.apache.avro.generic.{GenericData, GenericRecord}
+import org.apache.avro.util.Utf8
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+
+class Scala3EnumDecoderTest extends AnyFunSuite with Matchers {
+
+  test("support non-parametrized, non-extending Scala 3 enums") {
+    val schema = AvroSchema[Simple]
+    val record = GenericData.EnumSymbol(schema, "ONE")
+    val decoded = Decoder[Simple].decode(schema)(record)    
+    decoded shouldEqual Simple.ONE
+  }
+
+  test("supoort non-parametrized, extending Scala 3 enums") {
+    val schema = AvroSchema[Extending]
+    val record = GenericData.EnumSymbol(schema, "TWO")
+    val decoded = Decoder[Extending].decode(schema)(record)    
+    decoded shouldEqual Extending.TWO
+  }
+
+  test("supoort parametrized Scala 3 enums") {
+    val schema = AvroSchema[ParametrizedWithInt]
+    val record = GenericData.EnumSymbol(schema, "THREE")
+    val decoded = Decoder[ParametrizedWithInt].decode(schema)(record)    
+    decoded shouldEqual ParametrizedWithInt.THREE
+  }
+  
+}
+
+enum Simple {
+  case ONE, TWO, THREE
+}
+
+enum Extending {
+  case ONE extends Extending
+  case TWO extends Extending
+  case THREE extends Extending
+}
+
+enum ParametrizedWithInt(val param: Int) {
+  case ONE extends ParametrizedWithInt(1)
+  case TWO extends ParametrizedWithInt(2)
+  case THREE extends ParametrizedWithInt(3)
+}

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/Scala3EnumEncoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/Scala3EnumEncoderTest.scala
@@ -1,0 +1,81 @@
+package com.sksamuel.avro4s.record.encoder
+
+import com.sksamuel.avro4s.{Avro4sException, AvroSchema, Decoder, Encoder}
+import org.apache.avro.generic.{GenericData, GenericRecord}
+import org.apache.avro.util.Utf8
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import magnolia1.{AutoDerivation, CaseClass, SealedTrait}
+import com.sksamuel.avro4s.SchemaFor
+
+class Scala3EnumEncoderTest extends AnyFunSuite with Matchers {
+
+  test("support non-parametrized, non-extending Scala 3 enums") {
+    val schema = AvroSchema[Simple]
+    val record = Encoder[Simple].encode(schema).apply(Simple.ONE).asInstanceOf[GenericData.EnumSymbol]
+    schema.getType shouldBe org.apache.avro.Schema.Type.ENUM
+    record.toString shouldBe "ONE"
+  }
+
+  test("supoort non-parametrized, extending Scala 3 enums") {
+    val schema = AvroSchema[Extending]
+    val record = Encoder[Extending].encode(schema).apply(Extending.TWO).asInstanceOf[GenericData.EnumSymbol]
+    schema.getType shouldBe org.apache.avro.Schema.Type.ENUM
+    record.toString shouldBe "TWO"
+  }
+
+  test("supoort parametrized Scala 3 enums") {
+    val schema = AvroSchema[ParametrizedWithInt]
+    val record = Encoder[ParametrizedWithInt].encode(schema).apply(ParametrizedWithInt.THREE).asInstanceOf[GenericData.EnumSymbol]
+    schema.getType shouldBe org.apache.avro.Schema.Type.ENUM
+    record.toString shouldBe "THREE"
+  }
+
+  test("support non-parametrized, non-extending Scala 3 annotated enums") {
+    val schema = AvroSchema[SimpleAnnotated]
+    val record = Encoder[SimpleAnnotated].encode(schema).apply(SimpleAnnotated.ONE).asInstanceOf[GenericData.EnumSymbol]
+    schema.getType shouldBe org.apache.avro.Schema.Type.ENUM
+    schema.getNamespace shouldBe "com.test.namespace"
+    schema.getName shouldBe "CustomSimple"
+    record.toString shouldBe "ONE"
+  }
+  
+}
+
+enum Simple {
+  case ONE, TWO, THREE
+}
+
+enum Extending {
+  case ONE extends Extending
+  case TWO extends Extending
+  case THREE extends Extending
+}
+
+enum ParametrizedWithInt(val param: Int) {
+  case ONE extends ParametrizedWithInt(1)
+  case TWO extends ParametrizedWithInt(2)
+  case THREE extends ParametrizedWithInt(3)
+}
+
+@com.sksamuel.avro4s.AvroNamespace("com.test.namespace")
+@com.sksamuel.avro4s.AvroName("CustomSimple")
+enum SimpleAnnotated {
+  case ONE, TWO, THREE
+}
+
+@com.sksamuel.avro4s.AvroNamespace("com.test.namespace")
+@com.sksamuel.avro4s.AvroName("CustomExtended")
+enum ExtendingAnnotated {
+  case ONE extends ExtendingAnnotated
+  case TWO extends ExtendingAnnotated
+  case THREE extends ExtendingAnnotated
+}
+
+@com.sksamuel.avro4s.AvroNamespace("com.test.namespace")
+@com.sksamuel.avro4s.AvroName("CustomParametrizedWithInt")
+enum ParametrizedWithIntAnnotated(val param: Int) {
+  case ONE extends ParametrizedWithIntAnnotated(1)
+  case TWO extends ParametrizedWithIntAnnotated(2)
+  case THREE extends ParametrizedWithIntAnnotated(3)
+}

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/Scala3EnumEncoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/Scala3EnumEncoderTest.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.avro4s.record.encoder
 
-import com.sksamuel.avro4s.{Avro4sException, AvroSchema, Decoder, Encoder}
+import com.sksamuel.avro4s.{Avro4sException, AvroName, AvroNamespace, AvroSchema, Decoder, Encoder}
 import org.apache.avro.generic.{GenericData, GenericRecord}
 import org.apache.avro.util.Utf8
 import org.scalatest.funsuite.AnyFunSuite
@@ -17,14 +17,14 @@ class Scala3EnumEncoderTest extends AnyFunSuite with Matchers {
     record.toString shouldBe "ONE"
   }
 
-  test("supoort non-parametrized, extending Scala 3 enums") {
+  test("support non-parametrized, extending Scala 3 enums") {
     val schema = AvroSchema[Extending]
     val record = Encoder[Extending].encode(schema).apply(Extending.TWO).asInstanceOf[GenericData.EnumSymbol]
     schema.getType shouldBe org.apache.avro.Schema.Type.ENUM
     record.toString shouldBe "TWO"
   }
 
-  test("supoort parametrized Scala 3 enums") {
+  test("support parametrized Scala 3 enums") {
     val schema = AvroSchema[ParametrizedWithInt]
     val record = Encoder[ParametrizedWithInt].encode(schema).apply(ParametrizedWithInt.THREE).asInstanceOf[GenericData.EnumSymbol]
     schema.getType shouldBe org.apache.avro.Schema.Type.ENUM
@@ -37,7 +37,32 @@ class Scala3EnumEncoderTest extends AnyFunSuite with Matchers {
     schema.getType shouldBe org.apache.avro.Schema.Type.ENUM
     schema.getNamespace shouldBe "com.test.namespace"
     schema.getName shouldBe "CustomSimple"
-    record.toString shouldBe "ONE"
+    schema.getEnumSymbols should contain("ONE")
+  }
+
+  test("support non-parametrized, extending Scala 3 annotated enums") {
+    val schema = AvroSchema[ExtendingAnnotated]
+    val record = Encoder[ExtendingAnnotated].encode(schema).apply(ExtendingAnnotated.TWO).asInstanceOf[GenericData.EnumSymbol]
+    schema.getType shouldBe org.apache.avro.Schema.Type.ENUM
+    schema.getNamespace shouldBe "com.test.namespace"
+    schema.getName shouldBe "CustomExtended"
+    schema.getEnumSymbols should contain("TWO")
+  }
+
+  test("support parametrized Scala 3 annotated enums") {
+    val schema = AvroSchema[ParametrizedWithIntAnnotated]
+    val record = Encoder[ParametrizedWithIntAnnotated].encode(schema).apply(ParametrizedWithIntAnnotated.THREE).asInstanceOf[GenericData.EnumSymbol]
+    schema.getType shouldBe org.apache.avro.Schema.Type.ENUM
+    schema.getNamespace shouldBe "com.test.namespace"
+    schema.getName shouldBe "CustomParametrizedWithInt"
+    record.toString shouldBe "THREE"
+  }
+
+  test("support Scala 3 enums that are parametrized with a product") {
+    val schema = AvroSchema[WithProduct]
+    val record = Encoder[WithProduct].encode(schema).apply(WithProduct.One).asInstanceOf[GenericData.EnumSymbol]
+    schema.getType shouldBe org.apache.avro.Schema.Type.ENUM
+    record.toString shouldBe "One"
   }
   
 }
@@ -58,24 +83,32 @@ enum ParametrizedWithInt(val param: Int) {
   case THREE extends ParametrizedWithInt(3)
 }
 
-@com.sksamuel.avro4s.AvroNamespace("com.test.namespace")
-@com.sksamuel.avro4s.AvroName("CustomSimple")
+@AvroNamespace("com.test.namespace")
+@AvroName("CustomSimple")
 enum SimpleAnnotated {
   case ONE, TWO, THREE
 }
 
-@com.sksamuel.avro4s.AvroNamespace("com.test.namespace")
-@com.sksamuel.avro4s.AvroName("CustomExtended")
+@AvroNamespace("com.test.namespace")
+@AvroName("CustomExtended")
 enum ExtendingAnnotated {
   case ONE extends ExtendingAnnotated
   case TWO extends ExtendingAnnotated
   case THREE extends ExtendingAnnotated
 }
 
-@com.sksamuel.avro4s.AvroNamespace("com.test.namespace")
-@com.sksamuel.avro4s.AvroName("CustomParametrizedWithInt")
+@AvroNamespace("com.test.namespace")
+@AvroName("CustomParametrizedWithInt")
 enum ParametrizedWithIntAnnotated(val param: Int) {
   case ONE extends ParametrizedWithIntAnnotated(1)
   case TWO extends ParametrizedWithIntAnnotated(2)
   case THREE extends ParametrizedWithIntAnnotated(3)
+}
+
+
+final case class TestProduct(a: String, b: Int)
+
+enum WithProduct(product: TestProduct) {
+  case One extends WithProduct(TestProduct("a", 1))
+  case Two extends WithProduct(TestProduct("b", 2))
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/SealedTraitEncoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/SealedTraitEncoderTest.scala
@@ -5,7 +5,7 @@ import org.apache.avro.generic.{GenericData, GenericRecord}
 import org.apache.avro.util.Utf8
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import magnolia.{AutoDerivation, CaseClass, SealedTrait}
+import magnolia1.{AutoDerivation, CaseClass, SealedTrait}
 
 class SealedTraitEncoderTest extends AnyFunSuite with Matchers {
 

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ lazy val root = Project("avro4s", file("."))
 val `avro4s-core` = project.in(file("avro4s-core"))
   .settings(
     libraryDependencies ++= Seq(
-      "com.softwaremill.magnolia" % "magnolia-core_3" % MagnoliaVersion
+      "com.softwaremill.magnolia1_3" %% "magnolia" % MagnoliaVersion
       //      "com.chuusai" %% "shapeless" % ShapelessVersion,
       //      "org.json4s" %% "json4s-native" % Json4sVersion
     )
@@ -47,7 +47,7 @@ val benchmarks = project
   .dependsOn(`avro4s-core`)
   .enablePlugins(JmhPlugin)
   .settings(
-    fork in Test := true,
+    Test / fork := true,
     libraryDependencies ++= Seq(
       "pl.project13.scala" % "sbt-jmh-extras" % SbtJmhVersion,
       "org.openjdk.jmh" % "jmh-core" % JmhVersion,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -14,7 +14,7 @@ object Build extends AutoPlugin {
     val CatsVersion = "2.7.0"
     val RefinedVersion = "0.9.26"
     val ShapelessVersion = "2.3.7"
-    val MagnoliaVersion = "2.0.0-M9"
+    val MagnoliaVersion = "1.0.0"
     val SbtJmhVersion = "0.3.7"
     val JmhVersion = "1.32"
   }
@@ -32,10 +32,11 @@ object Build extends AutoPlugin {
   override def trigger = allRequirements
   override def projectSettings = publishingSettings ++ Seq(
     organization := org,
-    scalaVersion := "3.0.2",
+    scalaVersion := "3.1.0",
     resolvers += Resolver.mavenLocal,
-    parallelExecution in Test := false,
-    javacOptions := Seq("-source", "1.8", "-target", "1.8"),
+    Test / parallelExecution := false,
+    Test / scalacOptions ++= Seq("-Xmax-inlines:64"),
+    javacOptions := Seq("-source", "1.8", "-target", "1.8"),    
     libraryDependencies ++= Seq(
       "org.scala-lang"    % "scala3-compiler_3" % scalaVersion.value,
       "org.apache.avro"   % "avro"              % AvroVersion,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.8
+sbt.version=1.6.1


### PR DESCRIPTION
This is a draft of how new Scala 3 enums serialization/deserialization could work. This PR needs apparently a good review, given that I'm quite fresh with Avro in general and with Avro4s particularly.
Notes: 
- Scala 3 enums are translated to/from Avro enums, not unions.
- Workaround of `@AvroName`  being attached not only to the enum sealed class, but to the inheriting case classes/objects. Probably I should look into Magnolia to figure out if it is a bug or a feature.

