### PR TITLE
Use current thread's classloader when decoding Scala enums

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/BaseTypes.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/BaseTypes.scala
@@ -384,7 +384,7 @@ trait BaseDecoders {
     val enum = tag.tpe match {
       case TypeRef(enumType, _, _) =>
         val moduleSymbol = enumType.termSymbol.asModule
-        val mirror: Mirror = runtimeMirror(getClass.getClassLoader)
+        val mirror: Mirror = runtimeMirror(Thread.currentThread().getContextClassLoader)
         mirror.reflectModule(moduleSymbol).instance.asInstanceOf[Enumeration]
     }
 


### PR DESCRIPTION
Fixes https://github.com/sksamuel/avro4s/issues/712