### PR TITLE
Update json4s to v4.0.5

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -6,7 +6,7 @@ object Build extends AutoPlugin {
 
   object autoImport {
     val org = "com.sksamuel.avro4s"
-    val AvroVersion = "1.11.0"
+    val AvroVersion = "1.9.2"
     val Log4jVersion = "1.2.17"
     val ScalatestVersion = "3.2.9"
     val Slf4jVersion = "1.7.30"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -6,17 +6,17 @@ object Build extends AutoPlugin {
 
   object autoImport {
     val org = "com.sksamuel.avro4s"
-    val AvroVersion = "1.9.2"
+    val AvroVersion = "1.11.0"
     val Log4jVersion = "1.2.17"
     val ScalatestVersion = "3.2.9"
     val Slf4jVersion = "1.7.30"
-    val Json4sVersion = "3.6.11"
+    val Json4sVersion = "4.0.5"
     val CatsVersion = "2.0.0"
-    val RefinedVersion = "0.9.26"
-    val ShapelessVersion = "2.3.7"
+    val RefinedVersion = "0.9.29"
+    val ShapelessVersion = "2.3.9"
     val MagnoliaVersion = "0.17.0"
     val SbtJmhVersion = "0.3.7"
-    val JmhVersion = "1.23"
+    val JmhVersion = "1.35"
   }
 
   import autoImport._
@@ -35,7 +35,7 @@ object Build extends AutoPlugin {
     scalaVersion := "2.13.5",
     crossScalaVersions := Seq("2.12.14", "2.13.5"),
     resolvers += Resolver.mavenLocal,
-    parallelExecution in Test := false,
+    Test / parallelExecution := false,
     scalacOptions := Seq(
       "-unchecked", "-deprecation",
       "-encoding",
@@ -60,7 +60,7 @@ object Build extends AutoPlugin {
 
   val publishingSettings = Seq(
     publishMavenStyle := true,
-    publishArtifact in Test := false,
+    Test / publishArtifact := false,
     credentials += Credentials(
       "Sonatype Nexus Repository Manager",
       "oss.sonatype.org",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.2
+sbt.version=1.6.2


### PR DESCRIPTION
Updated json4s to v4.0.5 along with other dependencies: jmh, avro.
sbt 1.6.2

While upgrading our codebase to use json4s v4.x I found out that avro4s is a blocker since it's using v3.6.x.
This PR updates json4s and other dependencies to their latest versions