### PR TITLE
Add fromCodec method to reduce RecordFormat boilerplate #734

### DIFF
--- a/README.md
+++ b/README.md
@@ -1043,7 +1043,10 @@ To convert from a class into a record:
 ```scala
 case class Composer(name: String, birthplace: String, compositions: Seq[String])
 val ennio = Composer("ennio morricone", "rome", Seq("legend of 1900", "ecstasy of gold"))
-val format = RecordFormat[Composer]
+val schema: Schema = AvroSchema[Composer]
+implicit val toRecord: ToRecord[Composer] = ToRecord.apply[Composer](schema)
+implicit val fromRecord: FromRecord[Composer] = FromRecord.apply[Composer](schema)
+val format: RecordFormat[Composer] = RecordFormat.apply[Composer](schema)
 // record is a type that implements both GenericRecord and Specific Record
 val record = format.to(ennio)
 ```

--- a/README.md
+++ b/README.md
@@ -1044,9 +1044,7 @@ To convert from a class into a record:
 case class Composer(name: String, birthplace: String, compositions: Seq[String])
 val ennio = Composer("ennio morricone", "rome", Seq("legend of 1900", "ecstasy of gold"))
 val schema: Schema = AvroSchema[Composer]
-implicit val toRecord: ToRecord[Composer] = ToRecord.apply[Composer](schema)
-implicit val fromRecord: FromRecord[Composer] = FromRecord.apply[Composer](schema)
-val format: RecordFormat[Composer] = RecordFormat.apply[Composer](schema)
+val format: RecordFormat[Composer] = RecordFormat.fromCodec[Composer](schema)
 // record is a type that implements both GenericRecord and Specific Record
 val record = format.to(ennio)
 ```

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/RecordFormat.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/RecordFormat.scala
@@ -18,4 +18,12 @@ object RecordFormat {
     override def from(record: IndexedRecord): T = fromRecord.from(record)
     override def to(t: T): Record = toRecord.to(t)
   }
+
+  def fromCodec[T: Codec](schema: Schema) = new RecordFormat[T] {
+    val toRecord: ToRecord[T] = ToRecord.apply[T](schema)
+    val fromRecord: FromRecord[T] = FromRecord.apply[T](schema)
+
+    override def from(record: IndexedRecord): T = fromRecord.from(record)
+    override def to(t: T): Record = toRecord.to(t)
+  }
 }


### PR DESCRIPTION
Here I have decided to create a new method in RecordFormat so changes in the way that creation used to work are minimally impacted.

It is a little more verbose than before but I didn't want to modify the already existing apply method and defining another apply with the same argument (schema) but different implicits then raises ambiguity issues when calling any of them, which defeats the purpose of having arguments given implicitly