### PR TITLE
Scala3/support more option types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1104,49 +1104,52 @@ import shapeless.{:+:, CNil}
 The following table shows how types used in your code will be mapped / encoded in the generated Avro schemas and files.
 If a type can be mapped in multiple ways, it is listed more than once.
 
-| Scala Type                   	| Schema Type   	| Logical Type     	| Encoded Type |
-|------------------------------	|---------------	|------------------	| ------------ |
-| String                       	| STRING        	|                  	| Utf8                      |
-| String                       	| FIXED        	|                  	| GenericFixed         |
-| String                       	| BYTES        	|                  	| ByteBuffer         |
-| Boolean                      	| BOOLEAN       	|                  	| java.lang.Boolean |
-| Long                         	| LONG          	|                  	| java.lang.Long |
-| Int                          	| INT           	|                  	| java.lang.Integer |
-| Short                        	| INT           	|                  	| java.lang.Integer |
-| Byte                         	| INT           	|                  	| java.lang.Integer |
-| Double                       	| DOUBLE        	|                  	| java.lang.Double |
-| Float                        	| FLOAT         	|                  	| java.lang.Float |
-| UUID                         	| STRING        	| UUID             	| Utf8 |
-| LocalDate                    	| INT           	| Date             	| java.lang.Int |
-| LocalTime                    	| INT           	| time-millis      	| java.lang.Int |
-| LocalDateTime                	| LONG          	| timestamp-nanos 	| java.lang.Long |
-| java.sql.Date                	| INT           	| Date             	| java.lang.Int |
-| Instant                      	| LONG          	| Timestamp-Millis 	| java.lang.Long |
-| Timestamp                    	| LONG          	| Timestamp-Millis 	| java.lang.Long |
-| BigDecimal                   	| BYTES         	| Decimal<8,2>     	| ByteBuffer |
-| BigDecimal                   	| FIXED         	| Decimal<8,2>     	| GenericFixed |
-| BigDecimal                   	| STRING         	| Decimal<8,2>     	| String |
-| Option[T]                    	| UNION<null,T> 	|                  	| null, T |
-| Array[Byte]                  	| BYTES         	|                  	| ByteBuffer |
-| Array[Byte]                  	| FIXED         	|                  	| GenericFixed |
-| ByteBuffer                   	| BYTES         	|                  	| ByteBuffer |
-| Seq[Byte]                    	| BYTES         	|                  	| ByteBuffer |
-| List[Byte]                   	| BYTES         	|                  	| ByteBuffer |
-| Vector[Byte]                 	| BYTES         	|                  	| ByteBuffer |
-| Array[T]                     	| ARRAY<T>      	|                  	| Array[T] |
-| Vector[T]                    	| ARRAY<T>      	|                  	| Array[T] |
-| Seq[T]                       	| ARRAY<T>      	|                  	| Array[T] |
-| List[T]                      	| ARRAY<T>      	|                  	| Array[T] |
-| Set[T]                       	| ARRAY<T>      	|                  	| Array[T] |
-| sealed trait of case classes 	| UNION<A,B,..>  	|                  	| A, B, ... |
-| sealed trait of case objects 	| ENUM<A,B,..>  	|                  	| GenericEnumSymbol |
-| Map[String, V]              	| MAP<V>        	|                  	| java.util.Map[String, V] |
-| Either[A,B]                  	| UNION<A,B>    	|                  	| A, B |
-| A :+: B :+: C :+: CNil       	| UNION<A,B,C>  	|                  	| A, B, ... |
-| case class T                 	| RECORD        	|                  	| GenericRecord with SpecificRecord |
-| Scala enumeration            	| ENUM          	|                  	| GenericEnumSymbol |
-| Java enumeration             	| ENUM          	|                  	| GenericEnumSymbol |
-| Scala tuples                  | RECORD            |                   | GenericRecord with SpecificRecord |
+| Scala Type                   	         | Schema Type   	    | Logical Type     	| Encoded Type                      |
+|----------------------------------------|--------------------|------------------	|-----------------------------------|
+| String                       	         | STRING        	    |                  	| Utf8                              |
+| String                       	         | FIXED        	     |                  	| GenericFixed                      |
+| String                       	         | BYTES        	     |                  	| ByteBuffer                        |
+| Boolean                      	         | BOOLEAN       	    |                  	| java.lang.Boolean                 |
+| Long                         	         | LONG          	    |                  	| java.lang.Long                    |
+| Int                          	         | INT           	    |                  	| java.lang.Integer                 |
+| Short                        	         | INT           	    |                  	| java.lang.Integer                 |
+| Byte                         	         | INT           	    |                  	| java.lang.Integer                 |
+| Double                       	         | DOUBLE        	    |                  	| java.lang.Double                  |
+| Float                        	         | FLOAT         	    |                  	| java.lang.Float                   |
+| UUID                         	         | STRING        	    | UUID             	| Utf8                              |
+| LocalDate                    	         | INT           	    | Date             	| java.lang.Int                     |
+| LocalTime                    	         | INT           	    | time-millis      	| java.lang.Int                     |
+| LocalDateTime                	         | LONG          	    | timestamp-nanos 	| java.lang.Long                    |
+| java.sql.Date                	         | INT           	    | Date             	| java.lang.Int                     |
+| Instant                      	         | LONG          	    | Timestamp-Millis 	| java.lang.Long                    |
+| Timestamp                    	         | LONG          	    | Timestamp-Millis 	| java.lang.Long                    |
+| BigDecimal                   	         | BYTES         	    | Decimal<8,2>     	| ByteBuffer                        |
+| BigDecimal                   	         | FIXED         	    | Decimal<8,2>     	| GenericFixed                      |
+| BigDecimal                   	         | STRING         	   | Decimal<8,2>     	| String                            |
+| Option[T]                    	         | UNION<null,T> 	    |                  	| null, T                           |
+| Array[Byte]                  	         | BYTES         	    |                  	| ByteBuffer                        |
+| Array[Byte]                  	         | FIXED         	    |                  	| GenericFixed                      |
+| ByteBuffer                   	         | BYTES         	    |                  	| ByteBuffer                        |
+| Seq[Byte]                    	         | BYTES         	    |                  	| ByteBuffer                        |
+| List[Byte]                   	         | BYTES         	    |                  	| ByteBuffer                        |
+| Vector[Byte]                 	         | BYTES         	    |                  	| ByteBuffer                        |
+| Array[T]                     	         | ARRAY<T>      	    |                  	| Array[T]                          |
+| Vector[T]                    	         | ARRAY<T>      	    |                  	| Array[T]                          |
+| Seq[T]                       	         | ARRAY<T>      	    |                  	| Array[T]                          |
+| List[T]                      	         | ARRAY<T>      	    |                  	| Array[T]                          |
+| Set[T]                       	         | ARRAY<T>      	    |                  	| Array[T]                          |
+| sealed trait of case classes 	         | UNION<A,B,..>  	   |                  	| A, B, ...                         |
+| sealed trait of case objects 	         | ENUM<A,B,..>  	    |                  	| GenericEnumSymbol                 |
+| Map[String, V]              	          | MAP<V>        	    |                  	| java.util.Map[String, V]          |
+| Either[A,B]                  	         | UNION<A,B>    	    |                  	| A, B                              |
+| A :+: B :+: C :+: CNil       	         | UNION<A,B,C>  	    |                  	| A, B, ...                         |
+| case class T                 	         | RECORD        	    |                  	| GenericRecord with SpecificRecord |
+| Scala enumeration            	         | ENUM          	    |                  	| GenericEnumSymbol                 |
+| Java enumeration             	         | ENUM          	    |                  	| GenericEnumSymbol                 |
+| Scala tuples                           | RECORD             |                   | GenericRecord with SpecificRecord |
+| Option[Either[A,B]]                    | UNION<null,A,B>    |                   | null, A, B                        |
+| option of sealed trait of case classes | UNION<null,A,B,..> |                   | null, A, B, ...                   |
+| option of sealed trait of case objects   | UNION<null,A,B,..> |                   | null, GenericEnumSymbol           |
 
 To select the encoding in case multiple encoded types exist, create a new `Encoder` with a corresponding `SchemaFor` 
 instance to the via `withSchema`. For example, creating a string encoder that uses target type `BYTES` works like this:

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/decoders/options.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/decoders/options.scala
@@ -10,13 +10,16 @@ class OptionDecoder[T](decoder: Decoder[T]) extends Decoder[Option[T]] {
     require(schema.getType == Schema.Type.UNION, {
       "Options can only be encoded with a UNION schema"
     })
-    require(schema.getTypes.size() == 2, {
-      "Options can only be encoded with a 2 element union schema"
+    require(schema.getTypes.size() >= 2, {
+      "An option should be encoded with a UNION schema with at least 2 element types"
     })
     require(schema.getTypes.get(0).getType == Schema.Type.NULL, {
       "Options can only be encoded with a UNION schema with NULL as the first element type"
     })
-    val elementSchema = schema.getTypes.get(1)
+    val schemaSize = schema.getTypes.size()
+    val elementSchema = schemaSize match
+      case 2 => schema.getTypes.get(1)
+      case _ => Schema.createUnion(schema.getTypes.subList(1, schemaSize))
     val decode = decoder.decode(elementSchema)
     { value => if (value == null) None else Some(decode(value)) }
   }

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/options.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/options.scala
@@ -10,11 +10,14 @@ class OptionEncoder[T](encoder: Encoder[T]) extends Encoder[Option[T]] {
     require(schema.getType == Schema.Type.UNION, {
       "Options can only be encoded with a UNION schema"
     })
-    require(schema.getTypes.size() == 2, {
-      "Options can only be encoded with a 2 element union schema"
+    require(schema.getTypes.size() >= 2, {
+      "Options can only be encoded with a union schema with 2 or more types"
     })
     require(schema.getTypes.get(0).getType == Schema.Type.NULL)
-    val elementSchema = schema.getTypes.get(1)
+    val schemaSize = schema.getTypes.size()
+    val elementSchema = schemaSize match
+      case 2 => schema.getTypes.get(1)
+      case _ => Schema.createUnion(schema.getTypes.subList(1, schemaSize))
     val elementEncoder = encoder.encode(elementSchema)
     { option => option.fold(null)(value => elementEncoder(value)) }
   }

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/schemas/options.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/schemas/options.scala
@@ -12,8 +12,11 @@ trait OptionSchemas {
     override def schema: Schema = {
       val rhs: Schema = schemaFor.schema
       if (rhs.isUnion)
-        throw new Avro4sException("Options cannot contain other union types, such as sealed traits")
-      Schema.createUnion(Schema.create(Schema.Type.NULL), schemaFor.schema)
+        val types = rhs.getTypes
+        types.add(0, Schema.create(Schema.Type.NULL))
+        Schema.createUnion(types)
+      else
+        Schema.createUnion(Schema.create(Schema.Type.NULL), rhs)
     }
   }
 }

--- a/avro4s-core/src/test/resources/option_either.json
+++ b/avro4s-core/src/test/resources/option_either.json
@@ -1,0 +1,9 @@
+{
+  "type" : "record",
+  "name" : "Test",
+  "namespace" : "com.sksamuel.avro4s.schema.OptionSchemaTest",
+  "fields" : [ {
+    "name" : "option",
+    "type" : [ "null", "string", "boolean" ]
+  } ]
+}

--- a/avro4s-core/src/test/resources/option_enum.json
+++ b/avro4s-core/src/test/resources/option_enum.json
@@ -1,0 +1,13 @@
+{
+  "type" : "record",
+  "name" : "Test",
+  "namespace" : "com.sksamuel.avro4s.schema.OptionSchemaTest",
+  "fields" : [ {
+    "name" : "option",
+    "type" : [ "null", {
+      "type" : "enum",
+      "name" : "T",
+      "symbols" : [ "A", "B", "C" ]
+    } ]
+  } ]
+}

--- a/avro4s-core/src/test/resources/option_sealed_trait.json
+++ b/avro4s-core/src/test/resources/option_sealed_trait.json
@@ -1,0 +1,30 @@
+{
+  "type" : "record",
+  "name" : "Test",
+  "namespace" : "com.sksamuel.avro4s.schema.OptionSchemaTest",
+  "fields" : [ {
+    "name" : "option",
+    "type" : [ "null", {
+      "type" : "record",
+      "name" : "A",
+      "fields" : [ {
+        "name" : "a",
+        "type" : "string"
+      } ]
+    }, {
+      "type" : "record",
+      "name" : "B",
+      "fields" : [ {
+        "name" : "b",
+        "type" : "string"
+      } ]
+    }, {
+      "type" : "record",
+      "name" : "C",
+      "fields" : [ {
+        "name" : "c",
+        "type" : "string"
+      } ]
+    } ]
+  } ]
+}

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/OptionEncoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/OptionEncoderTest.scala
@@ -1,39 +1,89 @@
-//package com.sksamuel.avro4s.record.encoder
-//
-//import com.sksamuel.avro4s.{AvroSchema, Encoder, ImmutableRecord, SchemaFor}
-//import org.apache.avro.util.Utf8
-//import org.scalatest.matchers.should.Matchers
-//import org.scalatest.wordspec.AnyWordSpec
-//
-//class OptionEncoderTest extends AnyWordSpec with Matchers {
-//
-//  "Encoder" should {
-//    "support String options" in {
-//      case class Test(s: Option[String])
-//      val schema = AvroSchema[Test]
-//      Encoder[Test].encode(Test(Option("qwe"))) shouldBe ImmutableRecord(schema, Vector(new Utf8("qwe")))
-//      Encoder[Test].encode(Test(None)) shouldBe ImmutableRecord(schema, Vector(null))
-//    }
-//    "support boolean options" in {
-//      case class Test(b: Option[Boolean])
-//      val schema = AvroSchema[Test]
-//      Encoder[Test].encode(Test(Option(true))) shouldBe ImmutableRecord(schema, Vector(java.lang.Boolean.valueOf(true)))
-//      Encoder[Test].encode(Test(None)) shouldBe ImmutableRecord(schema, Vector(null))
-//    }
-//    "support options of case classes" in {
-//      case class Foo(s: String)
-//      case class Test(b: Option[Foo])
-//      val schema = AvroSchema[Test]
-//      val fooSchema = AvroSchema[Foo]
-//      Encoder[Test].encode(Test(Option(Foo("hello")))) shouldBe ImmutableRecord(schema, Vector(ImmutableRecord(fooSchema, Vector(new Utf8("hello")))))
-//      Encoder[Test].encode(Test(None)) shouldBe ImmutableRecord(schema, Vector(null))
-//    }
-//    "support schema overrides with either" in {
-//      case class Test(a: Option[Either[String, Int]])
-//      val expected = AvroSchema[Test]
-//      val schema = Encoder[Test].withSchema(SchemaFor[Test]).schema
-//      schema shouldBe expected
-//    }
-//  }
-//}
-//
+package com.sksamuel.avro4s.record.encoder
+
+import com.sksamuel.avro4s.{AvroSchema, Encoder, ImmutableRecord, SchemaFor}
+import org.apache.avro.generic.GenericData
+import org.apache.avro.util.Utf8
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class OptionEncoderTest extends AnyWordSpec with Matchers {
+
+  "Encoder" should {
+    "support String options" in {
+      case class Test(o: Option[String])
+      val schema = AvroSchema[Test]
+      val expectedSome = ImmutableRecord(schema, Vector(new Utf8("qwe")))
+      val expectedNone = ImmutableRecord(schema, Vector(null))
+
+      Encoder[Test].encode(schema)(Test(Some("qwe"))) shouldBe expectedSome
+      Encoder[Test].encode(schema)(Test(None)) shouldBe expectedNone
+    }
+
+    "support boolean options" in {
+      case class Test(o: Option[Boolean])
+      val schema = AvroSchema[Test]
+      val expectedSome = ImmutableRecord(schema, Vector(java.lang.Boolean.valueOf(true)))
+      val expectedNone = ImmutableRecord(schema, Vector(null))
+
+      Encoder[Test].encode(schema)(Test(Some(true))) shouldBe expectedSome
+      Encoder[Test].encode(schema)(Test(None)) shouldBe expectedNone
+    }
+
+    "support options of case classes" in {
+      case class Foo(s: String)
+      case class Test(o: Option[Foo])
+      val schema = AvroSchema[Test]
+      val fooSchema = AvroSchema[Foo]
+      val expectedSome = ImmutableRecord(schema, Vector(ImmutableRecord(fooSchema, Vector(new Utf8("hello")))))
+      val expectedNone = ImmutableRecord(schema, Vector(null))
+
+      Encoder[Test].encode(schema)(Test(Some(Foo("hello")))) shouldBe expectedSome
+      Encoder[Test].encode(schema)(Test(None)) shouldBe expectedNone
+    }
+
+    "support options of either" in {
+      case class Test(o: Option[Either[String, Boolean]])
+      val schema = AvroSchema[Test]
+      val expectedSomeLeft = ImmutableRecord(schema, Vector(new Utf8("hello")))
+      val expectedSomeRight = ImmutableRecord(schema, Vector(java.lang.Boolean.valueOf(true)))
+      val expectedNone = ImmutableRecord(schema, Vector(null))
+
+      Encoder[Test].encode(schema)(Test(Some(Left("hello")))) shouldBe expectedSomeLeft
+      Encoder[Test].encode(schema)(Test(Some(Right(true)))) shouldBe expectedSomeRight
+      Encoder[Test].encode(schema)(Test(None)) shouldBe expectedNone
+    }
+
+    "support options of sealed traits" in {
+      sealed trait T
+      case class A(a: String) extends T
+      case class B(b: String) extends T
+      case class Test(o: Option[T])
+      val schema = AvroSchema[Test]
+      val aSchema = AvroSchema[A]
+      val bSchema = AvroSchema[B]
+      val expectedSomeA = ImmutableRecord(schema, Vector(ImmutableRecord(aSchema, Vector(new Utf8("hello")))))
+      val expectedSomeB = ImmutableRecord(schema, Vector(ImmutableRecord(bSchema, Vector(new Utf8("hello")))))
+      val expectedNone = ImmutableRecord(schema, Vector(null))
+
+      Encoder[Test].encode(schema)(Test(Some(A("hello")))) shouldBe expectedSomeA
+      Encoder[Test].encode(schema)(Test(Some(B("hello")))) shouldBe expectedSomeB
+      Encoder[Test].encode(schema)(Test(None)) shouldBe expectedNone
+    }
+
+    "support options of enums" in {
+      sealed trait T
+      case object A extends T
+      case object B extends T
+      case class Test(o: Option[T])
+      val schema = AvroSchema[Test]
+      val tSchema = AvroSchema[T]
+      val expectedSomeA = ImmutableRecord(schema, Vector(new GenericData.EnumSymbol(tSchema, A)))
+      val expectedSomeB = ImmutableRecord(schema, Vector(new GenericData.EnumSymbol(tSchema, B)))
+      val expectedNone = ImmutableRecord(schema, Vector(null))
+
+      Encoder[Test].encode(schema)(Test(Some(A))) shouldBe expectedSomeA
+      Encoder[Test].encode(schema)(Test(Some(B))) shouldBe expectedSomeB
+      Encoder[Test].encode(schema)(Test(None)) shouldBe expectedNone
+    }
+  }
+}

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/OptionSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/OptionSchemaTest.scala
@@ -6,7 +6,39 @@ import org.scalatest.matchers.should.Matchers
 
 class OptionSchemaTest extends AnyFunSuite with Matchers {
 
-  test("generate option as Union[T, Null]") {
+  test("generate option of either Union[Null, A, B]") {
+    case class Test(option: Option[Either[String, Boolean]])
+
+    val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/option_either.json"))
+    val schema = AvroSchema[Test]
+    schema.toString(true) shouldBe expected.toString(true)
+  }
+
+  test("generate option of sealed traits enums as Union[Null, {enum}]") {
+    sealed trait T
+    case object A extends T
+    case object B extends T
+    case object C extends T
+    case class Test(option: Option[T])
+
+    val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/option_enum.json"))
+    val schema = AvroSchema[Test]
+    schema.toString(true) shouldBe expected.toString(true)
+  }
+
+  test("generate option of sealed traits as Union[Null, A, B, C]") {
+    sealed trait T
+    case class A(a: String) extends T
+    case class B(b: String) extends T
+    case class C(c: String) extends T
+    case class Test(option: Option[T])
+
+    val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/option_sealed_trait.json"))
+    val schema = AvroSchema[Test]
+    schema.toString(true) shouldBe expected.toString(true)
+  }
+
+  test("generate option as Union[Null, T]") {
     case class Test(option: Option[String])
     val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/option.json"))
     val schema = AvroSchema[Test]

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/SealedTraitSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/SealedTraitSchemaTest.scala
@@ -1,6 +1,5 @@
 package com.sksamuel.avro4s.schema
 
-import com.sksamuel.avro4s.record.encoder.MeasurableThing
 import com.sksamuel.avro4s.{Avro4sException, AvroName, AvroSchema}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -13,7 +12,8 @@ class SealedTraitSchemaTest extends AnyFunSuite with Matchers {
     schema.toString(true) shouldBe expected.toString(true)
   }
 
-  test("support trait subtypes fields with same name") {
+  test("support trait subtype" +
+    "s fields with same name") {
     val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/trait_subtypes_duplicate_fields.json"))
     val schema = AvroSchema[Trapper]
     schema.toString(true) shouldBe expected.toString(true)
@@ -35,12 +35,6 @@ class SealedTraitSchemaTest extends AnyFunSuite with Matchers {
     val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/sealed_trait_of_objects.json"))
     val schema = AvroSchema[Dibble]
     schema.toString(true) shouldBe expected.toString(true)
-  }
-
-  test("throw on options of sealed traits") {
-    intercept[Avro4sException] {
-      val schema = AvroSchema[MeasurableThing]
-    }
   }
 
   sealed trait Foo extends Product with Serializable


### PR DESCRIPTION
Attempt to solve [this issue](https://github.com/sksamuel/avro4s/issues/768)
Add support for encoding and decoding of:

- option of either
- option of sealed trait of case classes
- option of sealed trait of case objects