### PR TITLE
Invalid schema in ToRecord

### DIFF
--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/ToRecordTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/ToRecordTest.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.avro4s.record
 
-import com.sksamuel.avro4s.{AvroNamespace, AvroSchema, FromRecord, ToRecord}
+import com.sksamuel.avro4s.{AvroNamespace, AvroSchema, ImmutableRecord, Record, FromRecord, ToRecord}
 import org.apache.avro.generic.{GenericData, GenericRecord}
 import org.apache.avro.util.Utf8
 import org.scalatest.funsuite.AnyFunSuite
@@ -21,6 +21,17 @@ class ToRecordTest extends AnyFunSuite with Matchers {
     record.get("int").asInstanceOf[Int] shouldBe 42
     record.get("boolean").asInstanceOf[Boolean] shouldBe false
     record.get("nested").asInstanceOf[GenericRecord].get("foo") shouldBe new Utf8("there")
+  }
+
+  test("encode to record with sealed trait") {
+    val schema = AvroSchema[Foo]
+    val record = ToRecord[Foo](schema).to(Bar(1))
+
+    record.get("i").asInstanceOf[Int] shouldBe 1
+
+    record match
+      case r: ImmutableRecord => r.schema shouldBe schema
+      case _: Record => throw new Exception
   }
 
   //  test("ToRecord should work with a namespace annotation on an ADT") {


### PR DESCRIPTION
With given:

```scala
sealed trait Foo
case class Bar(i: Int) extends Foo
case class Baz(s: String) extends Foo
```

When we try to serialize a `sealed trait` schema:

```scala
val schema = AvroSchema[Foo]
val record = ToRecord[Foo](schema).to(Bar(1))
```

 a result record schema seems to be invalid and be regenerated to sub case class only (`Bar`) instead of a union for `Foo`

```
{
  "type": "record",
  "name": "Bar",
  "namespace": "com.sksamuel.avro4s.record",
  "fields": [
    {
      "name": "i",
      "type": "int"
    }
  ]
}

was not equal to 

[
  {
    "type": "record",
    "name": "Bar",
    "namespace": "com.sksamuel.avro4s.record",
    "fields": [
      {
        "name": "i",
        "type": "int"
      }
    ]
  },
  {
    "type": "record",
    "name": "Baz",
    "namespace": "com.sksamuel.avro4s.record",
    "fields": [
      {
        "name": "s",
        "type": "string"
      }
    ]
  }
]
```