### PR TITLE
fix: avro enum sorting by symbol position (as is) not alphabetical

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,9 @@ credentials.sbt
 
 universe.avro
 sbt.json
+
+#vs-code
+.vscode
+.bloop
+.bsp
+.metals

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/decoders/sealedtraits.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/decoders/sealedtraits.scala
@@ -13,7 +13,7 @@ object SealedTraits {
     override def decode(schema: Schema): Any => T = {
       require(schema.getType == Schema.Type.ENUM)
       val typeForSymbol: Map[GenericData.EnumSymbol, SealedTrait.Subtype[Decoder, T, _]] =
-        ctx.subtypes.sorted(EnumOrdering).zipWithIndex.map { (st, i) =>
+        ctx.subtypes.sorted(EnumOrdering.reverse).zipWithIndex.map { (st, i) =>
           val enumSymbol = GenericData.get.createEnum(schema.getEnumSymbols.get(i), schema).asInstanceOf[GenericData.EnumSymbol]
           enumSymbol -> st
         }.toMap

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/decoders/sealedtraits.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/decoders/sealedtraits.scala
@@ -13,7 +13,7 @@ object SealedTraits {
     override def decode(schema: Schema): Any => T = {
       require(schema.getType == Schema.Type.ENUM)
       val typeForSymbol: Map[GenericData.EnumSymbol, SealedTrait.Subtype[Decoder, T, _]] =
-        ctx.subtypes.sorted(EnumOrdering.reverse).zipWithIndex.map { (st, i) =>
+        ctx.subtypes.sorted(EnumOrdering).zipWithIndex.map { (st, i) =>
           val enumSymbol = GenericData.get.createEnum(schema.getEnumSymbols.get(i), schema).asInstanceOf[GenericData.EnumSymbol]
           enumSymbol -> st
         }.toMap

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/decoders/sealedtraits.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/decoders/sealedtraits.scala
@@ -3,7 +3,7 @@ package com.sksamuel.avro4s.decoders
 import com.sksamuel.avro4s.{ Decoder, Avro4sConfigurationException }
 import org.apache.avro.Schema
 import com.sksamuel.avro4s.avroutils.SchemaHelper
-import com.sksamuel.avro4s.typeutils.{Annotations, Names, SubtypeOrdering}
+import com.sksamuel.avro4s.typeutils.{Annotations, Names}
 import org.apache.avro.generic.GenericData
 import magnolia1.SealedTrait
 
@@ -13,7 +13,7 @@ object SealedTraits {
     override def decode(schema: Schema): Any => T = {
       require(schema.getType == Schema.Type.ENUM)
       val typeForSymbol: Map[GenericData.EnumSymbol, SealedTrait.Subtype[Decoder, T, _]] =
-        ctx.subtypes.sorted(SubtypeOrdering).zipWithIndex.map { (st, i) =>
+        ctx.subtypes.zipWithIndex.map { (st, i) =>
           val enumSymbol = GenericData.get.createEnum(schema.getEnumSymbols.get(i), schema).asInstanceOf[GenericData.EnumSymbol]
           enumSymbol -> st
         }.toMap

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/decoders/sealedtraits.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/decoders/sealedtraits.scala
@@ -3,7 +3,7 @@ package com.sksamuel.avro4s.decoders
 import com.sksamuel.avro4s.{ Decoder, Avro4sConfigurationException }
 import org.apache.avro.Schema
 import com.sksamuel.avro4s.avroutils.SchemaHelper
-import com.sksamuel.avro4s.typeutils.{Annotations, Names}
+import com.sksamuel.avro4s.typeutils.{Annotations, Names, EnumOrdering}
 import org.apache.avro.generic.GenericData
 import magnolia1.SealedTrait
 
@@ -13,7 +13,7 @@ object SealedTraits {
     override def decode(schema: Schema): Any => T = {
       require(schema.getType == Schema.Type.ENUM)
       val typeForSymbol: Map[GenericData.EnumSymbol, SealedTrait.Subtype[Decoder, T, _]] =
-        ctx.subtypes.zipWithIndex.map { (st, i) =>
+        ctx.subtypes.sorted(EnumOrdering).zipWithIndex.map { (st, i) =>
           val enumSymbol = GenericData.get.createEnum(schema.getEnumSymbols.get(i), schema).asInstanceOf[GenericData.EnumSymbol]
           enumSymbol -> st
         }.toMap

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/decoders/unions.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/decoders/unions.scala
@@ -2,7 +2,7 @@ package com.sksamuel.avro4s.decoders
 
 import com.sksamuel.avro4s.{Avro4sDecodingException, Decoder, Encoder}
 import com.sksamuel.avro4s.avroutils.SchemaHelper
-import com.sksamuel.avro4s.typeutils.{Annotations, Names, SubtypeOrdering}
+import com.sksamuel.avro4s.typeutils.{Annotations, Names}
 import magnolia1.SealedTrait
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericContainer

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/sealedtraits.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/sealedtraits.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.avro4s.encoders
 
-import com.sksamuel.avro4s.typeutils.{Annotations, Names}
+import com.sksamuel.avro4s.typeutils.{Annotations, Names, EnumOrdering}
 import com.sksamuel.avro4s.{Encoder, SchemaFor}
 import magnolia1.SealedTrait
 import org.apache.avro.generic.GenericData
@@ -9,7 +9,7 @@ import org.apache.avro.{Schema, SchemaBuilder}
 object SealedTraits {
   def encoder[T](ctx: SealedTrait[Encoder, T]): Encoder[T] = new Encoder[T] {
     override def encode(schema: Schema): T => Any = {
-      val symbolForSubtype: Map[SealedTrait.Subtype[Encoder, T, _], AnyRef] = ctx.subtypes.zipWithIndex.map {
+      val symbolForSubtype: Map[SealedTrait.Subtype[Encoder, T, _], AnyRef] = ctx.subtypes.sorted(EnumOrdering).zipWithIndex.map {
         case (st, i) => st -> GenericData.get.createEnum(schema.getEnumSymbols.get(i), schema)
       }.toMap
       { (value: T) => ctx.choose(value) { st => symbolForSubtype(st.subtype) } }

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/sealedtraits.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/sealedtraits.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.avro4s.encoders
 
-import com.sksamuel.avro4s.typeutils.{Annotations, Names, SubtypeOrdering}
+import com.sksamuel.avro4s.typeutils.{Annotations, Names}
 import com.sksamuel.avro4s.{Encoder, SchemaFor}
 import magnolia1.SealedTrait
 import org.apache.avro.generic.GenericData
@@ -9,7 +9,7 @@ import org.apache.avro.{Schema, SchemaBuilder}
 object SealedTraits {
   def encoder[T](ctx: SealedTrait[Encoder, T]): Encoder[T] = new Encoder[T] {
     override def encode(schema: Schema): T => Any = {
-      val symbolForSubtype: Map[SealedTrait.Subtype[Encoder, T, _], AnyRef] = ctx.subtypes.sorted(SubtypeOrdering).zipWithIndex.map {
+      val symbolForSubtype: Map[SealedTrait.Subtype[Encoder, T, _], AnyRef] = ctx.subtypes.zipWithIndex.map {
         case (st, i) => st -> GenericData.get.createEnum(schema.getEnumSymbols.get(i), schema)
       }.toMap
       { (value: T) => ctx.choose(value) { st => symbolForSubtype(st.subtype) } }

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/sealedtraits.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/sealedtraits.scala
@@ -9,7 +9,7 @@ import org.apache.avro.{Schema, SchemaBuilder}
 object SealedTraits {
   def encoder[T](ctx: SealedTrait[Encoder, T]): Encoder[T] = new Encoder[T] {
     override def encode(schema: Schema): T => Any = {
-      val symbolForSubtype: Map[SealedTrait.Subtype[Encoder, T, _], AnyRef] = ctx.subtypes.sorted(EnumOrdering).zipWithIndex.map {
+      val symbolForSubtype: Map[SealedTrait.Subtype[Encoder, T, _], AnyRef] = ctx.subtypes.sorted(EnumOrdering.reverse).zipWithIndex.map {
         case (st, i) => st -> GenericData.get.createEnum(schema.getEnumSymbols.get(i), schema)
       }.toMap
       { (value: T) => ctx.choose(value) { st => symbolForSubtype(st.subtype) } }

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/sealedtraits.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/sealedtraits.scala
@@ -9,7 +9,7 @@ import org.apache.avro.{Schema, SchemaBuilder}
 object SealedTraits {
   def encoder[T](ctx: SealedTrait[Encoder, T]): Encoder[T] = new Encoder[T] {
     override def encode(schema: Schema): T => Any = {
-      val symbolForSubtype: Map[SealedTrait.Subtype[Encoder, T, _], AnyRef] = ctx.subtypes.sorted(EnumOrdering.reverse).zipWithIndex.map {
+      val symbolForSubtype: Map[SealedTrait.Subtype[Encoder, T, _], AnyRef] = ctx.subtypes.sorted(EnumOrdering).zipWithIndex.map {
         case (st, i) => st -> GenericData.get.createEnum(schema.getEnumSymbols.get(i), schema)
       }.toMap
       { (value: T) => ctx.choose(value) { st => symbolForSubtype(st.subtype) } }

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/schemas/sealedtraits.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/schemas/sealedtraits.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.avro4s.schemas
 
 import com.sksamuel.avro4s.{AvroName, SchemaFor}
-import com.sksamuel.avro4s.typeutils.{Annotations, Names, SubtypeOrdering}
+import com.sksamuel.avro4s.typeutils.{Annotations, Names}
 import magnolia1.SealedTrait
 import org.apache.avro.{Schema, SchemaBuilder}
 
@@ -16,7 +16,7 @@ object SealedTraits {
     // if its name equals to the whole enumeration name.
     // Annotaions that are attached to the enum elements are not visible here.
     // Looks lilke we ned to have a look into either Magnolia or Scala 3.
-    val symbols = ctx.subtypes.sorted(SubtypeOrdering).map { st =>
+    val symbols = ctx.subtypes.map { st =>
       Names(
         st.typeInfo,
         Annotations(

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/schemas/sealedtraits.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/schemas/sealedtraits.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.avro4s.schemas
 
 import com.sksamuel.avro4s.{AvroName, SchemaFor}
-import com.sksamuel.avro4s.typeutils.{Annotations, Names}
+import com.sksamuel.avro4s.typeutils.{Annotations, Names, EnumOrdering}
 import magnolia1.SealedTrait
 import org.apache.avro.{Schema, SchemaBuilder}
 
@@ -16,7 +16,7 @@ object SealedTraits {
     // if its name equals to the whole enumeration name.
     // Annotaions that are attached to the enum elements are not visible here.
     // Looks lilke we ned to have a look into either Magnolia or Scala 3.
-    val symbols = ctx.subtypes.map { st =>
+    val symbols = ctx.subtypes.sorted(EnumOrdering).map { st =>
       Names(
         st.typeInfo,
         Annotations(

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/schemas/sealedtraits.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/schemas/sealedtraits.scala
@@ -16,7 +16,7 @@ object SealedTraits {
     // if its name equals to the whole enumeration name.
     // Annotaions that are attached to the enum elements are not visible here.
     // Looks lilke we ned to have a look into either Magnolia or Scala 3.
-    val symbols = ctx.subtypes.sorted(EnumOrdering.reverse).map { st =>
+    val symbols = ctx.subtypes.sorted(EnumOrdering).map { st =>
       Names(
         st.typeInfo,
         Annotations(

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/schemas/sealedtraits.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/schemas/sealedtraits.scala
@@ -16,7 +16,7 @@ object SealedTraits {
     // if its name equals to the whole enumeration name.
     // Annotaions that are attached to the enum elements are not visible here.
     // Looks lilke we ned to have a look into either Magnolia or Scala 3.
-    val symbols = ctx.subtypes.sorted(EnumOrdering).map { st =>
+    val symbols = ctx.subtypes.sorted(EnumOrdering.reverse).map { st =>
       Names(
         st.typeInfo,
         Annotations(

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/typeutils/EnumTypes.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/typeutils/EnumTypes.scala
@@ -11,6 +11,6 @@ object EnumOrdering extends Ordering[SealedTrait.Subtype[_, _, _]] {
     val priorityA = annosA.sortPriority.getOrElse(0F)
     val priorityB = annosB.sortPriority.getOrElse(0F)
 
-    if (priorityA == priorityB) 0 else priorityA.compare(priorityB)
+    if (priorityA == priorityB) 0 else priorityB.compare(priorityA)
   }
 }

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/typeutils/EnumTypes.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/typeutils/EnumTypes.scala
@@ -2,17 +2,14 @@ package com.sksamuel.avro4s.typeutils
 
 import magnolia1.SealedTrait
 
-object SubtypeOrdering extends Ordering[SealedTrait.Subtype[_, _, _]] {
+object EnumOrdering extends Ordering[SealedTrait.Subtype[_, _, _]] {
   override def compare(a: SealedTrait.Subtype[_, _, _], b: SealedTrait.Subtype[_, _, _]): Int = {
 
     val annosA = new Annotations(a.annotations)
     val annosB = new Annotations(b.annotations)
 
-    val namesA = new Names(a.typeInfo, annosA)
-    val namesB = new Names(b.typeInfo, annosB)
-
-    val priorityA = annosA.sortPriority.getOrElse(999999F)
-    val priorityB = annosB.sortPriority.getOrElse(999999F)
+    val priorityA = annosA.sortPriority.getOrElse(0F)
+    val priorityB = annosB.sortPriority.getOrElse(0F)
 
     if (priorityA == priorityB) 0 else priorityA.compare(priorityB)
   }

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/typeutils/EnumTypes.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/typeutils/EnumTypes.scala
@@ -11,6 +11,6 @@ object EnumOrdering extends Ordering[SealedTrait.Subtype[_, _, _]] {
     val priorityA = annosA.sortPriority.getOrElse(0F)
     val priorityB = annosB.sortPriority.getOrElse(0F)
 
-    if (priorityA == priorityB) 0 else priorityB.compare(priorityA)
+    if (priorityA == priorityB) 0 else priorityA.compare(priorityB)
   }
 }

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/typeutils/Subtypes.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/typeutils/Subtypes.scala
@@ -14,6 +14,6 @@ object SubtypeOrdering extends Ordering[SealedTrait.Subtype[_, _, _]] {
     val priorityA = annosA.sortPriority.getOrElse(999999F)
     val priorityB = annosB.sortPriority.getOrElse(999999F)
 
-    if (priorityA == priorityB) 0 else priorityA.compare(priorityB)
+    if (priorityA == priorityB) namesA.fullName.compare(namesB.fullName) else priorityA.compare(priorityB)
   }
 }

--- a/avro4s-core/src/test/resources/avro_name_sealed_trait_symbol.json
+++ b/avro4s-core/src/test/resources/avro_name_sealed_trait_symbol.json
@@ -3,6 +3,7 @@
   "name": "Benelux",
   "namespace": "com.sksamuel.avro4s.schema",
   "symbols": [
+    "Netherlands",
     "Luxembourg",
     "foofoo"
   ]

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/AvroNameSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/AvroNameSchemaTest.scala
@@ -54,6 +54,8 @@ case object Sunny extends Weather
 
 sealed trait Benelux
 @AvroName("foofoo")
-@AvroSortPriority(5)
+@AvroSortPriority(-1)
 case object Belgium extends Benelux
 case object Luxembourg extends Benelux
+@AvroSortPriority(1)
+case object Netherlands extends Benelux

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/AvroNameSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/AvroNameSchemaTest.scala
@@ -53,6 +53,7 @@ case object Rainy extends Weather
 case object Sunny extends Weather
 
 sealed trait Benelux
+
+case object Luxembourg extends Benelux
 @AvroName("foofoo")
 case object Belgium extends Benelux
-case object Luxembourg extends Benelux

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/AvroNameSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/AvroNameSchemaTest.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.avro4s.schema
 
-import com.sksamuel.avro4s.{AvroName, AvroSchema, SnakeCase}
+import com.sksamuel.avro4s.{AvroName, AvroSortPriority, AvroSchema, SnakeCase}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
@@ -53,7 +53,7 @@ case object Rainy extends Weather
 case object Sunny extends Weather
 
 sealed trait Benelux
-
-case object Luxembourg extends Benelux
 @AvroName("foofoo")
+@AvroSortPriority(5)
 case object Belgium extends Benelux
+case object Luxembourg extends Benelux

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/EnumSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/EnumSchemaTest.scala
@@ -680,11 +680,11 @@ enum Sport:
   case Boxing, Soccer, Ruggers
 
 sealed trait CupcatEnum
-@AvroSortPriority(0) case object SnoutleyEnum extends CupcatEnum
+@AvroSortPriority(2) case object SnoutleyEnum extends CupcatEnum
 @AvroSortPriority(1) case object CuppersEnum extends CupcatEnum
 
 @AvroEnumDefault(SnoutleyAnnotatedEnum)
 sealed trait CupcatAnnotatedEnum
-@AvroSortPriority(0) case object SnoutleyAnnotatedEnum extends CupcatAnnotatedEnum
+@AvroSortPriority(2) case object SnoutleyAnnotatedEnum extends CupcatAnnotatedEnum
 @AvroSortPriority(1) case object CuppersAnnotatedEnum extends CupcatAnnotatedEnum
 

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/SealedTraitSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/SealedTraitSchemaTest.scala
@@ -67,8 +67,8 @@ case object Dabble extends Dibble
 case object Dobbles extends Dibble
 
 sealed trait Wibble
-case class Wobble(str: String) extends Wibble
 case class Wabble(dbl: Double) extends Wibble
+case class Wobble(str: String) extends Wibble
 case class Wrapper(wibble: Wibble)
 
 sealed trait Tibble


### PR DESCRIPTION
This PR addresses an issue referenced in #769

Avro4s wrongfully sorts enum type symbols instead of using in the order they are defined in a schema. AVRO spec states sorting is based on symbol position: https://avro.apache.org/docs/1.11.1/specification/#sort-order

In `AvroNameSchemaTest` there was wrong testdata. `Benelux` had it's subtypes in a different order as in `avro_name_sealed_trait_symbol.json`
The test succeeded because it accidently was sorted in the correct order as `List("foofoo", "Luxembourg").sorted == List("Luxembourg", "foofoo")`, as uppercase chars precede lowercase chars.

To take into account priorities I added `EnumOrdering`, because SubtypeOrdering takes into account the type names.
