### PR TITLE
Remove unnecessary (?) compiler dependency

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -38,7 +38,6 @@ object Build extends AutoPlugin {
     Test / scalacOptions ++= Seq("-Xmax-inlines:100", "-Yretain-trees"),
     javacOptions := Seq("-source", "1.8", "-target", "1.8"),    
     libraryDependencies ++= Seq(
-      "org.scala-lang"    % "scala3-compiler_3" % scalaVersion.value,
       "org.apache.avro"   % "avro"              % AvroVersion,
       "org.slf4j"         % "slf4j-api"         % Slf4jVersion          % "test",
       "log4j"             % "log4j"             % Log4jVersion          % "test",


### PR DESCRIPTION
I ended up with `protobuf-java` 3.7.0 on my project classpath, and found that the culprit was `avro4s-core -> scala3-compiler_3 -> compiler-interface`. The problem is that `protobuf-java` `3.7.0` is very old and has a number of CVEs. 

At any rate, I was confused as to why avro4s needed the `scala3-compiler_3` dependency, so tried compiling without it. It compiles fine, and tests pass.

I assume it was added for a reason, at some point, but maybe is no longer necessary? Or am I missing something?