### PR TITLE
Remove scala-compiler dependency for release/4.0.x branch

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -49,7 +49,6 @@ object Build extends AutoPlugin {
     javacOptions := Seq("-source", "1.8", "-target", "1.8"),
     libraryDependencies ++= Seq(
       "org.scala-lang"    % "scala-reflect"     % scalaVersion.value,
-      "org.scala-lang"    % "scala-compiler"    % scalaVersion.value,
       "org.apache.avro"   % "avro"              % AvroVersion,
       "org.slf4j"         % "slf4j-api"         % Slf4jVersion          % "test",
       "log4j"             % "log4j"             % Log4jVersion          % "test",


### PR DESCRIPTION
Same as https://github.com/sksamuel/avro4s/pull/813. In my case, scala-compiler depends on a version of scala-xml that conflicts with another dependency's version of scala-xml.