### PR TITLE
Match Union's sort order with enum's and with sort order in 4.x

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/typeutils/Subtypes.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/typeutils/Subtypes.scala
@@ -14,6 +14,6 @@ object SubtypeOrdering extends Ordering[SealedTrait.Subtype[_, _, _]] {
     val priorityA = annosA.sortPriority.getOrElse(999999F)
     val priorityB = annosB.sortPriority.getOrElse(999999F)
 
-    if (priorityA == priorityB) namesA.fullName.compare(namesB.fullName) else priorityA.compare(priorityB)
+    if (priorityA == priorityB) namesA.fullName.compare(namesB.fullName) else priorityB.compare(priorityA)
   }
 }

--- a/avro4s-core/src/test/resources/avro_union_position_enum.json
+++ b/avro4s-core/src/test/resources/avro_union_position_enum.json
@@ -1,0 +1,6 @@
+{
+  "type": "enum",
+  "name": "Numeric",
+  "namespace": "com.sksamuel.avro4s.schema.AvroUnionPositionSchemaTestContext",
+  "symbols": ["NaturalNumber", "RationalNumber", "RealNumber"]
+}

--- a/avro4s-core/src/test/resources/avro_union_position_union.json
+++ b/avro4s-core/src/test/resources/avro_union_position_union.json
@@ -1,0 +1,32 @@
+{
+  "type": "record",
+  "name": "FightingStyleWrapper",
+  "namespace": "com.sksamuel.avro4s.schema.AvroUnionPositionSchemaTestContext",
+  "fields": [
+    {
+      "name": "fightingstyle",
+      "type": [
+        {
+          "type": "record",
+          "name": "DefensiveFightingStyle",
+          "fields": [
+            {
+              "name": "has_armor",
+              "type": "boolean"
+            }
+          ]
+        },
+        {
+          "type": "record",
+          "name": "AggressiveFightingStyle",
+          "fields": [
+            {
+              "name": "agressiveness",
+              "type": "float"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/AvroSortPrioritySchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/AvroSortPrioritySchemaTest.scala
@@ -1,49 +1,48 @@
-//package com.sksamuel.avro4s.schema
-//
-//import com.sksamuel.avro4s.{AvroSchema, AvroSortPriority}
-//
-//import org.scalatest.funsuite.AnyFunSuite
-//import org.scalatest.matchers.should.Matchers
-//
-//class AvroSortPrioritySchemaTest extends AnyFunSuite with Matchers {
-//
-//  test("enums should be sorted by descending priority") {
-//    val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/avro_sort_priority_enum.json"))
-//    val schema = AvroSchema[Numeric]
-//    schema.toString(true) shouldBe expected.toString(true)
-//  }
-//
-//  test("unions should be sorted by descending priority") {
-//    val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/avro_sort_priority_union.json"))
-//    val schema = AvroSchema[FightingStyleWrapper]
-//
-//    schema.toString(true) shouldBe expected.toString(true)
-//  }
-//
+package com.sksamuel.avro4s.schema
+
+import com.sksamuel.avro4s.{AvroSchema, AvroSortPriority}
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class AvroSortPrioritySchemaTest extends AnyFunSuite with Matchers {
+
+  test("enums should be sorted by descending priority") {
+    val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/avro_sort_priority_enum.json"))
+    val schema = AvroSchema[Numeric]
+    schema.toString(true) shouldBe expected.toString(true)
+  }
+
+  test("unions should be sorted by descending priority") {
+    val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/avro_sort_priority_union.json"))
+    val schema = AvroSchema[FightingStyleWrapper]
+
+    schema.toString(true) shouldBe expected.toString(true)
+  }
+
 //  test("avrosortpriority should respect union default ordering") {
 //    val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/avro_sort_priority_union_with_default.json"))
 //    val schema = AvroSchema[FightingStyleWrapperWithDefault]
 //
 //    schema.toString(true) shouldBe expected.toString(true)
 //  }
-//}
-//
-//
-//sealed trait Numeric
-//@AvroSortPriority(1)
-//case object RationalNumber extends Numeric
-//@AvroSortPriority(0)
-//case object RealNumber extends Numeric
-//@AvroSortPriority(2)
-//case object NaturalNumber extends Numeric
-//
-//
-//case class FightingStyleWrapper(fightingstyle: FightingStyle)
+}
+
+
+sealed trait Numeric
+@AvroSortPriority(1)
+case object RationalNumber extends Numeric
+@AvroSortPriority(0)
+case object RealNumber extends Numeric
+@AvroSortPriority(2)
+case object NaturalNumber extends Numeric
+
+
+case class FightingStyleWrapper(fightingstyle: FightingStyle)
 //case class FightingStyleWrapperWithDefault(fightingstyle: FightingStyle = AggressiveFightingStyle(10))
-//
-//sealed trait FightingStyle
-//@AvroSortPriority(2)
-//case class AggressiveFightingStyle(agressiveness: Float) extends FightingStyle
-//@AvroSortPriority(10)
-//case class DefensiveFightingStyle(has_armor: Boolean) extends FightingStyle
-//
+
+sealed trait FightingStyle
+@AvroSortPriority(2)
+case class AggressiveFightingStyle(agressiveness: Float) extends FightingStyle
+@AvroSortPriority(10)
+case class DefensiveFightingStyle(has_armor: Boolean) extends FightingStyle

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/AvroUnionPositionSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/AvroUnionPositionSchemaTest.scala
@@ -1,0 +1,49 @@
+package com.sksamuel.avro4s.schema
+
+import com.sksamuel.avro4s.{AvroSchema, AvroUnionPosition}
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class AvroUnionPositionSchemaTest extends AnyFunSuite with Matchers with AvroUnionPositionSchemaTestContext {
+
+  test("enums should be sorted by ascending union position") {
+    val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/avro_union_position_enum.json"))
+    val schema = AvroSchema[Numeric]
+    schema.toString(true) shouldBe expected.toString(true)
+  }
+
+  test("unions should be sorted by ascending union position") {
+    val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/avro_union_position_union.json"))
+    val schema = AvroSchema[FightingStyleWrapper]
+
+    schema.toString(true) shouldBe expected.toString(true)
+  }
+
+//  test("avrosortpriority should respect union default ordering") {
+//    val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/avro_sort_priority_union_with_default.json"))
+//    val schema = AvroSchema[FightingStyleWrapperWithDefault]
+//
+//    schema.toString(true) shouldBe expected.toString(true)
+//  }
+}
+
+trait AvroUnionPositionSchemaTestContext {
+
+  sealed trait Numeric
+  @AvroUnionPosition(2)
+  case object RationalNumber extends Numeric
+  @AvroUnionPosition(3)
+  case object RealNumber extends Numeric
+  @AvroUnionPosition(1)
+  case object NaturalNumber extends Numeric
+
+  case class FightingStyleWrapper(fightingstyle: FightingStyle)
+//  case class FightingStyleWrapperWithDefault(fightingstyle: FightingStyle = AggressiveFightingStyle(10))
+
+  sealed trait FightingStyle
+  @AvroUnionPosition(2)
+  case class AggressiveFightingStyle(agressiveness: Float) extends FightingStyle
+  @AvroUnionPosition(1)
+  case class DefensiveFightingStyle(has_armor: Boolean) extends FightingStyle
+}


### PR DESCRIPTION
Seems like annotation `@AvroSortPriority` sorts records in Union in reversed order comparing with Enums, as well as with Enums/Unions from `avro4s:4.x`.

Probably the reason is a sort order [here in Subtypes](https://github.com/sksamuel/avro4s/blob/master/avro4s-core/src/main/scala/com/sksamuel/avro4s/typeutils/Subtypes.scala#L17). Comparing with [enums in 5.x](https://github.com/sksamuel/avro4s/blob/2beb8cbdcbb021609bd1b30f922444b81fbc0096/avro4s-core/src/main/scala/com/sksamuel/avro4s/typeutils/EnumTypes.scala#L14) and [unions in 4.x](https://github.com/sksamuel/avro4s/blob/a4aee30f04eb3f891d5d1e05e91979229dd060ac/avro4s-core/src/main/scala/com/sksamuel/avro4s/TypeUnions.scala#L103), it seems to me that the Ordering compares A with B - ascending order, when instead it should compare B to A - descending.
Since `AvroSortPriority` is descending-based (if we could say so), then there should be `B compare A`. 

The same (but reversed) issue with `AvroUnionPosition` will be automatically resolved since these two annotations are tightly coupled anyway.

