### PR TITLE
Enable json values for @AvroProp.

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/annotations.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/annotations.scala
@@ -1,5 +1,6 @@
 package com.sksamuel.avro4s
 
+import com.fasterxml.jackson.databind.JsonNode
 import scala.annotation.StaticAnnotation
 
 case class AvroAlias(override val alias: String) extends AvroAliasable
@@ -79,11 +80,11 @@ trait AvroNamespaceable extends AvroFieldReflection {
   val namespace: String
 }
 
-case class AvroProp(override val key: String, override val value:String) extends AvroProperty
+case class AvroProp(override val key: String, override val value: String | JsonNode) extends AvroProperty
 
 trait AvroProperty extends AvroFieldReflection {
   val key: String
-  val value: String
+  val value: String | JsonNode
 }
 
 /**

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/typeutils/Annotations.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/typeutils/Annotations.scala
@@ -1,5 +1,6 @@
 package com.sksamuel.avro4s.typeutils
 
+import com.fasterxml.jackson.databind.JsonNode
 import com.sksamuel.avro4s.{AvroAliasable, AvroDoc, AvroDocumentable, AvroErasedName, AvroError, AvroFixed, AvroName, AvroNameable, AvroNamespace, AvroNoDefault, AvroProp, AvroProperty, AvroSortPriority, AvroTransient, AvroUnionPosition}
 import magnolia1.{CaseClass, TypeInfo}
 
@@ -18,7 +19,7 @@ class Annotations(annos: Seq[Any], inheritedAnnos: Seq[Any] = Nil) {
     case t: AvroAliasable => t.alias
   }.filterNot(_.trim.isEmpty)
 
-  def props: Map[String, String] = annos.collect {
+  def props: Map[String, String | JsonNode] = annos.collect {
     case t: AvroProperty => (t.key, t.value)
   }.toMap
 

--- a/avro4s-core/src/test/resources/props_annotation_json_field.json
+++ b/avro4s-core/src/test/resources/props_annotation_json_field.json
@@ -1,0 +1,15 @@
+{
+  "type": "record",
+  "name": "Annotated",
+  "namespace": "com.sksamuel.avro4s.schema.AvroPropSchemaTest",
+  "fields": [
+    {
+      "name": "str",
+      "type": "string",
+      "terms": [
+        "foo",
+        "bar"
+      ]
+    }
+  ]
+}

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/AvroPropSchemaTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/schema/AvroPropSchemaTest.scala
@@ -1,5 +1,6 @@
 package com.sksamuel.avro4s.schema
 
+import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import com.sksamuel.avro4s.{AvroProp, AvroSchema}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -16,6 +17,13 @@ class AvroPropSchemaTest extends AnyWordSpec with Matchers {
     "support prop annotation on field" in {
       case class Annotated(@AvroProp("cold", "play") str: String, @AvroProp("kate", "bush") long: Long, int: Int)
       val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/props_annotation_field.json"))
+      val schema = AvroSchema[Annotated]
+      schema.toString(true) shouldBe expected.toString(true)
+    }
+    "support json prop annotation on field" in {
+      val jsonArray = (new ObjectMapper()).createArrayNode().add("foo").add("bar")
+      case class Annotated(@AvroProp("terms", jsonArray) str: String)
+      val expected = new org.apache.avro.Schema.Parser().parse(getClass.getResourceAsStream("/props_annotation_json_field.json"))
       val schema = AvroSchema[Annotated]
       schema.toString(true) shouldBe expected.toString(true)
     }


### PR DESCRIPTION
Avro properties can according to the schema specification and schema api be general json objects, but avro4s currently allows strings. See https://github.com/sksamuel/avro4s/issues/490.