### PR TITLE
Serializable Encoder, Decoder and SchemaFor

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/Decoder.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/Decoder.scala
@@ -13,7 +13,7 @@ import org.apache.avro.Schema
   * Another example, a decoder for Option[String] would handle inputs of null
   * by emitting a None, and a non-null input by emitting a String wrapped in a Some.
   */
-trait Decoder[T] {
+trait Decoder[T] extends Serializable {
   self =>
 
   def decode(schema: Schema): Any => T

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/Encoder.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/Encoder.scala
@@ -38,7 +38,7 @@ import org.apache.avro.specific.SpecificRecord
   * However for interop with other systems you may wish to customize this, for example, by
   * writing out field names in snake_case or adding a prefix.
   */
-trait Encoder[T] {
+trait Encoder[T] extends Serializable {
   self =>
 
   def encode(schema: Schema): T => Any

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/SchemaFor.scala
@@ -16,7 +16,7 @@ import java.util.{Date, UUID}
   * For example, a SchemaFor[String] could return a schema of type Schema.Type.STRING, and
   * a SchemaFor[Int] could return an schema of type Schema.Type.INT
   */
-trait SchemaFor[T] {
+trait SchemaFor[T] extends Serializable {
   self =>
 
   /**


### PR DESCRIPTION
This is needed to be able to use with frameworks like Apache Flink.
This is similar to circe Encoder and Decoder