### PR TITLE
change return type of `encoder` from `Any` to `AnyRef`

### DIFF
--- a/avro4s-cats/src/main/scala/com/sksamuel/avro4s/cats/package.scala
+++ b/avro4s-cats/src/main/scala/com/sksamuel/avro4s/cats/package.scala
@@ -16,21 +16,21 @@ package object cats:
   given[T](using schemaFor: SchemaFor[T]): SchemaFor[NonEmptyChain[T]] = SchemaFor(Schema.createArray(schemaFor.schema))
 
   given[T](using encoder: Encoder[T]): Encoder[NonEmptyList[T]] = new Encoder[NonEmptyList[T]] :
-    override def encode(schema: Schema): NonEmptyList[T] => Any = {
+    override def encode(schema: Schema): NonEmptyList[T] => AnyRef = {
       require(schema.getType == Schema.Type.ARRAY)
       val encode = encoder.encode(schema)
       { value => value.map(encode).toList.asJava }
     }
 
   given[T](using encoder: Encoder[T]): Encoder[NonEmptyVector[T]] = new Encoder[NonEmptyVector[T]] :
-    override def encode(schema: Schema): NonEmptyVector[T] => Any = {
+    override def encode(schema: Schema): NonEmptyVector[T] => AnyRef = {
       require(schema.getType == Schema.Type.ARRAY)
       val encode = encoder.encode(schema)
       { value => value.map(encode).toVector.asJava }
     }
 
   given[T](using encoder: Encoder[T]): Encoder[NonEmptyChain[T]] = new Encoder[NonEmptyChain[T]] :
-    override def encode(schema: Schema): NonEmptyChain[T] => Any = {
+    override def encode(schema: Schema): NonEmptyChain[T] => AnyRef = {
       require(schema.getType == Schema.Type.ARRAY)
       val encode = encoder.encode(schema)
       { value => value.map(encode).toNonEmptyList.toList.asJava }

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/Encoder.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/Encoder.scala
@@ -41,14 +41,14 @@ import org.apache.avro.specific.SpecificRecord
 trait Encoder[T] extends Serializable {
   self =>
 
-  def encode(schema: Schema): T => Any
+  def encode(schema: Schema): T => AnyRef
 
   /**
     * Returns an [[Encoder[U]] by applying a function that maps a U
     * to an T, before encoding as an T using this encoder.
     */
   final def contramap[U](f: U => T): Encoder[U] = new Encoder[U] {
-    override def encode(schema: Schema): U => Any = { u => self.encode(schema).apply(f(u)) }
+    override def encode(schema: Schema): U => AnyRef = { u => self.encode(schema).apply(f(u)) }
   }
 }
 
@@ -67,14 +67,14 @@ object Encoder
   /**
     * Returns an [Encoder] that encodes using the supplied function.
     */
-  def apply[T](f: T => Any) = new Encoder[T] {
-    def encode(schema: Schema): T => Any = { t => f(t) }
+  def apply[T](f: T => AnyRef) = new Encoder[T] {
+    def encode(schema: Schema): T => AnyRef = f
   }
 
   /**
     * Returns an [Encoder] that encodes by simply returning the input value.
     */
-  def identity[T]: Encoder[T] = Encoder[T](t => t)
+  def identity[T <: AnyRef]: Encoder[T] = Encoder[T](t => t)
 
   def apply[T](using encoder: Encoder[T]): Encoder[T] = encoder
 }

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/bigdecimals.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/bigdecimals.scala
@@ -6,7 +6,7 @@ import org.apache.avro.{Conversions, Schema}
 
 trait BigDecimalEncoders:
   given Encoder[BigDecimal] = new Encoder[BigDecimal] :
-    override def encode(schema: Schema): BigDecimal => Any = {
+    override def encode(schema: Schema): BigDecimal => AnyRef = {
       schema.getType match {
         case Schema.Type.BYTES => BigDecimalBytesEncoder.encode(schema)
         case Schema.Type.STRING => BigDecimalStringEncoder.encode(schema)
@@ -22,7 +22,7 @@ trait BigDecimalEncoders:
   */
 object BigDecimalBytesEncoder extends Encoder[BigDecimal] {
 
-  override def encode(schema: Schema): BigDecimal => Any = {
+  override def encode(schema: Schema): BigDecimal => AnyRef = {
     require(schema.getType == Schema.Type.BYTES)
 
     val logical = schema.getLogicalType.asInstanceOf[Decimal]
@@ -38,7 +38,7 @@ object BigDecimalBytesEncoder extends Encoder[BigDecimal] {
   */
 object BigDecimalStringEncoder extends Encoder[BigDecimal] {
 
-  override def encode(schema: Schema): BigDecimal => Any = {
+  override def encode(schema: Schema): BigDecimal => AnyRef = {
     require(schema.getType == Schema.Type.STRING)
 
     val logical = schema.getLogicalType.asInstanceOf[Decimal]
@@ -54,7 +54,7 @@ object BigDecimalStringEncoder extends Encoder[BigDecimal] {
   */
 object BigDecimalFixedEncoder extends Encoder[BigDecimal] {
 
-  override def encode(schema: Schema): BigDecimal => Any = {
+  override def encode(schema: Schema): BigDecimal => AnyRef = {
     require(schema.getType == Schema.Type.FIXED)
 
     val logical = schema.getLogicalType.asInstanceOf[Decimal]

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/bytes.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/bytes.scala
@@ -16,7 +16,7 @@ trait ByteIterableEncoders:
   given Encoder[Seq[Byte]] = IterableByteEncoder.contramap(_.toIterable)
 
 object ByteBufferEncoder extends Encoder[ByteBuffer] :
-  override def encode(schema: Schema): ByteBuffer => Any = {
+  override def encode(schema: Schema): ByteBuffer => AnyRef = {
     schema.getType match {
       case Schema.Type.BYTES => identity
       case Schema.Type.FIXED => FixedByteBufferEncoder.encode(schema)
@@ -26,7 +26,7 @@ object ByteBufferEncoder extends Encoder[ByteBuffer] :
   }
 
 object ByteArrayEncoder extends Encoder[Array[Byte]] :
-  override def encode(schema: Schema): Array[Byte] => Any = {
+  override def encode(schema: Schema): Array[Byte] => AnyRef = {
     schema.getType match {
       case Schema.Type.BYTES => { bytes => ByteBuffer.wrap(bytes) }
       case Schema.Type.FIXED => FixedByteArrayEncoder.encode(schema)
@@ -36,7 +36,7 @@ object ByteArrayEncoder extends Encoder[Array[Byte]] :
   }
 
 object FixedByteBufferEncoder extends Encoder[ByteBuffer] {
-  override def encode(schema: Schema): ByteBuffer => Any = { value =>
+  override def encode(schema: Schema): ByteBuffer => AnyRef = { value =>
     val array = new Array[Byte](schema.getFixedSize)
     val bbArray = ByteBufferHelper.asArray(value)
     System.arraycopy(bbArray, 0, array, 0, bbArray.length)
@@ -45,7 +45,7 @@ object FixedByteBufferEncoder extends Encoder[ByteBuffer] {
 }
 
 object FixedByteArrayEncoder extends Encoder[Array[Byte]] {
-  override def encode(schema: Schema): Array[Byte] => Any = { value =>
+  override def encode(schema: Schema): Array[Byte] => AnyRef = { value =>
     val array = new Array[Byte](schema.getFixedSize)
     System.arraycopy(value, 0, array, 0, value.length)
     GenericData.get.createFixed(null, array, schema)

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/collections.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/collections.scala
@@ -9,7 +9,7 @@ import scala.reflect.ClassTag
 trait CollectionEncoders:
 
   private def iterableEncoder[T, C[X] <: Iterable[X]](encoder: Encoder[T]): Encoder[C[T]] = new Encoder[C[T]] {
-    override def encode(schema: Schema): C[T] => Any = {
+    override def encode(schema: Schema): C[T] => AnyRef = {
       require(schema.getType == Schema.Type.ARRAY)
       val elementEncoder = encoder.encode(schema.getElementType)
       { t => t.map(elementEncoder.apply).toList.asJava }
@@ -17,7 +17,7 @@ trait CollectionEncoders:
   }
 
   given[T](using encoder: Encoder[T], tag: ClassTag[T]): Encoder[Array[T]] = new Encoder[Array[T]] {
-    override def encode(schema: Schema): Array[T] => Any = {
+    override def encode(schema: Schema): Array[T] => AnyRef = {
       require(schema.getType == Schema.Type.ARRAY)
       val elementEncoder = encoder.encode(schema.getElementType)
       { t => t.map(elementEncoder.apply).toList.asJava }
@@ -32,7 +32,7 @@ trait CollectionEncoders:
   given mapEncoder[T](using encoder: Encoder[T]): Encoder[Map[String, T]] = new MapEncoder[T](encoder)
 
 class MapEncoder[T](encoder: Encoder[T]) extends Encoder[Map[String, T]] :
-  override def encode(schema: Schema): Map[String, T] => Any = {
+  override def encode(schema: Schema): Map[String, T] => AnyRef = {
     val encodeT = encoder.encode(schema.getValueType)
     { value =>
       val map = new java.util.HashMap[String, Any]

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/eithers.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/eithers.scala
@@ -6,7 +6,7 @@ import org.apache.avro.Schema
 
 trait EitherEncoders:
   given eitherEncoder[A, B] (using a: Encoder[A], b: Encoder[B]): Encoder[Either[A, B]] with
-    override def encode(schema: Schema): Either[A, B] => Any = {
+    override def encode(schema: Schema): Either[A, B] => AnyRef = {
       require(schema.isUnion)
 
       val leftSchema = SchemaHelper.extractEitherLeftSchema(schema)

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/options.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/options.scala
@@ -8,7 +8,7 @@ import scala.jdk.CollectionConverters.*
 
 class OptionEncoder[T](encoder: Encoder[T]) extends Encoder[Option[T]] {
 
-  override def encode(schema: Schema): Option[T] => Any = {
+  override def encode(schema: Schema): Option[T] => AnyRef = {
     // nullables must be encoded with a union of 2 elements, one of which is null
     require(schema.getType == Schema.Type.UNION, {
       "Options can only be encoded with a UNION schema"

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/primitives.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/primitives.scala
@@ -16,5 +16,5 @@ trait PrimitiveEncoders {
 }
 
 object IntEncoder extends Encoder[Int] {
-  override def encode(schema: Schema): Int => Any = { value => java.lang.Integer.valueOf(value) }
+  override def encode(schema: Schema): Int => AnyRef = { value => java.lang.Integer.valueOf(value) }
 }

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/records.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/records.scala
@@ -11,7 +11,7 @@ import scala.reflect.ClassTag
 
 class RecordEncoder[T](ctx: magnolia1.CaseClass[Encoder, T]) extends Encoder[T] {
 
-  def encode(schema: Schema): T => Any = {
+  def encode(schema: Schema): T => AnyRef = {
     // the order of the encoders comes from the schema
     val encoders: Array[FieldEncoder[T]] = schema.getFields.asScala.map { field =>
       val param = findParam(field, ctx)

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/sealedtraits.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/sealedtraits.scala
@@ -8,7 +8,7 @@ import org.apache.avro.{Schema, SchemaBuilder}
 
 object SealedTraits {
   def encoder[T](ctx: SealedTrait[Encoder, T]): Encoder[T] = new Encoder[T] {
-    override def encode(schema: Schema): T => Any = {
+    override def encode(schema: Schema): T => AnyRef = {
       val symbolForSubtype: Map[SealedTrait.Subtype[Encoder, T, _], AnyRef] = ctx.subtypes.sortBy(_.index).sorted(EnumOrdering).zipWithIndex.map {
         case (st, i) => st -> GenericData.get.createEnum(schema.getEnumSymbols.get(i), schema)
       }.toMap

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/strings.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/strings.scala
@@ -17,7 +17,7 @@ trait StringEncoders:
   given Encoder[UUID] = UUIDEncoder
 
 object StringEncoder extends Encoder[String] :
-  override def encode(schema: Schema): String => Any = schema.getType match {
+  override def encode(schema: Schema): String => AnyRef = schema.getType match {
     case Schema.Type.STRING if schema.getObjectProp("avro.java.string") == "String" => Encoder.identity[String].encode(schema)
     case Schema.Type.STRING => UTF8StringEncoder.encode(schema)
     case Schema.Type.BYTES => ByteStringEncoder.encode(schema)
@@ -26,26 +26,26 @@ object StringEncoder extends Encoder[String] :
   }
 
 object UUIDEncoder extends Encoder[UUID] :
-  override def encode(schema: Schema): UUID => Any = uuid => new Utf8(uuid.toString)
+  override def encode(schema: Schema): UUID => AnyRef = uuid => new Utf8(uuid.toString)
 
 /**
   * An [[Encoder]] for Strings that encodes as avro [[Utf8]]s.
   */
 object UTF8StringEncoder extends Encoder[String] :
-  override def encode(schema: Schema): String => Any = string => new Utf8(string)
+  override def encode(schema: Schema): String => AnyRef = string => new Utf8(string)
 
 /**
   * An [[Encoder]] for Strings that encodes as [[ByteBuffer]]s.
   */
 object ByteStringEncoder extends Encoder[String] :
-  override def encode(schema: Schema): String => Any = string =>
+  override def encode(schema: Schema): String => AnyRef = string =>
     ByteBuffer.wrap(string.getBytes(StandardCharsets.UTF_8))
 
 /**
   * An [[Encoder]] for Strings that encodes as [[GenericFixed]]s.
   */
 object FixedStringEncoder extends Encoder[String] :
-  override def encode(schema: Schema): String => Any = string =>
+  override def encode(schema: Schema): String => AnyRef = string =>
     val bytes = string.getBytes(StandardCharsets.UTF_8)
     if (bytes.length > schema.getFixedSize)
       throw new Avro4sEncodingException(s"Cannot write string with ${bytes.length} bytes to fixed type of size ${schema.getFixedSize}")

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/temporal.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/temporal.scala
@@ -22,12 +22,12 @@ trait TemporalEncoders:
   given Encoder[OffsetDateTime] = OffsetDateTimeEncoder
 
 object OffsetDateTimeEncoder extends Encoder[OffsetDateTime] :
-  override def encode(schema: Schema): OffsetDateTime => Any = { value =>
+  override def encode(schema: Schema): OffsetDateTime => AnyRef = { value =>
     value.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
   }
 
 object LocalTimeEncoder extends Encoder[LocalTime] :
-  override def encode(schema: Schema): LocalTime => Any = {
+  override def encode(schema: Schema): LocalTime => AnyRef = {
     val toNanosFactor = schema.getLogicalType match {
       case _: TimeMicros => 1000L
       case _: TimeMillis => 1000000L
@@ -52,7 +52,7 @@ private abstract class TemporalWithLogicalTypeEncoder[T] extends Encoder[T] :
   def epochSeconds(temporal: T): Long
   def nanos(temporal: T): Long
 
-  override def encode(schema: Schema): T => Any = {
+  override def encode(schema: Schema): T => AnyRef = {
     val toLong: T => Long = schema.getLogicalType match {
       case _: TimestampMillis => epochMillis
       case _: TimestampMicros => t => epochSeconds(t) * 1000000L + nanos(t) / 1000L

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/tuples.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/tuples.scala
@@ -13,7 +13,7 @@ trait TupleEncoders:
     Tuple5Encoder(a, b, c, d, e)
 
 class Tuple2Encoder[A, B](a: Encoder[A], b: Encoder[B]) extends Encoder[Tuple2[A, B]] {
-  override def encode(schema: Schema): ((A, B)) => Any = {
+  override def encode(schema: Schema): ((A, B)) => AnyRef = {
     val fieldA: Schema.Field = schema.getFields.get(0)
     val fieldB: Schema.Field = schema.getFields.get(1)
     val encoderA = a.encode(fieldA.schema())
@@ -28,7 +28,7 @@ class Tuple2Encoder[A, B](a: Encoder[A], b: Encoder[B]) extends Encoder[Tuple2[A
 }
 
 class Tuple3Encoder[A, B, C](a: Encoder[A], b: Encoder[B], c: Encoder[C]) extends Encoder[Tuple3[A, B, C]] {
-  override def encode(schema: Schema): ((A, B, C)) => Any = {
+  override def encode(schema: Schema): ((A, B, C)) => AnyRef = {
     val fieldA: Schema.Field = schema.getFields.get(0)
     val fieldB: Schema.Field = schema.getFields.get(1)
     val fieldC: Schema.Field = schema.getFields.get(2)
@@ -46,7 +46,7 @@ class Tuple3Encoder[A, B, C](a: Encoder[A], b: Encoder[B], c: Encoder[C]) extend
 }
 
 class Tuple4Encoder[A, B, C, D](a: Encoder[A], b: Encoder[B], c: Encoder[C], d: Encoder[D]) extends Encoder[Tuple4[A, B, C, D]] {
-  override def encode(schema: Schema): ((A, B, C, D)) => Any = {
+  override def encode(schema: Schema): ((A, B, C, D)) => AnyRef = {
     val fieldA: Schema.Field = schema.getFields.get(0)
     val fieldB: Schema.Field = schema.getFields.get(1)
     val fieldC: Schema.Field = schema.getFields.get(2)
@@ -67,7 +67,7 @@ class Tuple4Encoder[A, B, C, D](a: Encoder[A], b: Encoder[B], c: Encoder[C], d: 
 }
 
 class Tuple5Encoder[A, B, C, D, E](a: Encoder[A], b: Encoder[B], c: Encoder[C], d: Encoder[D], e: Encoder[E]) extends Encoder[Tuple5[A, B, C, D, E]] {
-  override def encode(schema: Schema): ((A, B, C, D, E)) => Any = {
+  override def encode(schema: Schema): ((A, B, C, D, E)) => AnyRef = {
     val fieldA: Schema.Field = schema.getFields.get(0)
     val fieldB: Schema.Field = schema.getFields.get(1)
     val fieldC: Schema.Field = schema.getFields.get(2)

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/unions.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/unions.scala
@@ -13,7 +13,7 @@ object TypeUnions {
     * Builds an [[Encoder]] for a sealed trait enum.
     */
   def encoder[T](ctx: SealedTrait[Encoder, T]): Encoder[T] = new Encoder[T] {
-    override def encode(schema: Schema): T => Any = {
+    override def encode(schema: Schema): T => AnyRef = {
       require(schema.isUnion)
 
       val encoderBySubtype = ctx.subtypes.sorted(SubtypeOrdering).map(st => {
@@ -22,7 +22,7 @@ object TypeUnions {
         val names = Names(st.typeInfo, annos)
 
         val subschema: Schema = SchemaHelper.extractTraitSubschema(names.fullName, schema)
-        val encodeT: T => Any = st.typeclass.asInstanceOf[Encoder[T]].encode(subschema)
+        val encodeT: T => AnyRef = st.typeclass.asInstanceOf[Encoder[T]].encode(subschema)
 
         (st, encodeT)
       }).toMap

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/GithubIssue387.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/GithubIssue387.scala
@@ -14,12 +14,12 @@ class GithubIssue387 extends AnyWordSpec with Matchers {
     "encode the value to a int represented as milliseconds since midnight" in {
       val localTime = LocalTime.now()
       val encoded = Encoder[LocalTime].encode(AvroSchema[LocalTime]).apply(localTime)
-      encoded shouldBe localTime.toNanoOfDay / NANOSECONDS_IN_A_MICROSECOND
+      (encoded: Any) shouldBe localTime.toNanoOfDay / NANOSECONDS_IN_A_MICROSECOND
     }
 
     "encode the value and truncate any precision beyond milliseconds" in {
       val encoded = Encoder[LocalTime].encode(AvroSchema[LocalTime]).apply(LocalTime.MAX)
-      encoded shouldBe LocalTime.MAX.toNanoOfDay / NANOSECONDS_IN_A_MICROSECOND
+      (encoded: Any) shouldBe LocalTime.MAX.toNanoOfDay / NANOSECONDS_IN_A_MICROSECOND
     }
 
     "encode and decode back to an equivalent LocalTime object when Local has microsecond precision" in {


### PR DESCRIPTION
Hey there,

I'd like to propose to change the return type of `Encoder` from `Any` to `AnyRef`.

The motivation is that some Avro APIs take a parameter of type `Object` (i. e. `AnyRef` in Scala), for example `GenericDatumWriter.write`. The `Any` return type means that in order to use that method I have to add an ugly `.asInstanceOf[AnyRef]`.

Since an `Any` return type is erased to `java.lang.Object` anyway, the return value of `encode` is always an `AnyRef` anyway, so we might as well declare that statically. For the same reason, this should be a binary compatible change. 