### PR TITLE
optimize `map` and `contramap`

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/Decoder.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/Decoder.scala
@@ -19,8 +19,9 @@ trait Decoder[T] extends Serializable {
   def decode(schema: Schema): Any => T
 
   final def map[U](f: T => U): Decoder[U] = new Decoder[U] {
-    override def decode(schema: Schema): Any => U = { input =>
-      f(self.decode(schema).apply(input))
+    override def decode(schema: Schema): Any => U = {
+      val decode = self.decode(schema)
+      input => f(decode(input))
     }
   }
 }

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/Encoder.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/Encoder.scala
@@ -48,7 +48,10 @@ trait Encoder[T] extends Serializable {
     * to an T, before encoding as an T using this encoder.
     */
   final def contramap[U](f: U => T): Encoder[U] = new Encoder[U] {
-    override def encode(schema: Schema): U => AnyRef = { u => self.encode(schema).apply(f(u)) }
+    override def encode(schema: Schema): U => AnyRef = {
+      val encode = self.encode(schema)
+      u => encode(f(u))
+    }
   }
 }
 


### PR DESCRIPTION
This should make mapped Encoders/Decoders faster because the schema only needs to be processed once, not every time a value is encoded or decoded.