### PR TITLE
Add option to use default case class value during decoding of AvroTransient field

### DIFF
--- a/.github/workflows/pr_scala_3.yml
+++ b/.github/workflows/pr_scala_3.yml
@@ -28,6 +28,7 @@ jobs:
         run: sbt test
 
       - name: Import GPG key
+        if: github.event.pull_request.head.repo.fork == false
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v3
         with:
@@ -35,4 +36,5 @@ jobs:
           passphrase: ${{ secrets.PGP_PASSPHRASE }}
 
       - name: publish local
+        if: github.event.pull_request.head.repo.fork == false
         run: sbt publishLocalSigned

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/annotations.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/annotations.scala
@@ -68,7 +68,7 @@ trait AvroFixable extends AvroFieldReflection {
   */
 case class AvroName(override val name: String) extends AvroNameable
 
-case class AvroTransient() extends StaticAnnotation
+case class AvroTransient(useDefault:Boolean=false) extends StaticAnnotation
 
 trait AvroNameable extends AvroFieldReflection {
   val name: String

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/decoders/records.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/decoders/records.scala
@@ -16,7 +16,10 @@ class RecordDecoder[T](ctx: magnolia1.CaseClass[Decoder, T]) extends Decoder[T] 
     val decoders: Array[FieldDecoder[T]] = ctx.params
       .map { param =>
         val annos = Annotations(param.annotations)
-        if (annos.transient) TransientFieldDecoder else new SchemaFieldDecoder(param, schema)
+        annos.transient match {
+          case Some(useDefault) => TransientFieldDecoder(useDefault, param)
+          case None => new SchemaFieldDecoder(param, schema)
+        }
       }.toArray
     { t => decodeT(schema, decoders, t) }
   }
@@ -48,8 +51,13 @@ trait FieldDecoder[+T] extends Serializable {
 /**
   * Fields marked with @AvroTransient are always decoded as None's.
   */
-object TransientFieldDecoder extends FieldDecoder[Nothing] {
-  override def decode(record: IndexedRecord): Any = None
+case class TransientFieldDecoder[T](useDefault:Boolean, param: magnolia1.CaseClass.Param[Decoder, T]) extends FieldDecoder[Nothing] {
+  override def decode(record: IndexedRecord): Any = {
+    if(useDefault)
+      param.default.get
+    else 
+     None  
+  }
 }
 
 /**

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/schemas/records.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/schemas/records.scala
@@ -24,7 +24,7 @@ object Records:
 
     val fields = ctx.params.toList.flatMap { param =>
       val fieldAnnos = Annotations(param.annotations)
-      if (fieldAnnos.transient) None
+      if (fieldAnnos.transient.isDefined) None
       else {
         val doc = fieldAnnos.doc //.orElse(valueTypeDoc).orNull
         //        val doc = valueTypeDoc(ctx, param)

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/typeutils/Annotations.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/typeutils/Annotations.scala
@@ -27,10 +27,10 @@ class Annotations(annos: Seq[Any], inheritedAnnos: Seq[Any] = Nil) {
     case t: AvroDocumentable => t.doc
   }
 
-  def transient: Boolean = annos.collectFirst {
-    case t: AvroTransient => t
-  }.isDefined
-
+  def transient: Option[Boolean] = annos.collectFirst {
+    case t: AvroTransient => t.useDefault
+  }
+  
   def erased: Boolean = annos.collectFirst {
     case t: AvroErasedName => t
   }.isDefined

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/TransientDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/TransientDecoderTest.scala
@@ -16,4 +16,14 @@ class TransientDecoderTest extends AnyFunSuite with Matchers {
     record.put("a", new Utf8("hello"))
     Decoder[TransientFoo].decode(schema).apply(record) shouldBe TransientFoo("hello", None)
   }
+
+  case class Foo(name:String)
+  case class TransientFooWithDefault(a: String, @AvroTransient(true) b: Foo = Foo("hello"))
+
+  test("decoder should populate transient fields with default case class value") {
+    val schema = AvroSchema[TransientFooWithDefault]
+    val record = new GenericData.Record(schema)
+    record.put("a", new Utf8("hello"))
+    Decoder[TransientFooWithDefault].decode(schema).apply(record) shouldBe TransientFooWithDefault("hello")
+  }
 }


### PR DESCRIPTION
Hello,
My use case is read data in protobuf format and translate it into avro format.
For protobuf I use scalapb library and it generates model case classes based on protobuf schema. 
Generated case classes have  [UnknownFieldSet](https://protobuf.dev/reference/java/api-docs/com/google/protobuf/UnknownFieldSet) filed with default empty value. (There is an option to exclude them but I need them for analysis).
`scalapb`  allows to inject annatations into generated classes (https://scalapb.github.io/docs/customizations#adding-annotations) so to exclude `UnknownFieldSet `filed from avro schema I use `AvroTransient` annotation.  Everything works fine one model fror protobuf and avro but when `avro4s` tries to decode value that is marked with `AvroTransient` it returns None which cause class cast exception. 

I added `useDefault` boolean flag into `AvroTransient`  so now if it is true defalut value from the case class is used istead on none 